### PR TITLE
Fix: auto-enable MP4 downloads via Cloudflare Stream webhook

### DIFF
--- a/.claude/docs/architecture.md
+++ b/.claude/docs/architecture.md
@@ -91,13 +91,34 @@ r2NativeAdapter({
 
 ## Custom Endpoints
 
-Custom endpoint handlers are organized in `src/endpoints/` and registered on their respective collections via the `endpoints` config property.
+The project has **two** places to add HTTP endpoints. Choose based on the scope of the endpoint:
+
+### Payload collection endpoints (`src/endpoints/*.ts`)
+
+Use for operations tied to a specific collection. Registered on the collection via its `endpoints` config property. The handler receives `req.payload` for free.
+
+**Use when**: the URL logically belongs under a collection (e.g., `/api/frames/by-narrator/:narratorId`), the operation reads or writes a single collection's documents, and you want automatic auth/access integration with Payload.
 
 | File | Collection | Path | Description |
 |------|-----------|------|-------------|
 | `src/endpoints/framesByNarrator.ts` | Frames | `/by-narrator/:narratorId` | Returns frames filtered by narrator gender |
 
 Each endpoint exports an `Endpoint` object (from `payload`) with `path`, `method`, and `handler` properties. The barrel export at `src/endpoints/index.ts` re-exports all handlers.
+
+### Next.js App Router routes (`src/app/(payload)/api/**/route.ts`)
+
+Use for anything not scoped to a single collection — webhooks, health checks, OpenAPI spec generation, seed triggers, or operations that span multiple collections.
+
+**Use when**: the endpoint is not "about" one collection (webhooks from third parties, `/api/health`, `/api/docs`, `/api/seed/:script`), you need direct access to the raw request body (e.g., HMAC signature verification), or you need Next.js-specific features (streaming, `NextResponse.redirect`).
+
+| File | Path | Purpose |
+|------|------|---------|
+| `src/app/(payload)/api/health/route.ts` | `/api/health` | Liveness check |
+| `src/app/(payload)/api/openapi.json/route.ts` | `/api/openapi.json` | Filtered OpenAPI spec |
+| `src/app/(payload)/api/seed/[script]/route.ts` | `/api/seed/:script` | Seed trigger with SSE |
+| `src/app/(payload)/api/webhooks/cloudflare-stream/route.ts` | `/api/webhooks/cloudflare-stream` | Cloudflare Stream webhook handler |
+
+**Critical constraint**: Next.js route files may only export HTTP method handlers (`GET`, `POST`, etc.) and a small set of config constants. Helper functions must live in `src/lib/`, not in the route file. Lint and tests pass with extra exports, but `pnpm build` fails with a cryptic "not a valid Route export field" error. See `.claude/rules/routes.md` for the thin-wrapper + pure-helpers pattern.
 
 ## API Explorer (OpenAPI / Scalar)
 

--- a/.claude/docs/architecture.md
+++ b/.claude/docs/architecture.md
@@ -17,6 +17,7 @@ The application uses **Cloudflare-native storage services** for optimal performa
   - Thumbnails: `https://customer-<code>.cloudflarestream.com/<videoId>/thumbnails/thumbnail.jpg`
   - MP4: `https://customer-<code>.cloudflarestream.com/<videoId>/downloads/default.mp4`
 - **Replaces**: FFmpeg thumbnail generation
+- **MP4 downloads**: enabled asynchronously via a Cloudflare Stream webhook. After a video finishes transcoding, Cloudflare POSTs to `/api/webhooks/cloudflare-stream`, which verifies the HMAC-SHA256 signature and calls the downloads API. See [cloudflare-stream-webhook.md](./cloudflare-stream-webhook.md) for setup.
 
 ### R2 Native Bindings (Audio & Generic Files)
 - **Collections**: `meditations`, `songs`, `lessons`, `files`

--- a/.claude/docs/cloudflare-stream-webhook.md
+++ b/.claude/docs/cloudflare-stream-webhook.md
@@ -1,0 +1,158 @@
+# Cloudflare Stream Webhook
+
+## Overview
+
+When a video is uploaded to Cloudflare Stream it is not immediately playable as an MP4 — Cloudflare transcodes the video, but the `/<uid>/downloads/default.mp4` URL returns 404 until MP4 downloads are explicitly enabled on that video. Since our admin interface and downstream consumers rely on the MP4 URL, we need to enable downloads on every new upload.
+
+We cannot enable downloads synchronously inside the storage adapter: the downloads API rejects the request until the video reaches `readyToStream: true`, which takes seconds to minutes depending on the file. Instead we subscribe to the account-level Cloudflare Stream webhook and enable MP4 downloads from a signed webhook handler once Cloudflare notifies us that the video is ready.
+
+## Architecture
+
+```
+Admin upload
+   │
+   ▼
+cloudflareStreamAdapter.handleUpload
+   │  POST /accounts/{id}/stream   (upload bytes)
+   │  ◄── { uid, readyToStream: false }
+   │  filename set to uid, document saved
+   ▼
+(Cloudflare transcodes in the background)
+   │
+   ▼
+Cloudflare Stream
+   │  POST https://cloud.sydevelopers.com/api/webhooks/cloudflare-stream
+   │  Webhook-Signature: time=<unix>,sig1=<hmac-sha256-hex>
+   │  body = full video object ({ uid, readyToStream, status: { state: "ready" }, ... })
+   ▼
+Webhook route handler
+   │  1. Read raw body
+   │  2. Verify HMAC-SHA256 over `${time}.${rawBody}`
+   │  3. Parse with Zod
+   │  4. If status.state === "ready":
+   │       POST /accounts/{id}/stream/{uid}/downloads
+   │  5. Respond 200 (Cloudflare retries on non-2xx)
+   ▼
+Video has MP4 URL
+```
+
+## One-time production setup
+
+The webhook is **account-scoped**: there is exactly one notification URL per Cloudflare account. Only production registers the webhook — see "Dev environment" below.
+
+### 1. Register the webhook with Cloudflare
+
+```bash
+export CLOUDFLARE_ACCOUNT_ID=<prod-account-id>
+export CLOUDFLARE_API_KEY=<token-with-stream-edit>
+
+pnpm tsx scripts/setup-stream-webhook.ts \
+  --url https://cloud.sydevelopers.com/api/webhooks/cloudflare-stream
+```
+
+The script prints the signing secret returned by Cloudflare. Copy it.
+
+If a different URL is already registered, the script refuses and prints the current value. Pass `--force` to override (only do this if you are certain).
+
+You can also inspect the current subscription without changing it:
+
+```bash
+pnpm tsx scripts/setup-stream-webhook.ts --get
+```
+
+### 2. Store the signing secret in Workers
+
+```bash
+wrangler secret put CLOUDFLARE_STREAM_WEBHOOK_SECRET
+# Paste the secret from step 1 when prompted
+```
+
+### 3. Redeploy
+
+```bash
+pnpm run deploy:prod
+```
+
+Secrets take effect on the next request, but redeploying makes the rollout explicit and avoids surprises.
+
+### 4. Verify end-to-end
+
+1. Log into the admin at `https://cloud.sydevelopers.com/admin`.
+2. Upload a small test video (to `videos`, `frames`, or `files`).
+3. In another shell: `wrangler tail sahajcloud --format pretty`.
+4. You should see (in order):
+   - `Uploading video to Cloudflare Stream`
+   - `Video uploaded successfully`
+   - 15-60 seconds later: `MP4 downloads enabled via webhook`
+5. Open the `url` virtual field of the uploaded document — it should point to `https://customer-aorobtik2fce41s5.cloudflarestream.com/<uid>/downloads/default.mp4`.
+6. Pasting that URL in a browser should play / download the MP4.
+
+### Raw curl equivalents
+
+If the setup script is unavailable, the registration can be done by hand:
+
+```bash
+# Get current registration
+curl -H "Authorization: Bearer ${CLOUDFLARE_API_KEY}" \
+  https://api.cloudflare.com/client/v4/accounts/${CLOUDFLARE_ACCOUNT_ID}/stream/webhook
+
+# Register / update
+curl -X PUT \
+  -H "Authorization: Bearer ${CLOUDFLARE_API_KEY}" \
+  -H "Content-Type: application/json" \
+  -d '{"notificationUrl":"https://cloud.sydevelopers.com/api/webhooks/cloudflare-stream"}' \
+  https://api.cloudflare.com/client/v4/accounts/${CLOUDFLARE_ACCOUNT_ID}/stream/webhook
+
+# Delete
+curl -X DELETE \
+  -H "Authorization: Bearer ${CLOUDFLARE_API_KEY}" \
+  https://api.cloudflare.com/client/v4/accounts/${CLOUDFLARE_ACCOUNT_ID}/stream/webhook
+```
+
+## Dev environment
+
+Dev deployments **do not** subscribe to the Cloudflare Stream webhook and **do not** auto-enable MP4 downloads on uploads. The reason is that webhooks are account-scoped — if a dev machine registered its own URL, the next production upload would fail to get MP4 downloads enabled until someone re-registered the production URL.
+
+The route handler is still deployed in dev, but without `CLOUDFLARE_STREAM_WEBHOOK_SECRET` set it returns 503 for any POST. Cloudflare would only hit this URL if someone had manually registered the dev deployment, which shouldn't happen.
+
+**Trade-off**: videos uploaded via the dev admin will have broken MP4 URLs until someone enables downloads manually on them. For local QA that requires a working MP4, upload against production or backfill the specific video (see Manual backfill below).
+
+## Security
+
+- **HMAC-SHA256** signatures over `{time}.{rawBody}`, keyed with the webhook signing secret Cloudflare returned at registration time.
+- **5-minute freshness window** — stale timestamps (past or future) are rejected to prevent replays.
+- **Constant-time comparison** on the hex-encoded signature to prevent timing attacks.
+- The raw body is read with `request.text()` *before* any JSON parse so the bytes used for HMAC verification are byte-identical to what Cloudflare signed.
+- The handler uses Web Crypto (`crypto.subtle`) rather than Node's `crypto` module so the implementation is identical in Workers and in vitest.
+
+## Manual backfill
+
+For any video that was uploaded before the webhook was wired up (or for dev uploads that need to play):
+
+```bash
+export CLOUDFLARE_ACCOUNT_ID=<account-id>
+export CLOUDFLARE_API_KEY=<token-with-stream-edit>
+export VIDEO_UID=<the-videos-filename-field>
+
+curl -X POST \
+  -H "Authorization: Bearer ${CLOUDFLARE_API_KEY}" \
+  https://api.cloudflare.com/client/v4/accounts/${CLOUDFLARE_ACCOUNT_ID}/stream/${VIDEO_UID}/downloads
+```
+
+The video's `filename` field in Payload is the Stream UID.
+
+## Debugging
+
+- Tail production logs: `wrangler tail sahajcloud --format pretty`
+- Look for `MP4 downloads enabled via webhook` (success) or `Failed to enable MP4 downloads` / `Cloudflare Stream reported processing error` (failures).
+- A 400/401 response from the webhook route usually means the signing secret in Workers doesn't match the one Cloudflare has. Re-run `scripts/setup-stream-webhook.ts --get` and compare.
+- Cloudflare retries non-2xx responses with exponential backoff, so transient errors generally recover on their own.
+
+## Key files
+
+- [src/app/(payload)/api/webhooks/cloudflare-stream/route.ts](../../src/app/(payload)/api/webhooks/cloudflare-stream/route.ts) — Next.js POST handler (thin wrapper)
+- [src/lib/storage/cloudflareStreamWebhook.ts](../../src/lib/storage/cloudflareStreamWebhook.ts) — pure helpers (`parseSignatureHeader`, `verifySignature`, `handleStreamWebhook`)
+- [src/lib/storage/cloudflareSchemas.ts](../../src/lib/storage/cloudflareSchemas.ts) — `CloudflareStreamWebhookPayloadSchema`
+- [src/lib/storage/cloudflareStreamAdapter.ts](../../src/lib/storage/cloudflareStreamAdapter.ts) — upload-time adapter (no longer attempts to enable downloads)
+- [scripts/setup-stream-webhook.ts](../../scripts/setup-stream-webhook.ts) — one-off setup / teardown script
+- [tests/int/cloudflare-stream-webhook.int.spec.ts](../../tests/int/cloudflare-stream-webhook.int.spec.ts) — unit tests for the handler

--- a/.claude/rules/pr-requirements.md
+++ b/.claude/rules/pr-requirements.md
@@ -22,6 +22,21 @@ If you discover failing tests on `main`:
 - Create separate commit if fix is unrelated to feature
 - Document in PR description
 
+### Fast verification recipe
+
+To confirm a failure exists on `main` without losing your working changes:
+
+```bash
+git stash
+git checkout main -- tests/int/<failing-file>.int.spec.ts
+pnpm exec vitest run tests/int/<failing-file>.int.spec.ts
+# observe the same failure → it's pre-existing
+git checkout <your-branch> -- tests/int/<failing-file>.int.spec.ts
+git stash pop
+```
+
+This swaps just the single test file to its `main` version, re-runs it, then restores everything. Takes ~10 seconds and avoids a full branch checkout dance.
+
 ## PR Description Format
 
 Include test results summary:

--- a/.claude/rules/routes.md
+++ b/.claude/rules/routes.md
@@ -1,0 +1,91 @@
+---
+paths: src/app/(payload)/api/**/route.ts
+---
+
+# Next.js App Router Route Rules
+
+Rules for writing Next.js route handlers under `src/app/(payload)/api/`.
+
+## Allowed Exports (Critical)
+
+Next.js App Router route files may **only** export specific named values.
+Exporting anything else causes a build-time type error:
+
+```
+Type error: Route "path/to/route.ts" does not match the required types of a Next.js Route.
+  "<name>" is not a valid Route export field.
+```
+
+**Allowed exports**:
+- HTTP methods: `GET`, `POST`, `PUT`, `PATCH`, `DELETE`, `HEAD`, `OPTIONS`
+- Config: `dynamic`, `revalidate`, `runtime`, `preferredRegion`, `fetchCache`, `dynamicParams`, `maxDuration`, `generateStaticParams`
+
+**Not allowed**: arbitrary helper functions, constants, types, schemas, or anything else.
+Lint and tests will pass — only `pnpm build` catches this.
+
+## Pattern: Thin Route + Pure Helpers in `src/lib/`
+
+When a route has non-trivial logic (signature verification, complex branching,
+side-effect orchestration), extract the logic to a sibling file under
+`src/lib/` and keep the route file as a thin wrapper. This also makes the
+logic trivially unit-testable without booting Payload.
+
+```
+src/lib/storage/cloudflareStreamWebhook.ts    ← pure helpers (exported freely)
+src/app/(payload)/api/webhooks/cloudflare-stream/route.ts    ← thin POST wrapper
+tests/int/cloudflare-stream-webhook.int.spec.ts    ← imports helpers from @/lib/
+```
+
+**Route wrapper shape** (when the handler is pure and doesn't need Payload):
+
+```typescript
+import type { NextRequest } from 'next/server'
+
+import { NextResponse } from 'next/server'
+
+import { serverEnv } from '@/lib/env'
+import { handleMyThing } from '@/lib/<domain>/myThingHandler'
+import { createWorkerSafeLogger } from '@/lib/workerSafeLogger'
+
+// Module-level logger so cold starts don't re-init it on every request.
+const logger = createWorkerSafeLogger(serverEnv.NEXT_PUBLIC_LOG_LEVEL ?? 'info')
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  const rawBody = await request.text()
+
+  const result = await handleMyThing({
+    rawBody,
+    /* ...injected deps... */
+    logger,
+  })
+
+  return NextResponse.json(result.body, { status: result.status })
+}
+```
+
+**Prefer `createWorkerSafeLogger` over `getPayload({ config })`** when the handler is pure. Booting Payload just for `payload.logger` adds significant cold-start latency on Cloudflare Workers, which matters for webhooks (Cloudflare retries on non-2xx and on timeouts). Only reach for `getPayload` when the handler genuinely needs Payload features (`payload.find`, `payload.auth`, etc.).
+
+## Raw Body vs JSON
+
+If the handler needs to verify a signature (webhooks) or otherwise operate on
+exact bytes, always read the body as text first:
+
+```typescript
+const rawBody = await request.text()  // exact bytes for HMAC
+const parsed = JSON.parse(rawBody)    // OK to parse AFTER capturing raw
+```
+
+Never call `request.json()` and then try to re-serialize — `JSON.stringify`
+does not guarantee byte-identical output.
+
+## When to use a route handler vs a Payload endpoint
+
+See `.claude/docs/architecture.md` → "Custom Endpoints" for the full decision
+matrix. Short version:
+
+- **`src/endpoints/*.ts` (Payload endpoint)**: operations tied to a specific
+  collection (e.g., `/api/frames/by-narrator/:id`). Registered via the
+  collection's `endpoints` array. Has `req.payload` automatically.
+- **`src/app/(payload)/api/**/route.ts` (Next.js route)**: webhooks, health
+  checks, OpenAPI spec generation, seed triggers, or anything not scoped to
+  a single collection.

--- a/.claude/rules/tests.md
+++ b/.claude/rules/tests.md
@@ -25,9 +25,42 @@ Rules for writing tests in this codebase.
 - File upload mechanics
 - minRows/maxRows validation
 
-## Writing Isolated Tests
+## Pure Functions vs Payload-backed Tests
 
-Use `createTestEnvironment()` for complete test isolation.
+**Rule of thumb**: if the code under test doesn't touch Payload (no `req.payload`, no collection queries, no access control), skip `createTestEnvironment()` and import the module directly. A pure-function test suite runs in ~200ms; a `createTestEnvironment()` suite runs in ~8s minimum. Over a full suite the difference is huge.
+
+### When to use pure-function tests
+- Utilities in `src/lib/` with no Payload dependency (e.g., `cloudflareStreamWebhook.ts`, `mimeUtils.ts`, `schemaUtils.ts`)
+- Signature verification, parsing, validation logic
+- Pure helpers extracted from route handlers (the thin-wrapper pattern — see `.claude/rules/routes.md`)
+
+### Pattern
+
+Use `vi.resetModules()` + dynamic `await import(...)` in `beforeEach` to swap env vars between cases. Inject dependencies (e.g., `fetchFn`, `logger`) as function arguments rather than stubbing globals, so tests don't leak state.
+
+```typescript
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+let myHelper: typeof import('@/lib/domain/myHelper').myHelper
+
+beforeEach(async () => {
+  vi.resetModules()
+  process.env = { ...originalEnv, SOME_VAR: 'test-value' }
+  const mod = await import('@/lib/domain/myHelper')
+  myHelper = mod.myHelper
+})
+
+afterEach(() => {
+  process.env = originalEnv
+  vi.restoreAllMocks()
+})
+```
+
+Examples in the codebase: `tests/int/storage-utils.int.spec.ts`, `tests/int/cloudflare-stream-webhook.int.spec.ts`.
+
+## Writing Payload-backed Tests
+
+Use `createTestEnvironment()` for tests that need a real Payload instance (collection operations, hooks, access control integration, relationships).
 
 **IMPORTANT**: Only call `createTestEnvironment()` once per test file. Multiple calls cause Payload global state conflicts. Use nested `describe` blocks to organize tests within a single environment.
 

--- a/.env.example
+++ b/.env.example
@@ -95,6 +95,13 @@ CLOUDFLARE_STREAM_DELIVERY_URL=https://customer-your-code.cloudflarestream.com
 # Production: https://assets.sydevelopers.com
 CLOUDFLARE_R2_DELIVERY_URL=https://assets.sydevelopers.com
 
+# Cloudflare Stream Webhook Signing Secret (production only)
+# Returned when registering the webhook via scripts/setup-stream-webhook.ts.
+# Used to verify HMAC-SHA256 signatures on inbound webhooks.
+# VALIDATION: At least 32 characters
+# Set via: wrangler secret put CLOUDFLARE_STREAM_WEBHOOK_SECRET
+CLOUDFLARE_STREAM_WEBHOOK_SECRET=
+
 # ============================================
 # NIRMALA VIDYA API (Required)
 # ============================================

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -210,6 +210,15 @@ Configuration: `src/lib/richEditor.ts`
 
 **Note**: Database schema migrations are in `src/migrations/` - these seed scripts are for data migration only.
 
+### Operator Scripts (`scripts/`)
+
+One-off operator scripts (NOT seeds — seeds live in `seeds/`). Use for tasks an operator runs manually from their machine: external API registration, one-time backfills, deployment helpers, etc.
+
+- **Location**: `scripts/<name>.ts` (TypeScript, run via `pnpm tsx scripts/<name>.ts`)
+- **Env access**: Read `process.env` directly, NOT the validated `serverEnv` module — the script runs from a local shell and shouldn't require unrelated env vars to be set
+- **Safety**: For destructive or state-changing scripts, add a `--force` flag guard and print a warning before making mutations
+- **Example**: [scripts/setup-stream-webhook.ts](scripts/setup-stream-webhook.ts) — registers the Cloudflare Stream webhook and prints the signing secret
+
 ## Development Workflow
 
 1. **Schema Changes**: Run `pnpm generate:types` after modifying collections

--- a/scripts/setup-stream-webhook.ts
+++ b/scripts/setup-stream-webhook.ts
@@ -1,0 +1,201 @@
+#!/usr/bin/env node
+/**
+ * One-off script to register (or delete) a Cloudflare Stream webhook.
+ *
+ * The Cloudflare Stream webhook is **account-scoped**: only one notification
+ * URL exists per account. Running this script against the wrong URL will
+ * silently break production. Only run from an operator machine, pointing at
+ * the production deployment.
+ *
+ * Usage:
+ *   pnpm tsx scripts/setup-stream-webhook.ts --url <https-url>
+ *   pnpm tsx scripts/setup-stream-webhook.ts --url <https-url> --force
+ *   pnpm tsx scripts/setup-stream-webhook.ts --delete
+ *   pnpm tsx scripts/setup-stream-webhook.ts --get
+ *
+ * Env vars required:
+ *   CLOUDFLARE_ACCOUNT_ID
+ *   CLOUDFLARE_API_KEY  (token with Stream:Edit permission)
+ *
+ * After running with --url, copy the printed signing secret into Workers:
+ *   wrangler secret put CLOUDFLARE_STREAM_WEBHOOK_SECRET
+ */
+import { z } from 'zod'
+
+const EXPECTED_HOST = 'cloud.sydevelopers.com'
+
+const WebhookResponseSchema = z.object({
+  success: z.boolean(),
+  errors: z
+    .array(z.object({ code: z.number().optional(), message: z.string() }))
+    .default([]),
+  result: z
+    .object({
+      notificationUrl: z.string().optional(),
+      modified: z.string().optional(),
+      secret: z.string().optional(),
+    })
+    .nullable()
+    .optional(),
+})
+
+interface Args {
+  url?: string
+  force: boolean
+  delete: boolean
+  get: boolean
+}
+
+function parseArgs(argv: string[]): Args {
+  const args: Args = { force: false, delete: false, get: false }
+  for (let i = 2; i < argv.length; i++) {
+    const arg = argv[i]
+    if (arg === '--url') {
+      args.url = argv[++i]
+    } else if (arg === '--force') {
+      args.force = true
+    } else if (arg === '--delete') {
+      args.delete = true
+    } else if (arg === '--get') {
+      args.get = true
+    } else if (arg === '--help' || arg === '-h') {
+      printUsage()
+      process.exit(0)
+    } else {
+      console.error(`Unknown argument: ${arg}`)
+      printUsage()
+      process.exit(1)
+    }
+  }
+  return args
+}
+
+function printUsage(): void {
+  console.error(
+    [
+      'Usage:',
+      '  pnpm tsx scripts/setup-stream-webhook.ts --url <https-url> [--force]',
+      '  pnpm tsx scripts/setup-stream-webhook.ts --delete',
+      '  pnpm tsx scripts/setup-stream-webhook.ts --get',
+      '',
+      'Env required: CLOUDFLARE_ACCOUNT_ID, CLOUDFLARE_API_KEY',
+    ].join('\n'),
+  )
+}
+
+function requireEnv(name: string): string {
+  const value = process.env[name]
+  if (!value || value.length === 0) {
+    console.error(`Missing required env var: ${name}`)
+    process.exit(1)
+  }
+  return value
+}
+
+async function cf(
+  method: 'GET' | 'PUT' | 'DELETE',
+  accountId: string,
+  apiKey: string,
+  body?: unknown,
+): Promise<z.infer<typeof WebhookResponseSchema>> {
+  const response = await fetch(
+    `https://api.cloudflare.com/client/v4/accounts/${accountId}/stream/webhook`,
+    {
+      method,
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        'Content-Type': 'application/json',
+      },
+      body: body ? JSON.stringify(body) : undefined,
+    },
+  )
+  const json = await response.json()
+  return WebhookResponseSchema.parse(json)
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv)
+  const accountId = requireEnv('CLOUDFLARE_ACCOUNT_ID')
+  const apiKey = requireEnv('CLOUDFLARE_API_KEY')
+
+  if (args.get) {
+    const result = await cf('GET', accountId, apiKey)
+    console.log(JSON.stringify(result, null, 2))
+    return
+  }
+
+  if (args.delete) {
+    if (args.url) {
+      console.error('--delete and --url are mutually exclusive')
+      process.exit(1)
+    }
+    const result = await cf('DELETE', accountId, apiKey)
+    if (!result.success) {
+      console.error('Failed to delete webhook:', result.errors)
+      process.exit(1)
+    }
+    console.log('Webhook deleted.')
+    return
+  }
+
+  if (!args.url) {
+    console.error('Missing --url')
+    printUsage()
+    process.exit(1)
+  }
+
+  if (!args.url.startsWith('https://')) {
+    console.error('--url must be an HTTPS URL')
+    process.exit(1)
+  }
+
+  if (!args.url.includes(EXPECTED_HOST)) {
+    console.error(
+      `\n  \x1b[33m⚠ WARNING\x1b[0m: URL does not contain "${EXPECTED_HOST}". Cloudflare Stream webhooks are account-scoped — you will overwrite the production registration. Proceed only if this is intentional.\n`,
+    )
+  }
+
+  // Inspect current registration first
+  const current = await cf('GET', accountId, apiKey)
+  const currentUrl = current.result?.notificationUrl
+  if (
+    current.success &&
+    currentUrl &&
+    currentUrl !== args.url &&
+    !args.force
+  ) {
+    console.error(
+      `\nRefusing to overwrite existing webhook.\n  Current: ${currentUrl}\n  New:     ${args.url}\n\nPass --force to override.\n`,
+    )
+    process.exit(1)
+  }
+
+  const result = await cf('PUT', accountId, apiKey, { notificationUrl: args.url })
+  if (!result.success) {
+    console.error('Failed to register webhook:', result.errors)
+    process.exit(1)
+  }
+
+  const secret = result.result?.secret
+  if (!secret) {
+    console.error('Cloudflare did not return a signing secret. Response:', result)
+    process.exit(1)
+  }
+
+  console.log('')
+  console.log('Webhook registered.')
+  console.log(`  Notification URL: ${args.url}`)
+  console.log(`  Signing secret:   ${secret}`)
+  console.log('')
+  console.log('Next steps:')
+  console.log('  1. Copy the signing secret above.')
+  console.log('  2. Run: wrangler secret put CLOUDFLARE_STREAM_WEBHOOK_SECRET')
+  console.log('  3. Paste the secret when prompted.')
+  console.log('  4. Deploy: pnpm run deploy:prod')
+  console.log('')
+}
+
+main().catch((error) => {
+  console.error(error)
+  process.exit(1)
+})

--- a/scripts/setup-stream-webhook.ts
+++ b/scripts/setup-stream-webhook.ts
@@ -144,14 +144,22 @@ async function main(): Promise<void> {
     process.exit(1)
   }
 
-  if (!args.url.startsWith('https://')) {
+  let parsedUrl: URL
+  try {
+    parsedUrl = new URL(args.url)
+  } catch {
+    console.error('--url is not a valid URL')
+    process.exit(1)
+  }
+
+  if (parsedUrl.protocol !== 'https:') {
     console.error('--url must be an HTTPS URL')
     process.exit(1)
   }
 
-  if (!args.url.includes(EXPECTED_HOST)) {
+  if (parsedUrl.hostname !== EXPECTED_HOST) {
     console.error(
-      `\n  \x1b[33m⚠ WARNING\x1b[0m: URL does not contain "${EXPECTED_HOST}". Cloudflare Stream webhooks are account-scoped — you will overwrite the production registration. Proceed only if this is intentional.\n`,
+      `\n  \x1b[33m⚠ WARNING\x1b[0m: URL hostname is "${parsedUrl.hostname}", expected "${EXPECTED_HOST}". Cloudflare Stream webhooks are account-scoped — you will overwrite the production registration. Proceed only if this is intentional.\n`,
     )
   }
 

--- a/src/app/(payload)/api/webhooks/cloudflare-stream/route.ts
+++ b/src/app/(payload)/api/webhooks/cloudflare-stream/route.ts
@@ -19,12 +19,19 @@
 import type { NextRequest } from 'next/server'
 
 import { NextResponse } from 'next/server'
-import { getPayload } from 'payload'
 
 import { serverEnv } from '@/lib/env'
+import type { WebhookLogger } from '@/lib/storage/cloudflareStreamWebhook'
 import { handleStreamWebhook } from '@/lib/storage/cloudflareStreamWebhook'
+import { createWorkerSafeLogger } from '@/lib/workerSafeLogger'
 
-import config from '@payload-config'
+// The webhook handler is pure and doesn't touch Payload, so we skip getPayload()
+// and use the worker-safe logger directly. This keeps cold-start latency low on
+// Cloudflare Workers, where Cloudflare Stream retries on non-2xx.
+// createWorkerSafeLogger is typed as Config['logger'] (a union including option
+// shapes and undefined); at runtime it returns a Pino-compatible instance with
+// info/warn/error, which is all WebhookLogger needs.
+const logger = createWorkerSafeLogger(serverEnv.NEXT_PUBLIC_LOG_LEVEL ?? 'info') as unknown as WebhookLogger
 
 /**
  * POST /api/webhooks/cloudflare-stream
@@ -36,15 +43,13 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
   const rawBody = await request.text()
   const signatureHeader = request.headers.get('webhook-signature')
 
-  const payload = await getPayload({ config })
-
   const result = await handleStreamWebhook({
     rawBody,
     signatureHeader,
     secret: serverEnv.CLOUDFLARE_STREAM_WEBHOOK_SECRET,
     accountId: serverEnv.CLOUDFLARE_ACCOUNT_ID,
     apiKey: serverEnv.CLOUDFLARE_API_KEY,
-    logger: payload.logger,
+    logger,
   })
 
   return NextResponse.json(result.body, { status: result.status })

--- a/src/app/(payload)/api/webhooks/cloudflare-stream/route.ts
+++ b/src/app/(payload)/api/webhooks/cloudflare-stream/route.ts
@@ -1,0 +1,51 @@
+/**
+ * Cloudflare Stream Webhook Handler
+ *
+ * Receives webhook notifications from Cloudflare when a video reaches a
+ * terminal state (`ready` or `error`). For ready videos we call the downloads
+ * API to enable MP4 downloads, which is the final step needed before an
+ * `<video>` tag can play the file via `/downloads/default.mp4`.
+ *
+ * The webhook is account-scoped: only production subscribes to it. Dev
+ * deployments have the route mounted but will 503 because the signing secret
+ * is not set. See `.claude/docs/cloudflare-stream-webhook.md`.
+ *
+ * The actual verification and processing logic lives in
+ * `src/lib/storage/cloudflareStreamWebhook.ts` (pure, testable). This file is
+ * just a Next.js route handler wrapper.
+ *
+ * @see https://developers.cloudflare.com/stream/manage-video-library/using-webhooks/
+ */
+import type { NextRequest } from 'next/server'
+
+import { NextResponse } from 'next/server'
+import { getPayload } from 'payload'
+
+import { serverEnv } from '@/lib/env'
+import { handleStreamWebhook } from '@/lib/storage/cloudflareStreamWebhook'
+
+import config from '@payload-config'
+
+/**
+ * POST /api/webhooks/cloudflare-stream
+ *
+ * Signed webhook from Cloudflare Stream. The body MUST be read as text first
+ * (before any JSON parsing) because the HMAC is computed over the raw bytes.
+ */
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  const rawBody = await request.text()
+  const signatureHeader = request.headers.get('webhook-signature')
+
+  const payload = await getPayload({ config })
+
+  const result = await handleStreamWebhook({
+    rawBody,
+    signatureHeader,
+    secret: serverEnv.CLOUDFLARE_STREAM_WEBHOOK_SECRET,
+    accountId: serverEnv.CLOUDFLARE_ACCOUNT_ID,
+    apiKey: serverEnv.CLOUDFLARE_API_KEY,
+    logger: payload.logger,
+  })
+
+  return NextResponse.json(result.body, { status: result.status })
+}

--- a/src/lib/env/server.ts
+++ b/src/lib/env/server.ts
@@ -83,6 +83,15 @@ const ServerEnvSchema = ClientEnvSchema.extend({
   CLOUDFLARE_R2_DELIVERY_URL: z.url().optional(),
 
   /**
+   * Cloudflare Stream webhook signing secret
+   * Returned by `PUT /accounts/{id}/stream/webhook` and used to verify HMAC-SHA256
+   * signatures on inbound webhooks. Production only — dev deployments do not
+   * subscribe to the account-scoped Stream webhook.
+   * Set via: `wrangler secret put CLOUDFLARE_STREAM_WEBHOOK_SECRET`
+   */
+  CLOUDFLARE_STREAM_WEBHOOK_SECRET: z.string().min(32).optional(),
+
+  /**
    * Wrangler environment selection
    * - 'dev': Uses [env.dev] configuration from wrangler.toml
    * - 'production': Uses [env.production] configuration from wrangler.toml

--- a/src/lib/storage/cloudflareSchemas.ts
+++ b/src/lib/storage/cloudflareSchemas.ts
@@ -118,9 +118,37 @@ export const CloudflareStreamDownloadsResponseSchema = CloudflareBaseResponseSch
     .optional(),
 })
 
+/**
+ * Cloudflare Stream webhook payload
+ *
+ * Sent when a video reaches a terminal state (ready or error). The shape
+ * mirrors `GET /stream/{uid}` — we only validate the fields we actually use
+ * and pass unknown fields through so Cloudflare can add new ones without
+ * breaking us.
+ *
+ * @see https://developers.cloudflare.com/stream/manage-video-library/using-webhooks/
+ */
+export const CloudflareStreamWebhookPayloadSchema = z
+  .object({
+    uid: z.string().min(1),
+    readyToStream: z.boolean().optional(),
+    status: z.object({
+      state: z.string(),
+      pctComplete: z.string().optional(),
+      errorReasonCode: z.string().optional(),
+      errorReasonText: z.string().optional(),
+    }),
+    meta: z.record(z.string(), z.string()).optional(),
+    created: z.string().optional(),
+    modified: z.string().optional(),
+    duration: z.number().optional(),
+  })
+  .passthrough()
+
 // Type inference for TypeScript
 export type CloudflareImagesResponse = z.infer<typeof CloudflareImagesResponseSchema>
 export type CloudflareStreamResponse = z.infer<typeof CloudflareStreamResponseSchema>
 export type CloudflareStreamDownloadsResponse = z.infer<
   typeof CloudflareStreamDownloadsResponseSchema
 >
+export type CloudflareStreamWebhookPayload = z.infer<typeof CloudflareStreamWebhookPayloadSchema>

--- a/src/lib/storage/cloudflareStreamAdapter.ts
+++ b/src/lib/storage/cloudflareStreamAdapter.ts
@@ -11,7 +11,7 @@ import { z } from 'zod'
 
 import { serverEnv } from '@/lib/env'
 
-import { CloudflareStreamDownloadsResponseSchema, CloudflareStreamResponseSchema } from './cloudflareSchemas'
+import { CloudflareStreamResponseSchema } from './cloudflareSchemas'
 import { validateFileUpload } from './uploadValidation'
 
 /**
@@ -130,38 +130,9 @@ export const cloudflareStreamAdapter = (config: CloudflareStreamConfig): Adapter
 
         req.payload.logger.info({ msg: 'Video uploaded successfully', videoId })
 
-        // Enable MP4 downloads for HTML5 video compatibility
-        try {
-          const downloadsResponse = await fetch(
-            `https://api.cloudflare.com/client/v4/accounts/${config.accountId}/stream/${videoId}/downloads`,
-            {
-              method: 'POST',
-              headers: {
-                Authorization: `Bearer ${config.apiKey}`,
-                'Content-Type': 'application/json',
-              },
-            },
-          )
-
-          const downloadsResult = CloudflareStreamDownloadsResponseSchema.parse(
-            await downloadsResponse.json(),
-          )
-
-          if (!downloadsResult.success) {
-            const errors = downloadsResult.errors.map((e) => e.message).join(', ')
-            req.payload.logger.warn({ msg: 'Failed to enable MP4 downloads', videoId, errors })
-          } else {
-            const downloadStatus = downloadsResult.result?.default?.status || 'unknown'
-            req.payload.logger.info({ msg: 'MP4 downloads enabled', videoId, status: downloadStatus })
-          }
-        } catch (error) {
-          // Non-fatal error - video upload succeeded
-          req.payload.logger.warn({
-            msg: 'Error enabling MP4 downloads',
-            videoId,
-            error: error instanceof Error ? error.message : String(error),
-          })
-        }
+        // Note: MP4 downloads are enabled asynchronously via a Cloudflare Stream webhook
+        // once the video finishes transcoding. See src/app/(payload)/api/webhooks/cloudflare-stream/
+        // and .claude/docs/cloudflare-stream-webhook.md.
 
         // Preserve original filename in fileMetadata for seed script deduplication
         // The original filename (e.g., "f47ac10b58cc4372.mp4") is used for matching

--- a/src/lib/storage/cloudflareStreamWebhook.ts
+++ b/src/lib/storage/cloudflareStreamWebhook.ts
@@ -1,0 +1,249 @@
+/**
+ * Cloudflare Stream webhook helpers (pure, no Payload / Next.js dependency).
+ *
+ * Kept in `src/lib/storage` rather than co-located with the route handler
+ * because Next.js App Router routes may only export specific named exports
+ * (GET, POST, etc.) — arbitrary helper exports cause a build error.
+ *
+ * @see https://developers.cloudflare.com/stream/manage-video-library/using-webhooks/
+ */
+import { z } from 'zod'
+
+import {
+  CloudflareStreamDownloadsResponseSchema,
+  CloudflareStreamWebhookPayloadSchema,
+} from './cloudflareSchemas'
+
+const FIVE_MINUTES_SECONDS = 300
+
+export type VerifyFailure = {
+  ok: false
+  reason: 'missing' | 'malformed' | 'stale' | 'mismatch'
+}
+export type VerifyResult = { ok: true } | VerifyFailure
+
+export interface WebhookLogger {
+  info: (obj: object) => void
+  warn: (obj: object) => void
+  error: (obj: object) => void
+}
+
+/**
+ * Parse a `Webhook-Signature: time=<unix>,sig1=<hex>` header.
+ * Tolerates extra segments (e.g. `sig2=...`) and is case-insensitive on keys.
+ */
+export function parseSignatureHeader(
+  header: string | null | undefined,
+): { time: number; sig: string } | null {
+  if (!header || typeof header !== 'string') return null
+
+  const parts = header.split(',')
+  let time: number | null = null
+  let sig: string | null = null
+
+  for (const part of parts) {
+    const idx = part.indexOf('=')
+    if (idx === -1) return null
+    const key = part.slice(0, idx).trim().toLowerCase()
+    const value = part.slice(idx + 1).trim()
+    if (!value) return null
+
+    if (key === 'time') {
+      if (!/^\d+$/.test(value)) return null
+      time = parseInt(value, 10)
+    } else if (key === 'sig1') {
+      sig = value
+    }
+  }
+
+  if (time === null || sig === null) return null
+  return { time, sig }
+}
+
+function bufferToHex(buf: ArrayBuffer): string {
+  const bytes = new Uint8Array(buf)
+  let out = ''
+  for (let i = 0; i < bytes.length; i++) {
+    out += bytes[i].toString(16).padStart(2, '0')
+  }
+  return out
+}
+
+/**
+ * Constant-time string comparison. Both strings MUST be equal length;
+ * a length mismatch is never a valid signature anyway.
+ */
+function constantTimeEqual(a: string, b: string): boolean {
+  if (a.length !== b.length) return false
+  let result = 0
+  for (let i = 0; i < a.length; i++) {
+    result |= a.charCodeAt(i) ^ b.charCodeAt(i)
+  }
+  return result === 0
+}
+
+/**
+ * Verify a Cloudflare Stream webhook signature using HMAC-SHA256 over
+ * `{time}.{rawBody}`. Uses Web Crypto (`crypto.subtle`) so it runs identically
+ * in Workers, Node 20+, and Vitest.
+ */
+export async function verifySignature(
+  rawBody: string,
+  signatureHeader: string | null | undefined,
+  secret: string,
+  nowSeconds: number = Math.floor(Date.now() / 1000),
+): Promise<VerifyResult> {
+  if (!signatureHeader) return { ok: false, reason: 'missing' }
+
+  const parsed = parseSignatureHeader(signatureHeader)
+  if (!parsed) return { ok: false, reason: 'malformed' }
+
+  if (Math.abs(nowSeconds - parsed.time) > FIVE_MINUTES_SECONDS) {
+    return { ok: false, reason: 'stale' }
+  }
+
+  const encoder = new TextEncoder()
+  const key = await crypto.subtle.importKey(
+    'raw',
+    encoder.encode(secret),
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign'],
+  )
+  const signed = await crypto.subtle.sign(
+    'HMAC',
+    key,
+    encoder.encode(`${parsed.time}.${rawBody}`),
+  )
+  const expectedHex = bufferToHex(signed)
+
+  if (!constantTimeEqual(parsed.sig.toLowerCase(), expectedHex)) {
+    return { ok: false, reason: 'mismatch' }
+  }
+
+  return { ok: true }
+}
+
+/**
+ * Pure webhook processor. No Payload or Next.js dependency — the route handler
+ * is a thin wrapper. Callers can inject `fetchFn` for tests.
+ */
+export async function handleStreamWebhook(params: {
+  rawBody: string
+  signatureHeader: string | null | undefined
+  secret: string | undefined
+  accountId: string | undefined
+  apiKey: string | undefined
+  logger: WebhookLogger
+  fetchFn?: typeof fetch
+}): Promise<{ status: number; body: unknown }> {
+  const { rawBody, signatureHeader, secret, accountId, apiKey, logger } = params
+  const doFetch = params.fetchFn ?? fetch
+
+  if (!secret) {
+    logger.warn({ msg: 'Cloudflare Stream webhook secret not configured' })
+    return { status: 503, body: { error: 'Webhook secret not configured' } }
+  }
+
+  const verification = await verifySignature(rawBody, signatureHeader, secret)
+  if (!verification.ok) {
+    const reason = verification.reason
+    logger.warn({ msg: 'Cloudflare Stream webhook signature verification failed', reason })
+
+    if (reason === 'missing' || reason === 'malformed') {
+      return { status: 400, body: { error: `Bad signature header: ${reason}` } }
+    }
+    if (reason === 'stale') {
+      return { status: 401, body: { error: 'Stale signature' } }
+    }
+    return { status: 401, body: { error: 'Invalid signature' } }
+  }
+
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(rawBody)
+  } catch {
+    return { status: 400, body: { error: 'Invalid JSON body' } }
+  }
+
+  const validation = CloudflareStreamWebhookPayloadSchema.safeParse(parsed)
+  if (!validation.success) {
+    logger.warn({
+      msg: 'Cloudflare Stream webhook payload validation failed',
+      issues: validation.error.issues,
+    })
+    return { status: 400, body: { error: 'Invalid webhook payload' } }
+  }
+
+  const payload = validation.data
+  const { uid, status } = payload
+
+  if (status.state === 'error') {
+    logger.error({
+      msg: 'Cloudflare Stream reported processing error',
+      uid,
+      state: status.state,
+      errorReasonCode: status.errorReasonCode,
+      errorReasonText: status.errorReasonText,
+    })
+    return { status: 200, body: { ok: true, action: 'logged-error' } }
+  }
+
+  if (status.state !== 'ready') {
+    logger.info({
+      msg: 'Cloudflare Stream webhook received for non-terminal state; ignoring',
+      uid,
+      state: status.state,
+    })
+    return { status: 200, body: { ok: true, action: 'ignored' } }
+  }
+
+  if (!accountId || !apiKey) {
+    logger.error({
+      msg: 'Cannot enable MP4 downloads — Cloudflare credentials not configured',
+      uid,
+    })
+    return { status: 503, body: { error: 'Cloudflare credentials not configured' } }
+  }
+
+  try {
+    const response = await doFetch(
+      `https://api.cloudflare.com/client/v4/accounts/${accountId}/stream/${uid}/downloads`,
+      {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${apiKey}`,
+          'Content-Type': 'application/json',
+        },
+      },
+    )
+
+    const result = CloudflareStreamDownloadsResponseSchema.parse(await response.json())
+
+    if (!result.success) {
+      const errors = result.errors.map((e) => e.message).join(', ')
+      logger.error({ msg: 'Failed to enable MP4 downloads', uid, errors })
+      return { status: 500, body: { error: 'Failed to enable downloads' } }
+    }
+
+    const downloadStatus = result.result?.default?.status ?? 'unknown'
+    logger.info({ msg: 'MP4 downloads enabled via webhook', uid, status: downloadStatus })
+    return { status: 200, body: { ok: true, action: 'downloads-enabled', downloadStatus } }
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      logger.error({
+        msg: 'Cloudflare downloads API response validation failed',
+        uid,
+        issues: error.issues,
+      })
+      return { status: 500, body: { error: 'Invalid downstream response' } }
+    }
+
+    logger.error({
+      msg: 'Error enabling MP4 downloads via webhook',
+      uid,
+      error: error instanceof Error ? error.message : String(error),
+    })
+    return { status: 500, body: { error: 'Failed to enable downloads' } }
+  }
+}

--- a/tests/int/cloudflare-stream-webhook.int.spec.ts
+++ b/tests/int/cloudflare-stream-webhook.int.spec.ts
@@ -1,0 +1,415 @@
+/**
+ * Integration tests for the Cloudflare Stream webhook handler.
+ *
+ * These tests exercise the pure helpers exported from the route handler
+ * (`parseSignatureHeader`, `verifySignature`, `handleStreamWebhook`) without
+ * booting a Payload instance — the handler is designed to accept an injected
+ * logger and fetch so tests stay fast.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Dynamic-import these after env is prepared so any module-level validation
+// (none today, but cheap insurance) sees the expected env values.
+let parseSignatureHeader: typeof import('@/lib/storage/cloudflareStreamWebhook').parseSignatureHeader
+let verifySignature: typeof import('@/lib/storage/cloudflareStreamWebhook').verifySignature
+let handleStreamWebhook: typeof import('@/lib/storage/cloudflareStreamWebhook').handleStreamWebhook
+
+const FAKE_NOW_SECONDS = 1_750_000_000
+const SECRET = 'test-webhook-signing-secret-with-32-plus-chars'
+
+interface CapturedLogger {
+  info: ReturnType<typeof vi.fn>
+  warn: ReturnType<typeof vi.fn>
+  error: ReturnType<typeof vi.fn>
+}
+
+function makeLogger(): CapturedLogger {
+  return {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  }
+}
+
+async function computeSignature(rawBody: string, secret: string, time: number): Promise<string> {
+  const encoder = new TextEncoder()
+  const key = await crypto.subtle.importKey(
+    'raw',
+    encoder.encode(secret),
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign'],
+  )
+  const signed = await crypto.subtle.sign(
+    'HMAC',
+    key,
+    encoder.encode(`${time}.${rawBody}`),
+  )
+  const bytes = new Uint8Array(signed)
+  let hex = ''
+  for (let i = 0; i < bytes.length; i++) {
+    hex += bytes[i].toString(16).padStart(2, '0')
+  }
+  return hex
+}
+
+function buildReadyPayload(overrides: Record<string, unknown> = {}): string {
+  return JSON.stringify({
+    uid: 'test-video-uid-abc123',
+    readyToStream: true,
+    status: { state: 'ready', pctComplete: '100.000000' },
+    ...overrides,
+  })
+}
+
+describe('Cloudflare Stream webhook handler', () => {
+  const originalEnv = process.env
+
+  beforeEach(async () => {
+    vi.resetModules()
+    process.env = {
+      ...originalEnv,
+      PAYLOAD_SECRET: 'test-secret-key-with-32-chars-minimum',
+      CLOUDFLARE_STREAM_WEBHOOK_SECRET: SECRET,
+      CLOUDFLARE_ACCOUNT_ID: 'test-account-id',
+      CLOUDFLARE_API_KEY: 'test-cloudflare-api-key-20chars',
+    }
+
+    const mod = await import('@/lib/storage/cloudflareStreamWebhook')
+    parseSignatureHeader = mod.parseSignatureHeader
+    verifySignature = mod.verifySignature
+    handleStreamWebhook = mod.handleStreamWebhook
+  })
+
+  afterEach(() => {
+    process.env = originalEnv
+    vi.restoreAllMocks()
+  })
+
+  describe('parseSignatureHeader', () => {
+    it('returns null for null / empty / non-string inputs', () => {
+      expect(parseSignatureHeader(null)).toBeNull()
+      expect(parseSignatureHeader('')).toBeNull()
+      expect(parseSignatureHeader(undefined)).toBeNull()
+    })
+
+    it('parses a well-formed header', () => {
+      const result = parseSignatureHeader('time=1700000000,sig1=deadbeef')
+      expect(result).toEqual({ time: 1_700_000_000, sig: 'deadbeef' })
+    })
+
+    it('ignores extra unknown segments', () => {
+      const result = parseSignatureHeader('time=1700000000,sig1=abc,sig2=ignored')
+      expect(result).toEqual({ time: 1_700_000_000, sig: 'abc' })
+    })
+
+    it('returns null when time is not numeric', () => {
+      expect(parseSignatureHeader('time=notanumber,sig1=abc')).toBeNull()
+    })
+
+    it('returns null when sig1 is missing', () => {
+      expect(parseSignatureHeader('time=1700000000')).toBeNull()
+    })
+
+    it('returns null when time is missing', () => {
+      expect(parseSignatureHeader('sig1=abc')).toBeNull()
+    })
+
+    it('returns null for malformed segments', () => {
+      expect(parseSignatureHeader('nosep,sig1=abc')).toBeNull()
+    })
+  })
+
+  describe('verifySignature', () => {
+    it('accepts a valid signature', async () => {
+      const body = buildReadyPayload()
+      const sig = await computeSignature(body, SECRET, FAKE_NOW_SECONDS)
+      const header = `time=${FAKE_NOW_SECONDS},sig1=${sig}`
+      const result = await verifySignature(body, header, SECRET, FAKE_NOW_SECONDS)
+      expect(result).toEqual({ ok: true })
+    })
+
+    it('rejects a signature signed with the wrong secret', async () => {
+      const body = buildReadyPayload()
+      const sig = await computeSignature(body, 'some-other-secret-32-chars-minimum!', FAKE_NOW_SECONDS)
+      const header = `time=${FAKE_NOW_SECONDS},sig1=${sig}`
+      const result = await verifySignature(body, header, SECRET, FAKE_NOW_SECONDS)
+      expect(result).toEqual({ ok: false, reason: 'mismatch' })
+    })
+
+    it('rejects a stale signature (> 5 minutes in the past)', async () => {
+      const body = buildReadyPayload()
+      const staleTime = FAKE_NOW_SECONDS - 301
+      const sig = await computeSignature(body, SECRET, staleTime)
+      const header = `time=${staleTime},sig1=${sig}`
+      const result = await verifySignature(body, header, SECRET, FAKE_NOW_SECONDS)
+      expect(result).toEqual({ ok: false, reason: 'stale' })
+    })
+
+    it('rejects a signature from > 5 minutes in the future', async () => {
+      const body = buildReadyPayload()
+      const futureTime = FAKE_NOW_SECONDS + 301
+      const sig = await computeSignature(body, SECRET, futureTime)
+      const header = `time=${futureTime},sig1=${sig}`
+      const result = await verifySignature(body, header, SECRET, FAKE_NOW_SECONDS)
+      expect(result).toEqual({ ok: false, reason: 'stale' })
+    })
+
+    it('rejects a missing header', async () => {
+      const result = await verifySignature('{}', null, SECRET, FAKE_NOW_SECONDS)
+      expect(result).toEqual({ ok: false, reason: 'missing' })
+    })
+
+    it('rejects a malformed header', async () => {
+      const result = await verifySignature('{}', 'garbage', SECRET, FAKE_NOW_SECONDS)
+      expect(result).toEqual({ ok: false, reason: 'malformed' })
+    })
+
+    it('rejects a signature with wrong length (different hex length)', async () => {
+      const body = buildReadyPayload()
+      const header = `time=${FAKE_NOW_SECONDS},sig1=deadbeef`
+      const result = await verifySignature(body, header, SECRET, FAKE_NOW_SECONDS)
+      expect(result).toEqual({ ok: false, reason: 'mismatch' })
+    })
+  })
+
+  describe('handleStreamWebhook', () => {
+    function makeFetchFn(response: unknown, status = 200): ReturnType<typeof vi.fn> {
+      return vi.fn().mockResolvedValue(
+        new Response(JSON.stringify(response), {
+          status,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      )
+    }
+
+    async function signedHeader(body: string): Promise<string> {
+      const sig = await computeSignature(body, SECRET, FAKE_NOW_SECONDS)
+      return `time=${FAKE_NOW_SECONDS},sig1=${sig}`
+    }
+
+    it('enables downloads when a ready event arrives', async () => {
+      const rawBody = buildReadyPayload()
+      const header = await signedHeader(rawBody)
+      const fetchFn = makeFetchFn({
+        success: true,
+        errors: [],
+        result: { default: { status: 'ready' } },
+      })
+      const logger = makeLogger()
+
+      // Freeze Date.now so verifySignature uses FAKE_NOW_SECONDS
+      vi.spyOn(Date, 'now').mockReturnValue(FAKE_NOW_SECONDS * 1000)
+
+      const result = await handleStreamWebhook({
+        rawBody,
+        signatureHeader: header,
+        secret: SECRET,
+        accountId: 'test-account-id',
+        apiKey: 'test-api-key',
+        logger,
+        fetchFn: fetchFn as unknown as typeof fetch,
+      })
+
+      expect(result.status).toBe(200)
+      expect(fetchFn).toHaveBeenCalledTimes(1)
+      const [url, init] = fetchFn.mock.calls[0]
+      expect(url).toBe(
+        'https://api.cloudflare.com/client/v4/accounts/test-account-id/stream/test-video-uid-abc123/downloads',
+      )
+      expect(init).toMatchObject({
+        method: 'POST',
+        headers: expect.objectContaining({ Authorization: 'Bearer test-api-key' }),
+      })
+      expect(logger.info).toHaveBeenCalledWith(
+        expect.objectContaining({ msg: 'MP4 downloads enabled via webhook' }),
+      )
+    })
+
+    it('logs and returns 200 on error state without calling downloads API', async () => {
+      const rawBody = JSON.stringify({
+        uid: 'bad-video',
+        status: {
+          state: 'error',
+          errorReasonCode: 'ERR_MALFORMED_VIDEO',
+          errorReasonText: 'The video was deemed to be corrupted',
+        },
+      })
+      const header = await signedHeader(rawBody)
+      const fetchFn = makeFetchFn({})
+      const logger = makeLogger()
+      vi.spyOn(Date, 'now').mockReturnValue(FAKE_NOW_SECONDS * 1000)
+
+      const result = await handleStreamWebhook({
+        rawBody,
+        signatureHeader: header,
+        secret: SECRET,
+        accountId: 'test-account-id',
+        apiKey: 'test-api-key',
+        logger,
+        fetchFn: fetchFn as unknown as typeof fetch,
+      })
+
+      expect(result.status).toBe(200)
+      expect(fetchFn).not.toHaveBeenCalled()
+      expect(logger.error).toHaveBeenCalledWith(
+        expect.objectContaining({
+          msg: 'Cloudflare Stream reported processing error',
+          uid: 'bad-video',
+          errorReasonCode: 'ERR_MALFORMED_VIDEO',
+        }),
+      )
+    })
+
+    it('ignores intermediate states without calling downloads API', async () => {
+      const rawBody = JSON.stringify({
+        uid: 'processing-video',
+        status: { state: 'inprogress', pctComplete: '50.0' },
+      })
+      const header = await signedHeader(rawBody)
+      const fetchFn = makeFetchFn({})
+      const logger = makeLogger()
+      vi.spyOn(Date, 'now').mockReturnValue(FAKE_NOW_SECONDS * 1000)
+
+      const result = await handleStreamWebhook({
+        rawBody,
+        signatureHeader: header,
+        secret: SECRET,
+        accountId: 'test-account-id',
+        apiKey: 'test-api-key',
+        logger,
+        fetchFn: fetchFn as unknown as typeof fetch,
+      })
+
+      expect(result.status).toBe(200)
+      expect(fetchFn).not.toHaveBeenCalled()
+    })
+
+    it('rejects with 401 when signature is invalid', async () => {
+      const rawBody = buildReadyPayload()
+      const fetchFn = makeFetchFn({})
+      const logger = makeLogger()
+      vi.spyOn(Date, 'now').mockReturnValue(FAKE_NOW_SECONDS * 1000)
+
+      const result = await handleStreamWebhook({
+        rawBody,
+        signatureHeader: `time=${FAKE_NOW_SECONDS},sig1=${'0'.repeat(64)}`,
+        secret: SECRET,
+        accountId: 'test-account-id',
+        apiKey: 'test-api-key',
+        logger,
+        fetchFn: fetchFn as unknown as typeof fetch,
+      })
+
+      expect(result.status).toBe(401)
+      expect(fetchFn).not.toHaveBeenCalled()
+    })
+
+    it('rejects with 400 when signature header is missing', async () => {
+      const logger = makeLogger()
+      const result = await handleStreamWebhook({
+        rawBody: buildReadyPayload(),
+        signatureHeader: null,
+        secret: SECRET,
+        accountId: 'test-account-id',
+        apiKey: 'test-api-key',
+        logger,
+      })
+      expect(result.status).toBe(400)
+    })
+
+    it('returns 503 when webhook secret is missing', async () => {
+      const logger = makeLogger()
+      const result = await handleStreamWebhook({
+        rawBody: buildReadyPayload(),
+        signatureHeader: 'time=1,sig1=abc',
+        secret: undefined,
+        accountId: 'test-account-id',
+        apiKey: 'test-api-key',
+        logger,
+      })
+      expect(result.status).toBe(503)
+      expect(logger.warn).toHaveBeenCalled()
+    })
+
+    it('returns 503 when accountId or apiKey is missing but event is ready', async () => {
+      const rawBody = buildReadyPayload()
+      const header = await signedHeader(rawBody)
+      const logger = makeLogger()
+      vi.spyOn(Date, 'now').mockReturnValue(FAKE_NOW_SECONDS * 1000)
+
+      const result = await handleStreamWebhook({
+        rawBody,
+        signatureHeader: header,
+        secret: SECRET,
+        accountId: undefined,
+        apiKey: undefined,
+        logger,
+      })
+
+      expect(result.status).toBe(503)
+    })
+
+    it('returns 500 when downstream Cloudflare API returns success: false', async () => {
+      const rawBody = buildReadyPayload()
+      const header = await signedHeader(rawBody)
+      const fetchFn = makeFetchFn({
+        success: false,
+        errors: [{ message: 'Video not ready yet' }],
+      })
+      const logger = makeLogger()
+      vi.spyOn(Date, 'now').mockReturnValue(FAKE_NOW_SECONDS * 1000)
+
+      const result = await handleStreamWebhook({
+        rawBody,
+        signatureHeader: header,
+        secret: SECRET,
+        accountId: 'test-account-id',
+        apiKey: 'test-api-key',
+        logger,
+        fetchFn: fetchFn as unknown as typeof fetch,
+      })
+
+      expect(result.status).toBe(500)
+      expect(logger.error).toHaveBeenCalledWith(
+        expect.objectContaining({ msg: 'Failed to enable MP4 downloads' }),
+      )
+    })
+
+    it('returns 400 when body is not valid JSON', async () => {
+      const rawBody = 'not-json'
+      const header = await signedHeader(rawBody)
+      const logger = makeLogger()
+      vi.spyOn(Date, 'now').mockReturnValue(FAKE_NOW_SECONDS * 1000)
+
+      const result = await handleStreamWebhook({
+        rawBody,
+        signatureHeader: header,
+        secret: SECRET,
+        accountId: 'test-account-id',
+        apiKey: 'test-api-key',
+        logger,
+      })
+
+      expect(result.status).toBe(400)
+    })
+
+    it('returns 400 when payload fails schema validation', async () => {
+      const rawBody = JSON.stringify({ uid: 'abc' }) // missing status
+      const header = await signedHeader(rawBody)
+      const logger = makeLogger()
+      vi.spyOn(Date, 'now').mockReturnValue(FAKE_NOW_SECONDS * 1000)
+
+      const result = await handleStreamWebhook({
+        rawBody,
+        signatureHeader: header,
+        secret: SECRET,
+        accountId: 'test-account-id',
+        apiKey: 'test-api-key',
+        logger,
+      })
+
+      expect(result.status).toBe(400)
+    })
+  })
+})

--- a/tests/int/role-based-access.int.spec.ts
+++ b/tests/int/role-based-access.int.spec.ts
@@ -397,6 +397,8 @@ describe('Role-Based Access Control', () => {
       })
 
       // Should NOT have implicit read to collections only in other projects
+      // lessons and app-cards are only in wemeditate-app; lectures is shared
+      // across wemeditate-web and wemeditate-app, so it IS readable here.
       expect(
         hasPermission(
           { user: managerUser, collection: 'lessons', operation: 'read' },
@@ -405,7 +407,7 @@ describe('Role-Based Access Control', () => {
       ).toBe(false)
       expect(
         hasPermission(
-          { user: managerUser, collection: 'lectures', operation: 'read' },
+          { user: managerUser, collection: 'app-cards', operation: 'read' },
           bypassPermissions,
         ),
       ).toBe(false)


### PR DESCRIPTION
## Summary

- Cloudflare Stream MP4 download URLs were returning 404 because the adapter tried to enable downloads immediately after upload, when the video was still transcoding. Editors had to manually click "Generate Download" in the Cloudflare dashboard for every upload.
- Replaces the eager call with an account-scoped Cloudflare Stream webhook. When a video reaches `status.state === 'ready'`, Cloudflare POSTs to `/api/webhooks/cloudflare-stream`, and the handler verifies an HMAC-SHA256 signature and calls the downloads API.
- Adds `scripts/setup-stream-webhook.ts` for one-time webhook registration; stores the signing secret via `wrangler secret put CLOUDFLARE_STREAM_WEBHOOK_SECRET`.

Closes #242

## Design notes

- **Account-scoped webhook**: Cloudflare Stream allows only one notification URL per account. Production subscribes; dev deployments do not. Dev uploads don't get MP4 downloads auto-enabled — accepted trade-off documented in `.claude/docs/cloudflare-stream-webhook.md`.
- **Pure helpers in `src/lib/storage/cloudflareStreamWebhook.ts`**: Next.js App Router routes can't export arbitrary helpers (only `GET`, `POST`, etc.), so the verification and handling logic lives in a sibling lib file that the route imports. Tests import from the lib directly — fast, no Payload boot.
- **Web Crypto (`crypto.subtle`) for HMAC-SHA256**: runs identically in Workers, Node 20+, and Vitest.
- **Constant-time signature comparison** and 5-minute freshness window to prevent replays.

## Post-merge setup (production, one-time)

```bash
export CLOUDFLARE_ACCOUNT_ID=<prod>
export CLOUDFLARE_API_KEY=<token-with-stream-edit>

pnpm tsx scripts/setup-stream-webhook.ts \
  --url https://cloud.sydevelopers.com/api/webhooks/cloudflare-stream

wrangler secret put CLOUDFLARE_STREAM_WEBHOOK_SECRET
# paste the signing secret printed above

pnpm run deploy:prod
```

Full setup details in [.claude/docs/cloudflare-stream-webhook.md](.claude/docs/cloudflare-stream-webhook.md).

## Pre-existing failures fixed

- `tests/int/role-based-access.int.spec.ts` — "grants read to project collections for managers with roles" was asserting `lectures` is not readable by a web-translator, but `lectures` was added to wemeditate-web in commit 3ac22bf. Replaced with `app-cards`, which remains wemeditate-app only. Fixed in a separate commit.

## Test Results

- Integration tests: 675 passed, 2 skipped (including 24 new webhook tests)
- E2E tests: not run (no UI changes)
- Build: ✓ Success (`.open-next/worker.js` for Cloudflare Workers)
- Lint: ✓ No warnings
- Pre-existing failures fixed: `role-based-access.int.spec.ts` lectures assertion

## Test plan

- [x] Unit tests cover: signature parsing, HMAC verification (valid/wrong secret/stale/future/missing/malformed/wrong length), ready event, error event, intermediate event, missing secret → 503, missing Cloudflare creds → 503, downstream 500, bad JSON → 400, schema failure → 400
- [ ] Production smoke test: register webhook, upload small test video, tail logs for "MP4 downloads enabled via webhook", verify MP4 URL plays in browser
- [ ] Verify dev deployment still uploads videos successfully (no webhook subscription, no MP4 downloads auto-enabled)

🤖 Generated with [Claude Code](https://claude.com/claude-code)