### PR TITLE
fix(logging): use a worker-safe payload logger everywhere

### DIFF
--- a/.claude/docs/architecture.md
+++ b/.claude/docs/architecture.md
@@ -270,7 +270,22 @@ Custom admin components for tag management:
 
 ## Logging & Error Tracking
 
-The application uses **PayloadCMS's built-in Pino logger** for server-side logging and **Sentry** for error tracking, with a custom implementation optimized for Cloudflare Workers.
+The application uses a **custom console-backed Payload logger** for server-side logging and **Sentry** for error tracking.
+
+### Server Logger Architecture
+
+- **Logger implementation**: `src/lib/workerSafeLogger.ts`
+- **Logger wiring**: `src/payload.config.ts`
+- **Why not Payload's default logger?** Payload's default logger uses Pino transports that eventually write through Node-style fs destinations. In Cloudflare Workers, those write paths can fail under Node compatibility shims, so the project uses `console` directly instead.
+
+The logger is intentionally small:
+
+- It implements the subset of the Pino interface that Payload uses in this project.
+- It respects `NEXT_PUBLIC_LOG_LEVEL`.
+- It supports `child()` bindings, so contextual fields are preserved.
+- It normalizes `Error` objects into plain serializable objects before logging.
+
+Using the same logger in local development, CLI usage, and Workers keeps behavior consistent across environments.
 
 ### Log Level Configuration
 

--- a/src/lib/workerSafeLogger.ts
+++ b/src/lib/workerSafeLogger.ts
@@ -1,0 +1,166 @@
+import type { Config } from 'payload'
+
+/**
+ * Worker-safe logger used by Payload in every environment.
+ *
+ * Why this exists:
+ * - Payload expects a Pino-compatible logger shape.
+ * - Pino's default destination ultimately writes through fs-backed transports.
+ * - In Cloudflare Workers, Node compatibility around those write paths can fail on
+ *   string encodings such as `fs.write(fd, value, 'utf8')`.
+ *
+ * How it works:
+ * - It implements the subset of the Pino logger interface that Payload and this repo use.
+ * - It routes all log output to `console`, which is reliable in Workers and local Node.
+ * - It keeps `child()` bindings and normalizes `Error` instances into plain objects so
+ *   logs stay readable in JSON-like console output.
+ */
+
+type LogArgument = unknown
+type LogBindings = Record<string, unknown>
+
+export type WorkerSafeLogLevel =
+  | 'silent'
+  | 'fatal'
+  | 'error'
+  | 'warn'
+  | 'info'
+  | 'debug'
+  | 'trace'
+
+type LoggerMethod = 'trace' | 'debug' | 'info' | 'warn' | 'error' | 'fatal'
+
+const LOG_LEVEL_PRIORITY: Record<WorkerSafeLogLevel, number> = {
+  silent: 0,
+  fatal: 1,
+  error: 2,
+  warn: 3,
+  info: 4,
+  debug: 5,
+  trace: 6,
+}
+
+const CONSOLE_METHODS: Record<LoggerMethod, keyof Console> = {
+  trace: 'log',
+  debug: 'debug',
+  info: 'info',
+  warn: 'warn',
+  error: 'error',
+  fatal: 'error',
+}
+
+const isPlainObject = (value: unknown): value is Record<string, unknown> => {
+  return Object.prototype.toString.call(value) === '[object Object]'
+}
+
+const isWorkerSafeLogLevel = (value: string): value is WorkerSafeLogLevel => {
+  return value in LOG_LEVEL_PRIORITY
+}
+
+const normalizeLogValue = (value: unknown): unknown => {
+  if (value instanceof Error) {
+    const serializedError: Record<string, unknown> = {
+      name: value.name,
+      message: value.message,
+      stack: value.stack,
+    }
+
+    if ('cause' in value && value.cause !== undefined) {
+      serializedError.cause = normalizeLogValue(value.cause)
+    }
+
+    return serializedError
+  }
+
+  if (Array.isArray(value)) {
+    return value.map(normalizeLogValue)
+  }
+
+  if (isPlainObject(value)) {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, nestedValue]) => [key, normalizeLogValue(nestedValue)]),
+    )
+  }
+
+  return value
+}
+
+const shouldLog = (configuredLevel: WorkerSafeLogLevel, method: LoggerMethod): boolean => {
+  return LOG_LEVEL_PRIORITY[configuredLevel] >= LOG_LEVEL_PRIORITY[method]
+}
+
+const mergeBindings = (bindings: LogBindings, args: LogArgument[]): LogArgument[] => {
+  if (Object.keys(bindings).length === 0) {
+    return args
+  }
+
+  if (args.length === 0) {
+    return [bindings]
+  }
+
+  const [firstArg, ...restArgs] = args
+
+  if (isPlainObject(firstArg)) {
+    return [{ ...bindings, ...firstArg }, ...restArgs]
+  }
+
+  return [bindings, firstArg, ...restArgs]
+}
+
+export const createWorkerSafeLogger = (
+  initialLevel: WorkerSafeLogLevel = 'info',
+  initialBindings: LogBindings = {},
+): Config['logger'] => {
+  const state: {
+    bindings: LogBindings
+    level: WorkerSafeLogLevel
+  } = {
+    bindings: { ...initialBindings },
+    level: initialLevel,
+  }
+
+  const write = (method: LoggerMethod, args: LogArgument[]) => {
+    if (!shouldLog(state.level, method)) {
+      return
+    }
+
+    const consoleMethod = CONSOLE_METHODS[method]
+    const normalizedArgs = mergeBindings(state.bindings, args.map(normalizeLogValue))
+
+    // eslint-disable-next-line no-console
+    ;(console[consoleMethod] as (...consoleArgs: LogArgument[]) => void)(...normalizedArgs)
+  }
+
+  const logger = {
+    msgPrefix: '',
+    silent: () => {},
+    trace: (...args: LogArgument[]) => write('trace', args),
+    debug: (...args: LogArgument[]) => write('debug', args),
+    info: (...args: LogArgument[]) => write('info', args),
+    warn: (...args: LogArgument[]) => write('warn', args),
+    error: (...args: LogArgument[]) => write('error', args),
+    fatal: (...args: LogArgument[]) => write('fatal', args),
+    child: (childBindings: LogBindings = {}) =>
+      createWorkerSafeLogger(state.level, { ...state.bindings, ...childBindings }),
+    bindings: () => ({ ...state.bindings }),
+    setBindings: (nextBindings: LogBindings) => {
+      Object.assign(state.bindings, nextBindings)
+    },
+    flush: () => {},
+    isLevelEnabled: (level: string) => {
+      return isWorkerSafeLogLevel(level) && level !== 'silent' && shouldLog(state.level, level)
+    },
+  }
+
+  Object.defineProperty(logger, 'level', {
+    enumerable: true,
+    get: () => state.level,
+    set: (nextLevel: string) => {
+      if (isWorkerSafeLogLevel(nextLevel)) {
+        state.level = nextLevel
+      }
+    },
+  })
+
+  return logger as unknown as Config['logger']
+}

--- a/src/payload.config.ts
+++ b/src/payload.config.ts
@@ -20,6 +20,7 @@ import { scalarPlugin } from '@/lib/openapi'
 import { sentryPlugin } from '@/lib/sentryPlugin'
 import { getServerUrl } from '@/lib/serverUrl'
 import { usagePlugin } from '@/lib/usage'
+import { createWorkerSafeLogger } from '@/lib/workerSafeLogger'
 
 import { collections, Managers } from './collections'
 import { globals } from './globals'
@@ -51,19 +52,13 @@ const E2E_DATABASE_PATH = path.resolve(dirname, '../tests/.e2e.sqlite')
 
 const payloadConfig = (overrides?: Partial<Config>) => {
   const serverUrl = getServerUrl()
+  const logger = createWorkerSafeLogger(serverEnv.NEXT_PUBLIC_LOG_LEVEL ?? 'info')
 
   return buildConfig({
     serverURL: serverUrl,
     debug: true, // Enable verbose error logging for troubleshooting R2 uploads
-    // Logger configuration - uses Pino under the hood
-    // Controlled by NEXT_PUBLIC_LOG_LEVEL: 'silent' | 'fatal' | 'error' | 'warn' | 'info' | 'debug' | 'trace'
-    ...(serverEnv.NEXT_PUBLIC_LOG_LEVEL && {
-      logger: {
-        options: {
-          level: serverEnv.NEXT_PUBLIC_LOG_LEVEL,
-        },
-      },
-    }),
+    // Use one logger implementation everywhere so local, CLI, and Worker behavior stay aligned.
+    logger,
     localization: {
       defaultLocalePublishOption: 'active',
       locales: buildPayloadLocales(),


### PR DESCRIPTION
## Summary
- replace Payload's default logger with a console-backed worker-safe logger
- use the same logger path in local, CLI, and Worker environments for consistent behavior
- document the logger architecture and why the wrapper exists

## Test Results
- Integration tests: 635 passed, 2 skipped
- Lint: passed
- Types: passed
- Build: reached static page generation/finalization successfully under escalated execution, but the command did not return control afterward in this environment
