### PR TITLE
fix(storage): persist sanitized/Cloudflare filenames after upload

### DIFF
--- a/.claude/docs/patterns.md
+++ b/.claude/docs/patterns.md
@@ -493,6 +493,57 @@ export const mixedMediaAdapter = (config: MixedMediaAdapterConfig): Adapter => {
 - Update barrel exports in `index.ts` when renaming
 - Update storagePlugin.ts collection configurations
 
+### handleUpload return-value contract
+
+**Critical**: `@payloadcms/plugin-cloud-storage` v3 calls `adapter.handleUpload` in an **afterChange** hook — *after* the document has already been written to the DB. The plugin persists filename/metadata changes only via the adapter's **return value**, which it merges and passes to `payload.update()`:
+
+```js
+// node_modules/@payloadcms/plugin-cloud-storage/dist/hooks/afterChange.js
+const uploadResults = await Promise.all(files.map(f => adapter.handleUpload({ data: doc, file: f, req })))
+const uploadMetadata = uploadResults.filter(r => r != null).reduce(...) // ← merges returns
+if (Object.keys(uploadMetadata).length > 0) {
+  await req.payload.update({ id: doc.id, collection: slug, data: uploadMetadata, ... })
+}
+```
+
+Implications for new or modified adapters:
+
+- **Return `{ filename, fileMetadata }`** (or whatever changed) from `handleUpload`. Without a return value, nothing persists.
+- **Mutating `data.filename` / `file.filename` is insufficient** for persistence. `data` here is the already-saved `doc`; mutation only affects the in-memory copy seen by downstream afterChange hooks in the same request.
+- **Do keep the mutations anyway** — they keep the in-memory doc consistent with what the follow-up `payload.update()` will write, so subsequent hooks in the chain don't see a stale filename.
+- **Do not write comments that claim mutation "persists to DB via pass-by-reference."** It doesn't. Previous versions of these adapters carried that false comment and a working afterChange hook was removed on the strength of it (see #276 / commit `c6d1b37`).
+
+Example:
+
+```typescript
+handleUpload: async ({ data, file, req }) => {
+  const imageId = await uploadToCloudflare(file)
+
+  // Mirror in-memory so downstream hooks see the new filename
+  file.filename = imageId
+  if (data) data.filename = imageId
+
+  // THIS is what persists to the DB
+  return { filename: imageId, fileMetadata: { originalFilename: file.filename } }
+},
+```
+
+Verify whenever you add a new adapter: grep the plugin source (`node_modules/@payloadcms/plugin-cloud-storage/dist/hooks/afterChange.js`) to confirm the contract hasn't changed in a version bump.
+
+## Debugging library-integration bugs
+
+When a bug's symptoms suggest a third-party plugin/hook/SDK isn't doing what you assumed, **read the compiled library source in `node_modules/`** before theorizing. The actual runtime behavior often differs from README/docs, especially for PayloadCMS plugins, Next.js internals, and Cloudflare SDKs.
+
+Practical approach:
+
+- `ls node_modules/<pkg>/dist/` to find the entry points.
+- Open the relevant hook/handler file directly with `Read`.
+- Grep for method names you're calling (`handleUpload`, `beforeChange`, etc.) to see how the library invokes them and what it does with the return value.
+
+This is often faster than fetching external docs and catches behavior that docs don't describe (e.g., "the plugin only persists via return values, not mutation" — undocumented but unambiguous from three lines of source).
+
+When to prefer external docs instead: researching *new* features or API you haven't used yet, where you need the canonical contract before writing code. For *debugging*, local source wins.
+
 ## Common JavaScript Pitfalls
 
 ### parseInt Parses Partial Strings

--- a/src/lib/storage/cloudflareImagesAdapter.ts
+++ b/src/lib/storage/cloudflareImagesAdapter.ts
@@ -11,7 +11,7 @@ import { z } from 'zod'
 import { serverEnv } from '@/lib/env'
 
 import { CloudflareImagesResponseSchema } from './cloudflareSchemas'
-import { generateCloudflareImageId } from './filenameUtils'
+import { applyFilename, generateCloudflareImageId } from './filenameUtils'
 import { validateFileUpload } from './uploadValidation'
 
 /**
@@ -129,19 +129,7 @@ export const cloudflareImagesAdapter = (config: CloudflareImagesConfig): Adapter
           originalFilename,
         }
 
-        // Mirror the new filename and metadata to in-memory locations so
-        // downstream afterChange hooks see them. The values are persisted
-        // to the DB via this function's return value (see
-        // @payloadcms/plugin-cloud-storage afterChange hook, which merges
-        // the return into a payload.update call).
-        file.filename = imageId
-        if (data) {
-          data.filename = imageId
-          data.fileMetadata = fileMetadata
-        }
-        if (req?.file) {
-          req.file.name = imageId
-        }
+        applyFilename(file, data, req, imageId, fileMetadata)
 
         return { filename: imageId, fileMetadata }
       } catch (error) {

--- a/src/lib/storage/cloudflareImagesAdapter.ts
+++ b/src/lib/storage/cloudflareImagesAdapter.ts
@@ -11,6 +11,7 @@ import { z } from 'zod'
 import { serverEnv } from '@/lib/env'
 
 import { CloudflareImagesResponseSchema } from './cloudflareSchemas'
+import { generateCloudflareImageId } from './filenameUtils'
 import { validateFileUpload } from './uploadValidation'
 
 /**
@@ -67,6 +68,12 @@ export const cloudflareImagesAdapter = (config: CloudflareImagesConfig): Adapter
         // Validate file before upload
         validateFileUpload(file, { category: 'image' })
 
+        // Use a human-readable slug as the Cloudflare Image ID so the delivery
+        // URL (.../<id>/public) is debuggable. CF rejects duplicate IDs; the
+        // random suffix baked into the slug makes collisions negligible.
+        const customId = generateCloudflareImageId(file.filename)
+        const originalFilename = file.filename
+
         const formData = new FormData()
         // Convert Buffer to Uint8Array for Cloudflare Workers compatibility
         // IMPORTANT: The Workers Buffer polyfill has multiple broken methods.
@@ -77,11 +84,13 @@ export const cloudflareImagesAdapter = (config: CloudflareImagesConfig): Adapter
           uint8Array[i] = file.buffer[i]
         }
         const blob = new Blob([uint8Array], { type: file.mimeType })
-        formData.append('file', blob, file.filename)
+        formData.append('file', blob, originalFilename)
+        formData.append('id', customId)
 
         req.payload.logger.info({
           msg: 'Uploading image to Cloudflare Images',
-          filename: file.filename,
+          filename: originalFilename,
+          customId,
         })
 
         const response = await fetch(
@@ -102,6 +111,8 @@ export const cloudflareImagesAdapter = (config: CloudflareImagesConfig): Adapter
           throw new Error(`Cloudflare Images upload failed: ${errors}`)
         }
 
+        // CF echoes back the ID we sent — trust the response rather than our
+        // local customId so any server-side normalization is reflected.
         const imageId = result.result?.id
         if (!imageId) {
           throw new Error('Cloudflare Images response missing image ID')
@@ -109,30 +120,30 @@ export const cloudflareImagesAdapter = (config: CloudflareImagesConfig): Adapter
 
         req.payload.logger.info({ msg: 'Image uploaded successfully', imageId })
 
-        // Preserve original filename in fileMetadata for seed script deduplication
-        // The original filename (e.g., "f47ac10b58cc4372.jpg") is used for matching
-        // since the stored filename will be the Cloudflare Image ID
-        if (data) {
-          data.fileMetadata = {
-            ...(typeof data.fileMetadata === 'object' && data.fileMetadata !== null
-              ? data.fileMetadata
-              : {}),
-            originalFilename: file.filename,
-          }
+        const existingMetadata =
+          typeof data?.fileMetadata === 'object' && data.fileMetadata !== null
+            ? (data.fileMetadata as Record<string, unknown>)
+            : {}
+        const fileMetadata = {
+          ...existingMetadata,
+          originalFilename,
         }
 
-        // Update filename in all locations to ensure PayloadCMS stores the Cloudflare Image ID
-        // - data.filename: The object that will be saved to the database (passed by reference)
-        // - file.filename: The file object used by the storage plugin
-        // - req.file.name: The original request file (for consistency)
-        // This eliminates the need for afterChange hooks to sync the filename
+        // Mirror the new filename and metadata to in-memory locations so
+        // downstream afterChange hooks see them. The values are persisted
+        // to the DB via this function's return value (see
+        // @payloadcms/plugin-cloud-storage afterChange hook, which merges
+        // the return into a payload.update call).
         file.filename = imageId
         if (data) {
           data.filename = imageId
+          data.fileMetadata = fileMetadata
         }
         if (req?.file) {
           req.file.name = imageId
         }
+
+        return { filename: imageId, fileMetadata }
       } catch (error) {
         // Handle Zod validation errors with detailed messages
         if (error instanceof z.ZodError) {

--- a/src/lib/storage/cloudflareStreamAdapter.ts
+++ b/src/lib/storage/cloudflareStreamAdapter.ts
@@ -134,30 +134,31 @@ export const cloudflareStreamAdapter = (config: CloudflareStreamConfig): Adapter
         // once the video finishes transcoding. See src/app/(payload)/api/webhooks/cloudflare-stream/
         // and .claude/docs/cloudflare-stream-webhook.md.
 
-        // Preserve original filename in fileMetadata for seed script deduplication
-        // The original filename (e.g., "f47ac10b58cc4372.mp4") is used for matching
-        // since the stored filename will be the Cloudflare Stream video ID
-        if (data) {
-          const existingMetadata =
-            typeof data.fileMetadata === 'object' && data.fileMetadata !== null ? data.fileMetadata : {}
-          data.fileMetadata = {
-            ...existingMetadata,
-            originalFilename: file.filename,
-          }
+        const originalFilename = file.filename
+        const existingMetadata =
+          typeof data?.fileMetadata === 'object' && data.fileMetadata !== null
+            ? (data.fileMetadata as Record<string, unknown>)
+            : {}
+        const fileMetadata = {
+          ...existingMetadata,
+          originalFilename,
         }
 
-        // Update filename in all locations to ensure PayloadCMS stores the Cloudflare Stream video ID
-        // - data.filename: The object that will be saved to the database (passed by reference)
-        // - file.filename: The file object used by the storage plugin
-        // - req.file.name: The original request file (for consistency)
-        // This eliminates the need for afterChange hooks to sync the filename
+        // Mirror the new filename and metadata to in-memory locations so
+        // downstream afterChange hooks see them. The values are persisted
+        // to the DB via this function's return value (see
+        // @payloadcms/plugin-cloud-storage afterChange hook, which merges
+        // the return into a payload.update call).
         file.filename = videoId
         if (data) {
           data.filename = videoId
+          data.fileMetadata = fileMetadata
         }
         if (req?.file) {
           req.file.name = videoId
         }
+
+        return { filename: videoId, fileMetadata }
       } catch (error) {
         // Handle Zod validation errors with detailed messages
         if (error instanceof z.ZodError) {

--- a/src/lib/storage/cloudflareStreamAdapter.ts
+++ b/src/lib/storage/cloudflareStreamAdapter.ts
@@ -12,6 +12,7 @@ import { z } from 'zod'
 import { serverEnv } from '@/lib/env'
 
 import { CloudflareStreamResponseSchema } from './cloudflareSchemas'
+import { applyFilename } from './filenameUtils'
 import { validateFileUpload } from './uploadValidation'
 
 /**
@@ -144,19 +145,7 @@ export const cloudflareStreamAdapter = (config: CloudflareStreamConfig): Adapter
           originalFilename,
         }
 
-        // Mirror the new filename and metadata to in-memory locations so
-        // downstream afterChange hooks see them. The values are persisted
-        // to the DB via this function's return value (see
-        // @payloadcms/plugin-cloud-storage afterChange hook, which merges
-        // the return into a payload.update call).
-        file.filename = videoId
-        if (data) {
-          data.filename = videoId
-          data.fileMetadata = fileMetadata
-        }
-        if (req?.file) {
-          req.file.name = videoId
-        }
+        applyFilename(file, data, req, videoId, fileMetadata)
 
         return { filename: videoId, fileMetadata }
       } catch (error) {

--- a/src/lib/storage/filenameUtils.ts
+++ b/src/lib/storage/filenameUtils.ts
@@ -9,8 +9,15 @@ import slugify from 'slugify'
 const RANDOM_SUFFIX_LENGTH = 6
 
 const buildSlug = (baseName: string): string => {
-  const slugified = slugify(baseName, { strict: true, lower: true })
-  const randomSuffix = Math.random()
+  // Fall back to "file" when slugify strips the entire base name (e.g.
+  // all-Unicode input like "文件名"). Without this, the slug would start
+  // with a hyphen, which Cloudflare Images may reject as a custom ID.
+  const slugified = slugify(baseName, { strict: true, lower: true }) || 'file'
+  // (Math.random() + 1) forces the integer part to 1, guaranteeing
+  // toString(36) yields a long enough base36 expansion for the slice
+  // below. Plain Math.random() can return values like 0.5 whose base36
+  // form ("0.i") yields fewer than RANDOM_SUFFIX_LENGTH chars.
+  const randomSuffix = (Math.random() + 1)
     .toString(36)
     .substring(2, 2 + RANDOM_SUFFIX_LENGTH)
   return `${slugified}-${randomSuffix}`
@@ -45,4 +52,32 @@ export const generateR2Key = (filename: string): string => {
 export const generateCloudflareImageId = (filename: string): string => {
   const { baseName } = splitExtension(filename)
   return buildSlug(baseName)
+}
+
+/**
+ * Mirror a newly-assigned filename (and optional fileMetadata) onto the
+ * in-memory `file`, `data`, and `req.file` objects.
+ *
+ * The persisted DB write happens via the storage adapter's return value
+ * (see @payloadcms/plugin-cloud-storage afterChange hook). This helper
+ * keeps the in-memory state consistent for downstream hooks that fire in
+ * the same operation (beforeChange / afterRead / afterChange).
+ */
+export const applyFilename = (
+  file: { filename: string },
+  data: Record<string, unknown> | null | undefined,
+  req: { file?: { name?: string } | null } | undefined,
+  filename: string,
+  fileMetadata?: Record<string, unknown>,
+): void => {
+  file.filename = filename
+  if (data) {
+    data.filename = filename
+    if (fileMetadata !== undefined) {
+      data.fileMetadata = fileMetadata
+    }
+  }
+  if (req?.file) {
+    req.file.name = filename
+  }
 }

--- a/src/lib/storage/filenameUtils.ts
+++ b/src/lib/storage/filenameUtils.ts
@@ -1,0 +1,48 @@
+/**
+ * Filename utilities for storage adapters.
+ *
+ * Generates URL-safe slugs from uploaded filenames, with a short random
+ * suffix to avoid collisions in the underlying storage backend.
+ */
+import slugify from 'slugify'
+
+const RANDOM_SUFFIX_LENGTH = 6
+
+const buildSlug = (baseName: string): string => {
+  const slugified = slugify(baseName, { strict: true, lower: true })
+  const randomSuffix = Math.random()
+    .toString(36)
+    .substring(2, 2 + RANDOM_SUFFIX_LENGTH)
+  return `${slugified}-${randomSuffix}`
+}
+
+const splitExtension = (filename: string): { baseName: string; ext: string } => {
+  const parts = filename.split('.')
+  if (parts.length <= 1) return { baseName: filename, ext: '' }
+  const ext = parts.pop() as string
+  return { baseName: parts.join('.'), ext }
+}
+
+/**
+ * Generate an R2 object key from an uploaded filename.
+ *
+ * Format: `<slug>-<random>.<ext>`
+ * Example: `"My Audio File.mp3"` → `"my-audio-file-xk2j9s.mp3"`
+ */
+export const generateR2Key = (filename: string): string => {
+  const { baseName, ext } = splitExtension(filename)
+  const slug = buildSlug(baseName)
+  return ext ? `${slug}.${ext}` : slug
+}
+
+/**
+ * Generate a Cloudflare-Images-compatible custom ID from an uploaded filename.
+ *
+ * Format: `<slug>-<random>` (no extension — the ID appears verbatim in the
+ * `imagedelivery.net` URL, which shouldn't carry a file extension).
+ * Example: `"My Photo.jpg"` → `"my-photo-xk2j9s"`
+ */
+export const generateCloudflareImageId = (filename: string): string => {
+  const { baseName } = splitExtension(filename)
+  return buildSlug(baseName)
+}

--- a/src/lib/storage/index.ts
+++ b/src/lib/storage/index.ts
@@ -12,8 +12,11 @@ export { storagePlugin as default } from './storagePlugin'
 // Storage adapters
 export { cloudflareImagesAdapter, getCloudflareImagesUrl } from './cloudflareImagesAdapter'
 export { cloudflareStreamAdapter, getCloudflareStreamMp4Url, getCloudflareStreamThumbnailUrl } from './cloudflareStreamAdapter'
-export { r2NativeAdapter, getR2Url, sanitizeFilename } from './r2NativeAdapter'
+export { r2NativeAdapter, getR2Url } from './r2NativeAdapter'
 export { mixedMediaAdapter } from './mixedMediaAdapter'
+
+// Filename utilities
+export { generateR2Key, generateCloudflareImageId } from './filenameUtils'
 
 // MIME type utilities
 export { getMimeCategory } from './mimeUtils'

--- a/src/lib/storage/r2NativeAdapter.ts
+++ b/src/lib/storage/r2NativeAdapter.ts
@@ -8,9 +8,9 @@
  */
 import type { Adapter } from '@payloadcms/plugin-cloud-storage/types'
 
-import slugify from 'slugify'
-
 import { serverEnv } from '@/lib/env'
+
+import { generateR2Key } from './filenameUtils'
 
 /**
  * Get R2 storage URL for a filename
@@ -30,30 +30,6 @@ export interface R2NativeConfig {
   bucket: R2Bucket
   /** Public URL for accessing R2 assets (e.g., "https://assets.sydevelopers.com") */
   publicUrl: string
-}
-
-/**
- * Sanitize filename for safe storage
- *
- * Converts filename to URL-safe slug and adds random suffix to prevent collisions.
- * Exported for testing purposes.
- *
- * @param filename - Original filename
- * @returns Sanitized filename
- *
- * @example
- * Input: "My Photo (1).mp3"
- * Output: "my-photo-1-xk2j9s.mp3"
- */
-export const sanitizeFilename = (filename: string): string => {
-  const parts = filename.split('.')
-  const ext = parts.length > 1 ? parts.pop() : ''
-  const baseName = parts.join('.')
-
-  const slugified = slugify(baseName, { strict: true, lower: true })
-  const randomSuffix = (Math.random() + 1).toString(36).substring(2)
-
-  return ext ? `${slugified}-${randomSuffix}.${ext}` : `${slugified}-${randomSuffix}`
 }
 
 /**
@@ -83,13 +59,12 @@ export const r2NativeAdapter = (config: R2NativeConfig): Adapter => {
 
     handleUpload: async ({ data, file, req }) => {
       try {
-        // Sanitize the filename to URL-safe slug with random suffix
-        const finalFilename = sanitizeFilename(file.filename)
+        const finalFilename = generateR2Key(file.filename)
 
-        // Update filename in all locations
-        // - data.filename: The object that will be saved to the database (passed by reference)
-        // - file.filename: The file object used by the storage plugin
-        // - req.file.name: The original request file (for consistency)
+        // Mirror the new filename to in-memory locations so downstream
+        // afterChange hooks see it. The value is persisted to the DB via this
+        // function's return value (see @payloadcms/plugin-cloud-storage
+        // afterChange hook, which merges the return into a payload.update call).
         file.filename = finalFilename
         if (data) {
           data.filename = finalFilename
@@ -113,6 +88,8 @@ export const r2NativeAdapter = (config: R2NativeConfig): Adapter => {
             contentType: file.mimeType,
           },
         })
+
+        return { filename: finalFilename }
       } catch (error) {
         const key = prefix ? `${prefix}/${file.filename}` : file.filename
         // eslint-disable-next-line no-console

--- a/src/lib/storage/r2NativeAdapter.ts
+++ b/src/lib/storage/r2NativeAdapter.ts
@@ -10,7 +10,7 @@ import type { Adapter } from '@payloadcms/plugin-cloud-storage/types'
 
 import { serverEnv } from '@/lib/env'
 
-import { generateR2Key } from './filenameUtils'
+import { applyFilename, generateR2Key } from './filenameUtils'
 
 /**
  * Get R2 storage URL for a filename
@@ -61,17 +61,7 @@ export const r2NativeAdapter = (config: R2NativeConfig): Adapter => {
       try {
         const finalFilename = generateR2Key(file.filename)
 
-        // Mirror the new filename to in-memory locations so downstream
-        // afterChange hooks see it. The value is persisted to the DB via this
-        // function's return value (see @payloadcms/plugin-cloud-storage
-        // afterChange hook, which merges the return into a payload.update call).
-        file.filename = finalFilename
-        if (data) {
-          data.filename = finalFilename
-        }
-        if (req?.file) {
-          req.file.name = finalFilename
-        }
+        applyFilename(file, data, req, finalFilename)
 
         const key = prefix ? `${prefix}/${finalFilename}` : finalFilename
 

--- a/tests/int/storage-utils.int.spec.ts
+++ b/tests/int/storage-utils.int.spec.ts
@@ -523,6 +523,14 @@ describe('Filename Utilities', () => {
       const result = generateCloudflareImageId('weird/name:with spaces?.png')
       expect(result).toMatch(/^[a-z0-9-]+$/)
     })
+
+    it('does not start with a hyphen for all-Unicode filenames', () => {
+      // slugify(strict) drops all non-ASCII; the helper falls back to "file"
+      // so the resulting ID never begins with a hyphen (CF Images rejects those).
+      const result = generateCloudflareImageId('文件名.jpg')
+      expect(result).toMatch(/^file-[a-z0-9]{6}$/)
+      expect(result.startsWith('-')).toBe(false)
+    })
   })
 })
 
@@ -740,6 +748,51 @@ describe('Storage Adapter handleUpload', () => {
       const [key] = put.mock.calls[0]
       expect(key).toBe(`meditations/${(result as { filename: string }).filename}`)
       expect(data.filename).toBe((result as { filename: string }).filename)
+    })
+  })
+
+  describe('mixedMediaAdapter.handleUpload', () => {
+    it('forwards the inner adapter return value (filename + fileMetadata)', async () => {
+      const { mixedMediaAdapter } = await import('@/lib/storage/mixedMediaAdapter')
+
+      // Inner adapter mock that returns a known payload — proves the mixed
+      // adapter doesn't accidentally swallow the return.
+      const innerReturn = {
+        filename: 'inner-image-id-abc123',
+        fileMetadata: { originalFilename: 'photo.jpg' },
+      }
+      const innerHandleUpload = vi.fn().mockResolvedValue(innerReturn)
+      const innerAdapter = vi.fn().mockReturnValue({
+        name: 'inner-images',
+        handleUpload: innerHandleUpload,
+        handleDelete: vi.fn(),
+        staticHandler: vi.fn(),
+      })
+
+      const r2Adapter = vi.fn().mockReturnValue({
+        name: 'r2',
+        handleUpload: vi.fn(),
+        handleDelete: vi.fn(),
+        staticHandler: vi.fn(),
+      })
+
+      const adapter = mixedMediaAdapter({
+        routes: { 'image/': innerAdapter as never },
+        r2Adapter: r2Adapter as never,
+      })({ collection: { slug: 'files' } as never, prefix: undefined })
+
+      const args = {
+        data: {},
+        file: makeImageFile() as never,
+        req: makeReq() as never,
+        clientUploadContext: undefined,
+        collection: { slug: 'files' } as never,
+      }
+
+      const result = await adapter.handleUpload(args)
+
+      expect(innerHandleUpload).toHaveBeenCalledOnce()
+      expect(result).toEqual(innerReturn)
     })
   })
 })

--- a/tests/int/storage-utils.int.spec.ts
+++ b/tests/int/storage-utils.int.spec.ts
@@ -11,8 +11,8 @@ import type { Field, FieldHook } from 'payload'
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 
+import { generateCloudflareImageId, generateR2Key } from '@/lib/storage/filenameUtils'
 import { getMimeCategory } from '@/lib/storage/mimeUtils'
-import { sanitizeFilename } from '@/lib/storage/r2NativeAdapter'
 
 // Helper to extract the afterRead hook from a field
 const getAfterReadHook = (field: Field): FieldHook | undefined => {
@@ -453,48 +453,293 @@ describe('MIME Utilities', () => {
   })
 })
 
-describe('R2 Native Adapter', () => {
-  describe('sanitizeFilename', () => {
-    it('converts filename to URL-safe slug', () => {
-      const result = sanitizeFilename('My Audio File.mp3')
-      expect(result).toMatch(/^my-audio-file-[a-z0-9]{8,11}\.mp3$/)
+describe('Filename Utilities', () => {
+  describe('generateR2Key', () => {
+    it('converts filename to URL-safe slug with extension', () => {
+      const result = generateR2Key('My Audio File.mp3')
+      expect(result).toMatch(/^my-audio-file-[a-z0-9]{6}\.mp3$/)
     })
 
     it('removes special characters', () => {
-      const result = sanitizeFilename('File (1) [test].mp3')
-      expect(result).toMatch(/^file-1-test-[a-z0-9]{8,11}\.mp3$/)
+      const result = generateR2Key('File (1) [test].mp3')
+      expect(result).toMatch(/^file-1-test-[a-z0-9]{6}\.mp3$/)
     })
 
-    it('preserves file extension', () => {
-      const result = sanitizeFilename('test.tar.gz')
-      // Multi-dot filename: dots are removed (not converted to hyphens)
-      expect(result).toMatch(/^testtar-[a-z0-9]{8,11}\.gz$/)
+    it('preserves only the final file extension', () => {
+      const result = generateR2Key('test.tar.gz')
+      // Multi-dot filename: dots in base are removed (not converted to hyphens)
+      expect(result).toMatch(/^testtar-[a-z0-9]{6}\.gz$/)
     })
 
     it('handles files without extension', () => {
-      const result = sanitizeFilename('README')
-      expect(result).toMatch(/^readme-[a-z0-9]{8,11}$/)
+      const result = generateR2Key('README')
+      expect(result).toMatch(/^readme-[a-z0-9]{6}$/)
     })
 
-    it('adds unique random suffix', () => {
-      const result1 = sanitizeFilename('test.mp3')
-      const result2 = sanitizeFilename('test.mp3')
-
+    it('adds a unique random suffix each call', () => {
+      const result1 = generateR2Key('test.mp3')
+      const result2 = generateR2Key('test.mp3')
       expect(result1).not.toBe(result2)
-      expect(result1).toMatch(/^test-[a-z0-9]{8,11}\.mp3$/)
-      expect(result2).toMatch(/^test-[a-z0-9]{8,11}\.mp3$/)
+      expect(result1).toMatch(/^test-[a-z0-9]{6}\.mp3$/)
+      expect(result2).toMatch(/^test-[a-z0-9]{6}\.mp3$/)
     })
 
     it('handles Unicode characters', () => {
-      const result = sanitizeFilename('文件名.mp3')
-      // Slugify converts non-ASCII to empty, then adds suffix
+      const result = generateR2Key('文件名.mp3')
       expect(result).toMatch(/^[a-z0-9-]+\.mp3$/)
     })
 
     it('handles multiple dots in filename', () => {
-      const result = sanitizeFilename('my.file.name.mp3')
-      // Multi-dot filename: dots are removed (not converted to hyphens)
-      expect(result).toMatch(/^myfilename-[a-z0-9]{8,11}\.mp3$/)
+      const result = generateR2Key('my.file.name.mp3')
+      expect(result).toMatch(/^myfilename-[a-z0-9]{6}\.mp3$/)
+    })
+  })
+
+  describe('generateCloudflareImageId', () => {
+    it('produces a slug with no extension', () => {
+      const result = generateCloudflareImageId('My Photo.jpg')
+      expect(result).toMatch(/^my-photo-[a-z0-9]{6}$/)
+      expect(result).not.toContain('.')
+    })
+
+    it('handles filenames without extensions', () => {
+      const result = generateCloudflareImageId('README')
+      expect(result).toMatch(/^readme-[a-z0-9]{6}$/)
+    })
+
+    it('handles filenames with multiple dots', () => {
+      const result = generateCloudflareImageId('my.lecture.thumbnail.jpg')
+      // Final ".jpg" is dropped; dots in base are stripped by slugify
+      expect(result).toMatch(/^mylecturethumbnail-[a-z0-9]{6}$/)
+    })
+
+    it('adds a unique random suffix each call', () => {
+      const a = generateCloudflareImageId('photo.jpg')
+      const b = generateCloudflareImageId('photo.jpg')
+      expect(a).not.toBe(b)
+    })
+
+    it('strips characters CF Image IDs cannot contain', () => {
+      const result = generateCloudflareImageId('weird/name:with spaces?.png')
+      expect(result).toMatch(/^[a-z0-9-]+$/)
+    })
+  })
+})
+
+describe('Storage Adapter handleUpload', () => {
+  const originalEnv = process.env
+  const originalFetch = globalThis.fetch
+
+  beforeEach(() => {
+    vi.resetModules()
+    process.env = {
+      ...originalEnv,
+      PAYLOAD_SECRET: 'test-secret-key-with-32-chars-minimum',
+      CLOUDFLARE_IMAGES_DELIVERY_URL: 'https://imagedelivery.net/test-hash',
+      CLOUDFLARE_STREAM_DELIVERY_URL: 'https://customer-test.cloudflarestream.com',
+      CLOUDFLARE_R2_DELIVERY_URL: 'https://assets.test',
+    }
+  })
+
+  afterEach(() => {
+    process.env = originalEnv
+    globalThis.fetch = originalFetch
+    vi.restoreAllMocks()
+  })
+
+  // Build a minimal req object with logger stubs
+  const makeReq = () => ({
+    payload: {
+      logger: {
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+      },
+    },
+    file: { name: 'original-input.jpg' },
+  })
+
+  const makeImageFile = (filename = 'lecture-thumbnail-167289004.jpg') => ({
+    filename,
+    buffer: Buffer.from([0x89, 0x50, 0x4e, 0x47]),
+    mimeType: 'image/jpeg',
+    filesize: 4,
+  })
+
+  const makeVideoFile = (filename = 'my-video.mp4') => ({
+    filename,
+    buffer: Buffer.from([0x00, 0x00, 0x00, 0x20]),
+    mimeType: 'video/mp4',
+    filesize: 4,
+  })
+
+  describe('cloudflareImagesAdapter.handleUpload', () => {
+    it('sends a custom id and returns filename + fileMetadata from the response', async () => {
+      const { cloudflareImagesAdapter } = await import('@/lib/storage/cloudflareImagesAdapter')
+      let sentFormData: FormData | undefined
+
+      const fetchMock = vi.fn(async (_url, init) => {
+        sentFormData = init?.body as FormData
+        const sentId = sentFormData.get('id') as string
+        return new Response(
+          JSON.stringify({
+            success: true,
+            errors: [],
+            result: { id: sentId, filename: 'lecture-thumbnail-167289004.jpg' },
+          }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } },
+        )
+      })
+      vi.stubGlobal('fetch', fetchMock)
+
+      const adapter = cloudflareImagesAdapter({
+        accountId: 'test-account',
+        apiKey: 'test-key',
+        deliveryUrl: 'https://imagedelivery.net/test-hash',
+      })({ collection: { slug: 'images' } as never, prefix: undefined })
+
+      const data: Record<string, unknown> = {}
+      const file = makeImageFile()
+      const req = makeReq()
+
+      const result = await adapter.handleUpload({
+        data,
+        file: file as never,
+        req: req as never,
+        clientUploadContext: undefined,
+        collection: { slug: 'images' } as never,
+      })
+
+      expect(fetchMock).toHaveBeenCalledOnce()
+      expect(sentFormData).toBeDefined()
+      const sentId = sentFormData!.get('id')
+      expect(sentId).toMatch(/^lecture-thumbnail-167289004-[a-z0-9]{6}$/)
+
+      expect(result).toEqual({
+        filename: sentId,
+        fileMetadata: { originalFilename: 'lecture-thumbnail-167289004.jpg' },
+      })
+
+      // In-memory mirror — downstream afterChange hooks see the new filename
+      expect(data.filename).toBe(sentId)
+      expect(data.fileMetadata).toEqual({ originalFilename: 'lecture-thumbnail-167289004.jpg' })
+      expect(file.filename).toBe(sentId)
+    })
+
+    it('throws when Cloudflare returns success:false', async () => {
+      const { cloudflareImagesAdapter } = await import('@/lib/storage/cloudflareImagesAdapter')
+      vi.stubGlobal(
+        'fetch',
+        vi.fn(
+          async () =>
+            new Response(
+              JSON.stringify({
+                success: false,
+                errors: [{ code: 5400, message: 'Duplicate ID' }],
+              }),
+              { status: 409, headers: { 'Content-Type': 'application/json' } },
+            ),
+        ),
+      )
+
+      const adapter = cloudflareImagesAdapter({
+        accountId: 'test-account',
+        apiKey: 'test-key',
+        deliveryUrl: 'https://imagedelivery.net/test-hash',
+      })({ collection: { slug: 'images' } as never, prefix: undefined })
+
+      await expect(
+        adapter.handleUpload({
+          data: {},
+          file: makeImageFile() as never,
+          req: makeReq() as never,
+          clientUploadContext: undefined,
+          collection: { slug: 'images' } as never,
+        }),
+      ).rejects.toThrow(/Duplicate ID/)
+    })
+  })
+
+  describe('cloudflareStreamAdapter.handleUpload', () => {
+    it('returns the CF-generated videoId as filename and does not send a custom id', async () => {
+      const { cloudflareStreamAdapter } = await import('@/lib/storage/cloudflareStreamAdapter')
+      let sentFormData: FormData | undefined
+
+      const fetchMock = vi.fn(async (_url, init) => {
+        sentFormData = init?.body as FormData
+        return new Response(
+          JSON.stringify({
+            success: true,
+            errors: [],
+            result: { uid: 'cf-video-uid-abc123' },
+          }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } },
+        )
+      })
+      vi.stubGlobal('fetch', fetchMock)
+
+      const adapter = cloudflareStreamAdapter({
+        accountId: 'test-account',
+        apiKey: 'test-key',
+        deliveryUrl: 'https://customer-test.cloudflarestream.com',
+      })({ collection: { slug: 'frames' } as never, prefix: undefined })
+
+      const data: Record<string, unknown> = {}
+      const file = makeVideoFile()
+
+      const result = await adapter.handleUpload({
+        data,
+        file: file as never,
+        req: makeReq() as never,
+        clientUploadContext: undefined,
+        collection: { slug: 'frames' } as never,
+      })
+
+      // Stream API doesn't accept custom IDs — make sure we didn't send one
+      expect(sentFormData!.has('id')).toBe(false)
+
+      expect(result).toEqual({
+        filename: 'cf-video-uid-abc123',
+        fileMetadata: { originalFilename: 'my-video.mp4' },
+      })
+      expect(data.filename).toBe('cf-video-uid-abc123')
+      expect(file.filename).toBe('cf-video-uid-abc123')
+    })
+  })
+
+  describe('r2NativeAdapter.handleUpload', () => {
+    it('writes a sanitized R2 key and returns it as the filename', async () => {
+      const { r2NativeAdapter } = await import('@/lib/storage/r2NativeAdapter')
+
+      const put = vi.fn().mockResolvedValue(null)
+      const bucket = { put } as unknown as R2Bucket
+
+      const adapter = r2NativeAdapter({
+        bucket,
+        publicUrl: 'https://assets.test',
+      })({ collection: { slug: 'meditations' } as never, prefix: 'meditations' })
+
+      const data: Record<string, unknown> = {}
+      const file = {
+        filename: 'My Audio (1).mp3',
+        buffer: Buffer.from([0x00, 0x01]),
+        mimeType: 'audio/mpeg',
+        filesize: 2,
+      }
+
+      const result = await adapter.handleUpload({
+        data,
+        file: file as never,
+        req: makeReq() as never,
+        clientUploadContext: undefined,
+        collection: { slug: 'meditations' } as never,
+      })
+
+      expect(result).toMatchObject({ filename: expect.stringMatching(/^my-audio-1-[a-z0-9]{6}\.mp3$/) })
+      expect(put).toHaveBeenCalledOnce()
+      const [key] = put.mock.calls[0]
+      expect(key).toBe(`meditations/${(result as { filename: string }).filename}`)
+      expect(data.filename).toBe((result as { filename: string }).filename)
     })
   })
 })


### PR DESCRIPTION
Closes #276

## Summary

- Storage adapter `handleUpload` methods mutated `data.filename` but never returned it. The `@payloadcms/plugin-cloud-storage` afterChange hook only persists filename changes via the adapter return value — it calls `payload.update()` with the merged result — so our mutations were silently dropped and the DB kept the original (PayloadCMS-collision-suffixed) upload filename. That made `imagedelivery.net/<hash>/<originalFilename>/public` 404 and left R2 keys unsanitized.
- Return `{ filename, fileMetadata }` from all three adapters (Cloudflare Images, Cloudflare Stream, R2) so the new filename is actually persisted.
- Upgrade Cloudflare Images to **human-readable slug IDs**: we now send a custom `id` form field (slug + 6-char random suffix) so delivery URLs look like `.../lecture-thumbnail-abc123/public`. Cloudflare Stream doesn't support custom IDs — videos keep the CF-generated uid.
- Extract sanitization helpers to a new `src/lib/storage/filenameUtils.ts` module with clearer names: `generateR2Key` (with extension) and `generateCloudflareImageId` (no extension — IDs appear verbatim in delivery URLs). The old `sanitizeFilename` export is retired.

## Why this regressed

Commit `c6d1b37` (#123, 2025-12-17) replaced a working afterChange-based filename-normalization hook with in-place mutation of `data.filename`, assuming that mutation would reach the DB. It doesn't: the plugin's afterChange hook runs `handleUpload` *after* the initial DB write and persists changes only via the adapter's return value. All three cloud storage adapters have been affected since that commit.

## Out of scope

Existing image records in production already have the wrong filenames (original uploaded name instead of Cloudflare Image ID). There's no automatic mapping back to the Cloudflare-side UUID, so those records need to be fixed separately (re-upload or manual CF Images API reconciliation). This PR prevents the problem for new uploads.

## Test plan

- [x] New handleUpload tests cover all three adapters (pure-function, `fetch` / `R2Bucket.put` mocked)
- [x] New tests for `generateR2Key` and `generateCloudflareImageId`
- [x] Full integration suite runs green
- [x] Post-deploy smoke: upload an image via admin UI, verify DB `filename` is a slug like `myfile-abc123` and the delivery URL 200s

## Test Results

- Integration tests: 771 passed, 2 skipped (both pre-existing: `lessons.int.spec.ts` draft versions, `app-cards.int.spec.ts` JSON schema `additionalProperties`)
- Build: ✓ Success
- Lint: ✓ No errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)