### PR TITLE
feat(meditations): add live preview configuration

### DIFF
--- a/src/collections/content/Meditations.ts
+++ b/src/collections/content/Meditations.ts
@@ -25,6 +25,12 @@ export const Meditations: CollectionConfig = {
     useAsTitle: 'label',
     defaultColumns: ['label', 'thumbnail', 'publishAt', 'tags', 'durationMinutes'],
     hidden: handleProjectVisibility('meditations', ['wemeditate-web', 'wemeditate-app']),
+    livePreview: {
+      url: ({ data }) => {
+        const baseURL = process.env.WEMEDITATE_WEB_URL || 'http://localhost:5173'
+        return `${baseURL}/${data.locale}/preview?collection=meditations&id=${data.id}`
+      },
+    },
   },
   hooks: {
     beforeOperation: [sanitizeFilename],


### PR DESCRIPTION
## Summary

Enable live preview for the Meditations collection, following the same pattern established in the Pages collection. This allows content editors to preview meditation content in the We Meditate Web frontend while editing in the admin panel.

### Changes

- Added `livePreview` configuration to the Meditations collection admin section
- Uses `data.locale` instead of `locale.code` since Meditations uses a custom locale field (not PayloadCMS's built-in localization)
- Preview URL format: `${baseURL}/${data.locale}/preview?collection=meditations&id=${data.id}`

### Key Difference from Pages

- **Pages**: Uses PayloadCMS's built-in localization → `locale.code`
- **Meditations**: Uses custom `locale` select field → `data.locale`

Closes #77

## Test Results

- Integration tests: 173 passed, 1 skipped (pre-existing)
- E2E tests: 2 passed, 15 skipped (pre-existing)
- Build: ✓ Compiled successfully (failed on disk trace due to local disk space issue - not code related)
- Lint: ✓ Passes (only pre-existing warnings in migrations)
- TypeScript: ✓ No errors in source files

## Manual Testing

To verify the live preview:
1. Start development server (`pnpm dev`)
2. Ensure We Meditate Web frontend is running at `WEMEDITATE_WEB_URL`
3. Open an existing meditation in the admin panel
4. Verify the live preview button appears
5. Click the live preview button to open the preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)