### PR TITLE
feat: implement Narrator collection (Issue #2)

### DIFF
--- a/src/collections/Narrators.ts
+++ b/src/collections/Narrators.ts
@@ -1,0 +1,52 @@
+import type { CollectionConfig } from 'payload'
+
+export const Narrators: CollectionConfig = {
+  slug: 'narrators',
+  admin: {
+    useAsTitle: 'name',
+  },
+  hooks: {
+    beforeChange: [
+      ({ data, operation }) => {
+        if (operation === 'create' || (operation === 'update' && data.name)) {
+          if (data.name && !data.slug) {
+            data.slug = data.name
+              .toLowerCase()
+              .replace(/[^a-z0-9]+/g, '-')
+              .replace(/^-+|-+$/g, '')
+          }
+        }
+        return data
+      },
+    ],
+  },
+  fields: [
+    {
+      name: 'name',
+      type: 'text',
+      required: true,
+    },
+    {
+      name: 'slug',
+      type: 'text',
+      unique: true,
+      admin: {
+        position: 'sidebar',
+      },
+    },
+    {
+      name: 'gender',
+      type: 'select',
+      options: [
+        {
+          label: 'Male',
+          value: 'male',
+        },
+        {
+          label: 'Female',
+          value: 'female',
+        },
+      ],
+    },
+  ],
+}

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -69,6 +69,7 @@ export interface Config {
   collections: {
     users: User;
     media: Media;
+    narrators: Narrator;
     'payload-locked-documents': PayloadLockedDocument;
     'payload-preferences': PayloadPreference;
     'payload-migrations': PayloadMigration;
@@ -77,6 +78,7 @@ export interface Config {
   collectionsSelect: {
     users: UsersSelect<false> | UsersSelect<true>;
     media: MediaSelect<false> | MediaSelect<true>;
+    narrators: NarratorsSelect<false> | NarratorsSelect<true>;
     'payload-locked-documents': PayloadLockedDocumentsSelect<false> | PayloadLockedDocumentsSelect<true>;
     'payload-preferences': PayloadPreferencesSelect<false> | PayloadPreferencesSelect<true>;
     'payload-migrations': PayloadMigrationsSelect<false> | PayloadMigrationsSelect<true>;
@@ -158,6 +160,18 @@ export interface Media {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "narrators".
+ */
+export interface Narrator {
+  id: string;
+  name: string;
+  slug?: string | null;
+  gender?: ('male' | 'female') | null;
+  updatedAt: string;
+  createdAt: string;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "payload-locked-documents".
  */
 export interface PayloadLockedDocument {
@@ -170,6 +184,10 @@ export interface PayloadLockedDocument {
     | ({
         relationTo: 'media';
         value: string | Media;
+      } | null)
+    | ({
+        relationTo: 'narrators';
+        value: string | Narrator;
       } | null);
   globalSlug?: string | null;
   user: {
@@ -252,6 +270,17 @@ export interface MediaSelect<T extends boolean = true> {
   height?: T;
   focalX?: T;
   focalY?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "narrators_select".
+ */
+export interface NarratorsSelect<T extends boolean = true> {
+  name?: T;
+  slug?: T;
+  gender?: T;
+  updatedAt?: T;
+  createdAt?: T;
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema

--- a/src/payload.config.ts
+++ b/src/payload.config.ts
@@ -9,6 +9,7 @@ import sharp from 'sharp'
 
 import { Users } from './collections/Users'
 import { Media } from './collections/Media'
+import { Narrators } from './collections/Narrators'
 
 const filename = fileURLToPath(import.meta.url)
 const dirname = path.dirname(filename)
@@ -27,7 +28,7 @@ export default buildConfig({
       ],
     },
   },
-  collections: [Users, Media],
+  collections: [Users, Media, Narrators],
   editor: lexicalEditor(),
   secret: process.env.PAYLOAD_SECRET || '',
   typescript: {

--- a/tests/int/narrators.int.spec.ts
+++ b/tests/int/narrators.int.spec.ts
@@ -1,0 +1,178 @@
+import { getPayload, Payload } from 'payload'
+import config from '@/payload.config'
+import { describe, it, beforeAll, afterEach, expect } from 'vitest'
+import type { Narrator } from '@/payload-types'
+
+let payload: Payload
+
+describe('Narrators Collection', () => {
+  beforeAll(async () => {
+    const payloadConfig = await config
+    payload = await getPayload({ config: payloadConfig })
+  })
+
+  afterEach(async () => {
+    await payload.delete({
+      collection: 'narrators',
+      where: {},
+    })
+  })
+
+  it('creates a narrator with auto-generated slug', async () => {
+    const narrator = await payload.create({
+      collection: 'narrators',
+      data: {
+        name: 'John Smith',
+        gender: 'male',
+      },
+    }) as Narrator
+
+    expect(narrator).toBeDefined()
+    expect(narrator.name).toBe('John Smith')
+    expect(narrator.slug).toBe('john-smith')
+    expect(narrator.gender).toBe('male')
+  })
+
+  it('creates a narrator with custom slug', async () => {
+    const narrator = await payload.create({
+      collection: 'narrators',
+      data: {
+        name: 'Jane Doe',
+        slug: 'custom-jane-slug',
+        gender: 'female',
+      },
+    }) as Narrator
+
+    expect(narrator.slug).toBe('custom-jane-slug')
+  })
+
+  it('handles special characters in slug generation', async () => {
+    const narrator = await payload.create({
+      collection: 'narrators',
+      data: {
+        name: 'María García-López',
+        gender: 'female',
+      },
+    }) as Narrator
+
+    expect(narrator.slug).toBe('mar-a-garc-a-l-pez')
+  })
+
+  it('finds narrators', async () => {
+    await payload.create({
+      collection: 'narrators',
+      data: {
+        name: 'Test Narrator 1',
+        gender: 'male',
+      },
+    })
+
+    await payload.create({
+      collection: 'narrators',
+      data: {
+        name: 'Test Narrator 2',
+        gender: 'female',
+      },
+    })
+
+    const result = await payload.find({
+      collection: 'narrators',
+    })
+
+    expect(result.docs).toHaveLength(2)
+    expect(result.totalDocs).toBe(2)
+  })
+
+  it('updates a narrator', async () => {
+    const narrator = await payload.create({
+      collection: 'narrators',
+      data: {
+        name: 'Original Name',
+        gender: 'male',
+      },
+    }) as Narrator
+
+    const updated = await payload.update({
+      collection: 'narrators',
+      id: narrator.id,
+      data: {
+        name: 'Updated Name',
+        gender: 'female',
+      },
+    }) as Narrator
+
+    expect(updated.name).toBe('Updated Name')
+    expect(updated.gender).toBe('female')
+    expect(updated.slug).toBe('original-name')
+  })
+
+  it('finds narrator by slug', async () => {
+    await payload.create({
+      collection: 'narrators',
+      data: {
+        name: 'Find By Slug',
+        gender: 'male',
+      },
+    })
+
+    const result = await payload.find({
+      collection: 'narrators',
+      where: {
+        slug: {
+          equals: 'find-by-slug',
+        },
+      },
+    })
+
+    expect(result.docs).toHaveLength(1)
+    expect(result.docs[0].name).toBe('Find By Slug')
+  })
+
+  it('deletes a narrator', async () => {
+    const narrator = await payload.create({
+      collection: 'narrators',
+      data: {
+        name: 'To Delete',
+        gender: 'female',
+      },
+    }) as Narrator
+
+    await payload.delete({
+      collection: 'narrators',
+      id: narrator.id,
+    })
+
+    const result = await payload.find({
+      collection: 'narrators',
+      where: {
+        id: {
+          equals: narrator.id,
+        },
+      },
+    })
+
+    expect(result.docs).toHaveLength(0)
+  })
+
+  it('enforces unique slug constraint', async () => {
+    await payload.create({
+      collection: 'narrators',
+      data: {
+        name: 'Duplicate Test',
+        slug: 'duplicate-slug',
+        gender: 'male',
+      },
+    })
+
+    await expect(
+      payload.create({
+        collection: 'narrators',
+        data: {
+          name: 'Another Name',
+          slug: 'duplicate-slug',
+          gender: 'female',
+        },
+      })
+    ).rejects.toThrow()
+  })
+})


### PR DESCRIPTION
## Summary
- Implemented the Narrator collection with name, slug, and gender fields
- Added automatic slug generation from the name field
- Created comprehensive integration tests for all CRUD operations

## Test plan
- [x] Unit tests for validation logic - Covered by integration tests
- [x] Integration tests for narrator operations - All 8 tests passing
- [x] Admin UI functionality - Verified with Puppeteer
- [x] Full test suite passes - All tests passing (16 integration + 1 E2E)

## Implementation Details
- Created `src/collections/Narrators.ts` with required fields
- Implemented slug auto-generation using beforeChange hook
- Added unique constraint on slug field
- Integrated collection into payload configuration
- Generated TypeScript types

Closes #2

🤖 Generated with [Claude Code](https://claude.ai/code)