### PR TITLE
fix: resolve 7 failing integration tests

### DIFF
--- a/src/app/(payload)/admin/importMap.js
+++ b/src/app/(payload)/admin/importMap.js
@@ -33,6 +33,7 @@ import { default as default_c76ed6d3c3881bbd4c90e56dac27b1a7 } from '@/component
 import { default as default_49cc57155f60c2bacf9eaa38c760d251 } from '@/components/admin/PermissionsTable'
 import { default as default_acdce971efa051c30eee554c2f9f8336 } from '@/components/admin/AbuseScore/AbuseScoreCell'
 import { default as default_d600b4f81bb40d92e487891c4971de20 } from '@/components/admin/AbuseScore/AbuseScoreField'
+import { default as default_96c2a71c5f4209510035b710f1955479 } from '@/components/admin/RecurrenceField'
 import { HorizontalRuleFeatureClient as HorizontalRuleFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
 import { ChecklistFeatureClient as ChecklistFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
 import { IndentFeatureClient as IndentFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
@@ -86,6 +87,7 @@ export const importMap = {
   "@/components/admin/PermissionsTable#default": default_49cc57155f60c2bacf9eaa38c760d251,
   "@/components/admin/AbuseScore/AbuseScoreCell#default": default_acdce971efa051c30eee554c2f9f8336,
   "@/components/admin/AbuseScore/AbuseScoreField#default": default_d600b4f81bb40d92e487891c4971de20,
+  "@/components/admin/RecurrenceField#default": default_96c2a71c5f4209510035b710f1955479,
   "@payloadcms/richtext-lexical/client#HorizontalRuleFeatureClient": HorizontalRuleFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
   "@payloadcms/richtext-lexical/client#ChecklistFeatureClient": ChecklistFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
   "@payloadcms/richtext-lexical/client#IndentFeatureClient": IndentFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,

--- a/src/components/admin/RecurrenceField/utils.ts
+++ b/src/components/admin/RecurrenceField/utils.ts
@@ -5,9 +5,14 @@
  * Converts between stored JSON format and UI state.
  */
 
-import type { Options } from 'rrule'
+// Use namespace import and access via .default for ESM/CJS interop
+import * as rruleModule from 'rrule'
 
-import { RRule, rrulestr, Frequency, Weekday } from 'rrule'
+// Handle both ESM and CJS module formats
+const rrule = (rruleModule as { default?: typeof rruleModule }).default || rruleModule
+const { RRule, rrulestr, Frequency, Weekday } = rrule
+type Options = rruleModule.Options
+type FrequencyType = (typeof rruleModule.Frequency)[keyof typeof rruleModule.Frequency]
 
 import type {
   RecurrenceData,
@@ -25,7 +30,7 @@ import { getDefaultUIState } from '@/types/recurrence'
  * Note: `interval` can be undefined for uiStateToData (cleaner RRULE output),
  * but MUST be a number for getHumanReadableSummary (toText() crashes on undefined).
  */
-type RRuleOptionsSubset = { freq: Frequency } & Partial<
+type RRuleOptionsSubset = { freq: FrequencyType } & Partial<
   Pick<Options, 'interval' | 'byweekday' | 'bymonthday' | 'count' | 'until'>
 >
 
@@ -79,7 +84,7 @@ export function rruleWeekToLabelIndex(value: number): number {
 /**
  * Convert RecurrenceType to rrule Frequency
  */
-export function recurrenceTypeToFrequency(type: RecurrenceType): Frequency | null {
+export function recurrenceTypeToFrequency(type: RecurrenceType): FrequencyType | null {
   switch (type) {
     case 'daily':
       return Frequency.DAILY
@@ -96,7 +101,7 @@ export function recurrenceTypeToFrequency(type: RecurrenceType): Frequency | nul
 /**
  * Convert rrule Frequency to RecurrenceType
  */
-export function frequencyToRecurrenceType(freq: Frequency | undefined): RecurrenceType {
+export function frequencyToRecurrenceType(freq: FrequencyType | undefined): RecurrenceType {
   switch (freq) {
     case Frequency.DAILY:
       return 'daily'

--- a/src/jobs/tasks/CleanupOrphanedMedia.ts
+++ b/src/jobs/tasks/CleanupOrphanedMedia.ts
@@ -43,11 +43,23 @@ type CleanupResult = {
  * or field knowledge required. Adding new collections with file/image references
  * requires no changes to this job.
  */
+/** Type for test-injected date range */
+type TestDateRangeInput = {
+  rangeStart: string
+  rangeEnd: string
+}
+
 export const CleanupOrphanedMedia: TaskConfig<'cleanupOrphanedMedia'> = {
   retries: 2,
   label: 'Cleanup Orphaned Media',
   slug: 'cleanupOrphanedMedia',
-  inputSchema: [],
+  inputSchema: [
+    {
+      name: 'testDateRange',
+      type: 'json',
+      required: false,
+    },
+  ],
   outputSchema: [
     {
       name: 'permanentlyDeletedFiles',
@@ -86,28 +98,40 @@ export const CleanupOrphanedMedia: TaskConfig<'cleanupOrphanedMedia'> = {
       queue: 'monthly',
     },
   ],
-  handler: async ({ req }) => {
+  handler: async ({ req, input }) => {
     const maxOperations = 500
     const gracePeriodHours = 24
 
-    // Determine date range based on current month (rotates through 3 ranges)
-    const currentMonth = new Date().getMonth() // 0-11
-    const rangeIndex = currentMonth % 3 // 0, 1, or 2
-    const rangeEndMonthsAgo = rangeIndex
-    const rangeStartMonthsAgo = rangeIndex + 1
+    let rangeStart: Date
+    let rangeEnd: Date
+    let rangeLabel: string
 
-    // Calculate range end (with grace period)
-    const rangeEnd = new Date()
-    rangeEnd.setMonth(rangeEnd.getMonth() - rangeEndMonthsAgo)
-    rangeEnd.setHours(rangeEnd.getHours() - gracePeriodHours)
+    // Check for test-injected date range
+    if (input?.testDateRange) {
+      const testRange = input.testDateRange as TestDateRangeInput
+      rangeStart = new Date(testRange.rangeStart)
+      rangeEnd = new Date(testRange.rangeEnd)
+      rangeLabel = 'test-range'
+    } else {
+      // Determine date range based on current month (rotates through 3 ranges)
+      const currentMonth = new Date().getMonth() // 0-11
+      const rangeIndex = currentMonth % 3 // 0, 1, or 2
+      const rangeEndMonthsAgo = rangeIndex
+      const rangeStartMonthsAgo = rangeIndex + 1
 
-    // Calculate range start
-    const rangeStart = new Date()
-    rangeStart.setMonth(rangeStart.getMonth() - rangeStartMonthsAgo)
+      // Calculate range end (with grace period)
+      rangeEnd = new Date()
+      rangeEnd.setMonth(rangeEnd.getMonth() - rangeEndMonthsAgo)
+      rangeEnd.setHours(rangeEnd.getHours() - gracePeriodHours)
 
-    // Human-readable labels for logging
-    const rangeLabels = ['0-1mo', '1-2mo', '2-3mo']
-    const rangeLabel = rangeLabels[rangeIndex]
+      // Calculate range start
+      rangeStart = new Date()
+      rangeStart.setMonth(rangeStart.getMonth() - rangeStartMonthsAgo)
+
+      // Human-readable labels for logging
+      const rangeLabels = ['0-1mo', '1-2mo', '2-3mo']
+      rangeLabel = rangeLabels[rangeIndex]
+    }
 
     req.payload.logger.info({
       msg: 'Starting orphaned media cleanup',

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -1016,7 +1016,7 @@ export interface AppCard {
    */
   appPage?: ('map' | 'lectures' | 'path' | 'music') | null;
   /**
-   * Recurrence schedule configuration (JSON)
+   * Define when this event repeats
    */
   recurrence?:
     | {
@@ -2469,7 +2469,17 @@ export interface PayloadJobsStatsSelect<T extends boolean = true> {
  * via the `definition` "TaskCleanupOrphanedMedia".
  */
 export interface TaskCleanupOrphanedMedia {
-  input?: unknown;
+  input: {
+    testDateRange?:
+      | {
+          [k: string]: unknown;
+        }
+      | unknown[]
+      | string
+      | number
+      | boolean
+      | null;
+  };
   output: {
     permanentlyDeletedFiles: number;
     permanentlyDeletedImages: number;

--- a/src/types/recurrence.ts
+++ b/src/types/recurrence.ts
@@ -9,9 +9,8 @@
 
 import type { JSONField } from 'payload'
 
-// Re-export rrule types for convenience
-export { Frequency, type Options, type ByWeekday } from 'rrule'
-export { Weekday, type WeekdayStr, ALL_WEEKDAYS } from 'rrule'
+// Note: rrule types should be imported directly from 'rrule' in consuming files
+// due to ESM/CJS interop issues with re-exports
 
 /**
  * Stored JSON structure in database.

--- a/tests/int/albums.int.spec.ts
+++ b/tests/int/albums.int.spec.ts
@@ -111,16 +111,21 @@ describe('Albums Collection', () => {
     })
 
     // Update with different locale
+    // Note: overrideAccess needed since test environment lacks proper user context for locale-based access
+    // Note: Both title and artist are localized and required, so we must provide both for the new locale
     const updated = (await payload.update({
       collection: 'albums',
       id: album.id,
       locale: 'de',
+      overrideAccess: true,
       data: {
+        title: 'Testalbum',
         artist: 'Deutscher Kunstlername',
       },
     })) as Album
 
     expect(updated.artist).toBe('Deutscher Kunstlername')
+    expect(updated.title).toBe('Testalbum')
   })
 
   it('updates an album', async () => {

--- a/tests/int/cleanup-orphaned-media.int.spec.ts
+++ b/tests/int/cleanup-orphaned-media.int.spec.ts
@@ -50,7 +50,9 @@ async function backdateCreatedAt(
 }
 
 /**
- * Run cleanup job by invoking handler directly
+ * Run cleanup job by invoking handler directly with a test-friendly date range.
+ * This date range includes files backdated to 48 hours ago but excludes files
+ * created "now" (respecting the 24h grace period).
  */
 async function runCleanupJob(payload: Payload): Promise<CleanupResult> {
   const { CleanupOrphanedMedia } = await import('@/jobs/tasks/CleanupOrphanedMedia')
@@ -59,8 +61,44 @@ async function runCleanupJob(payload: Payload): Promise<CleanupResult> {
     payload,
   } as PayloadRequest
 
+  // Test-friendly date range that:
+  // - Includes files backdated to 48 hours ago
+  // - Excludes files created "now" (respecting grace period)
+  const rangeStart = new Date()
+  rangeStart.setHours(rangeStart.getHours() - 72)
+  const rangeEnd = new Date()
+  rangeEnd.setHours(rangeEnd.getHours() - 25) // Outside 24h grace period
+
   // The handler type can be a string (for queued jobs) or function (inline)
   // Our job uses inline handler, so we can safely call it
+  const handler = CleanupOrphanedMedia.handler as (args: {
+    req: PayloadRequest
+    input: Record<string, unknown>
+  }) => Promise<{ output: CleanupResult }>
+  const result = await handler({
+    req: mockReq,
+    input: {
+      testDateRange: {
+        rangeStart: rangeStart.toISOString(),
+        rangeEnd: rangeEnd.toISOString(),
+      },
+    },
+  })
+  return result.output
+}
+
+/**
+ * Run cleanup job with default date range calculation (month-based rotation).
+ * Used for tests that verify the date range rotation logic works correctly.
+ */
+async function runCleanupJobWithDefaultRange(payload: Payload): Promise<CleanupResult> {
+  const { CleanupOrphanedMedia } = await import('@/jobs/tasks/CleanupOrphanedMedia')
+
+  const mockReq = {
+    payload,
+  } as PayloadRequest
+
+  // Don't pass testDateRange - uses default month-based calculation
   const handler = CleanupOrphanedMedia.handler as (args: {
     req: PayloadRequest
     input: Record<string, unknown>
@@ -601,8 +639,8 @@ describe('CleanupOrphanedMedia Job', () => {
         data: { createdAt: twoMonthsAgo.toISOString() },
       })
 
-      // Run cleanup job
-      await runCleanupJob(payload)
+      // Run cleanup job with default (month-based) date range
+      await runCleanupJobWithDefaultRange(payload)
 
       // Verify: Only 0-1 month old file processed
       expect(await fileInTrash(payload, file2weeksOld.id)).toBe(true)
@@ -639,8 +677,8 @@ describe('CleanupOrphanedMedia Job', () => {
         data: { createdAt: twoWeeksAgo.toISOString() },
       })
 
-      // Run cleanup job
-      await runCleanupJob(payload)
+      // Run cleanup job with default (month-based) date range
+      await runCleanupJobWithDefaultRange(payload)
 
       // Verify: Only 1-2 month old file processed
       expect(await fileInTrash(payload, file1p5moOld.id)).toBe(true)
@@ -677,8 +715,8 @@ describe('CleanupOrphanedMedia Job', () => {
         data: { createdAt: oneMonthAgo.toISOString() },
       })
 
-      // Run cleanup job
-      await runCleanupJob(payload)
+      // Run cleanup job with default (month-based) date range
+      await runCleanupJobWithDefaultRange(payload)
 
       // Verify: Only 2-3 month old file processed
       expect(await fileInTrash(payload, file2p5moOld.id)).toBe(true)
@@ -709,8 +747,8 @@ describe('CleanupOrphanedMedia Job', () => {
       // Verify file is in trash
       expect(await fileInTrash(payload, trashedFile.id)).toBe(true)
 
-      // Run cleanup job
-      const result = await runCleanupJob(payload)
+      // Run cleanup job with default (month-based) date range
+      const result = await runCleanupJobWithDefaultRange(payload)
 
       // Verify file was permanently deleted even though it's outside Phase B date range
       expect(result.permanentlyDeletedFiles).toBeGreaterThanOrEqual(1)

--- a/tests/int/storage-utils.int.spec.ts
+++ b/tests/int/storage-utils.int.spec.ts
@@ -92,7 +92,7 @@ describe('URL Field Factories', () => {
 
       const hook = getAfterReadHook(field)
       const url = callHook(hook!, { filename: 'video-id' })
-      expect(url).toBe('https://customer-test.cloudflarestream.com/video-id/downloads/default.mp4')
+      expect(url).toBe('https://customer-test.cloudflarestream.com/video-id/manifest/video.m3u8')
     })
 
     it('falls back to local URL when CLOUDFLARE_STREAM_DELIVERY_URL is not set', async () => {
@@ -314,7 +314,7 @@ describe('URL Field Factories', () => {
       expect(url).toBe('https://imagedelivery.net/abc123/image-id/public')
     })
 
-    it('generates Cloudflare Stream MP4 URL for videos', async () => {
+    it('generates Cloudflare Stream HLS URL for videos', async () => {
       process.env.CLOUDFLARE_STREAM_DELIVERY_URL = 'https://customer-test.cloudflarestream.com'
       process.env.PAYLOAD_SECRET = 'test-secret-key-with-32-chars-minimum'
 
@@ -324,7 +324,7 @@ describe('URL Field Factories', () => {
 
       const hook = getAfterReadHook(field)
       const url = callHook(hook!, { filename: 'video-id', mimeType: 'video/mp4' })
-      expect(url).toBe('https://customer-test.cloudflarestream.com/video-id/downloads/default.mp4')
+      expect(url).toBe('https://customer-test.cloudflarestream.com/video-id/manifest/video.m3u8')
     })
 
     it('generates R2 URL for other file types', async () => {

--- a/tests/int/videos.int.spec.ts
+++ b/tests/int/videos.int.spec.ts
@@ -21,10 +21,10 @@ describe('Videos Collection', () => {
     payload = testEnv.payload
     cleanup = testEnv.cleanup
 
-    // Create test video with string tags
+    // Create test video with string tag (single select field)
     testVideo = await testData.createVideo(payload, {
       title: 'Test Video',
-      tags: [testimonialTag],
+      tags: testimonialTag,
     })
   })
 
@@ -91,16 +91,14 @@ describe('Videos Collection', () => {
     expect((fileMetadataField as { admin: { readOnly: boolean } }).admin.readOnly).toBe(true)
   })
 
-  it('supports tag selection (hasMany with string enum)', async () => {
-    const videoWithTags = await testData.createVideo(payload, {
-      title: 'Multi-tag Video',
-      tags: [testimonialTag, workshopTag],
+  it('supports tag selection (single select with string enum)', async () => {
+    const videoWithTag = await testData.createVideo(payload, {
+      title: 'Tagged Video',
+      tags: workshopTag,
     })
 
-    expect(videoWithTags.tags).toBeDefined()
-    expect(videoWithTags.tags!.length).toBe(2)
-    expect(videoWithTags.tags).toContain(testimonialTag)
-    expect(videoWithTags.tags).toContain(workshopTag)
+    expect(videoWithTag.tags).toBeDefined()
+    expect(videoWithTag.tags).toBe(workshopTag)
   })
 
   it('accepts only video MIME types', async () => {
@@ -121,9 +119,9 @@ describe('Videos Collection', () => {
     expect(config.admin?.useAsTitle).toBe('title')
   })
 
-  it('is in Content admin group', async () => {
+  it('is in Media admin group', async () => {
     const config = payload.collections['videos'].config
-    expect(config.admin?.group).toBe('Content')
+    expect(config.admin?.group).toBe('Media')
   })
 
   it('has correct default columns configuration', async () => {

--- a/tests/utils/testData.ts
+++ b/tests/utils/testData.ts
@@ -295,7 +295,7 @@ export const testData = {
       collection: 'videos',
       data: {
         title: defaultTitle,
-        tags: ['testimonial'], // Default tag for required field
+        tags: 'testimonial', // Default tag for required field (single select, not hasMany)
         ...overrides,
       },
       file: {


### PR DESCRIPTION
## Summary

Fixes 7 failing integration tests across 4 test files, plus resolves pre-existing issues discovered during the fix.

### Original Test Failures (Issue #194)

**storage-utils.int.spec.ts (2 tests):**
- Updated URL expectations from MP4 (`/downloads/default.mp4`) to HLS (`/manifest/video.m3u8`) to match the implementation change from commit 3ad71d2

**albums.int.spec.ts (1 test):**
- Added `overrideAccess: true` to bypass access control in test environment
- Provided both required localized fields (`title` and `artist`) when updating with a different locale

**cleanup-orphaned-media.int.spec.ts (4 tests):**
- Added `testDateRange` input parameter to `CleanupOrphanedMedia` job for test-time date injection
- Created `runCleanupJobWithDefaultRange()` helper for Date Range Rotation tests
- Updated `runCleanupJob()` to pass test-friendly date range that includes backdated files

### Pre-existing Issues Fixed

**rrule ESM/CJS Interop:**
- Fixed namespace import pattern to handle both ESM and CJS module formats
- Removed unused re-exports from `src/types/recurrence.ts` that caused build errors

**videos.int.spec.ts:**
- Fixed tags field tests to use single-select (not hasMany array)
- Updated admin group test from "Content" to "Media" to match collection config

## Test Results
- Integration tests: 503 passed, 1 skipped
- Build: ✓ Success
- Pre-existing failures fixed: rrule imports, videos test config mismatch

Closes #194

🤖 Generated with [Claude Code](https://claude.com/claude-code)