### PR TITLE
fix(richtext): populate nested relationships inside lexical blocks

### DIFF
--- a/src/lib/richEditor.ts
+++ b/src/lib/richEditor.ts
@@ -39,7 +39,6 @@ export const fullRichTextEditor = (blocks?: Block[]) =>
       HeadingFeature({ enabledHeadingSizes: ['h2', 'h3'] }),
       RelationshipFeature({
         enabledCollections: ['pages', 'forms', 'lectures', 'albums', 'app-cards'],
-        maxDepth: 1,
       }),
       UploadFeature({
         collections: {

--- a/tests/int/pages.int.spec.ts
+++ b/tests/int/pages.int.spec.ts
@@ -148,4 +148,65 @@ describe('Pages Collection', () => {
       expect(fields.caption).toBeUndefined()
     })
   })
+
+  describe('Lexical Relationship Population Depth', () => {
+    it('populates nested relationships on app-card referenced via lexical relationship node', async () => {
+      // Create an image and app-card (with image reference) to embed via relationship
+      const image = await testData.createMediaImage(payload, { alt: 'App card cover' })
+      const appCard = await testData.createAppCard(payload, {
+        title: 'Embedded App Card',
+        image: image.id,
+      })
+
+      // Build a page with a Lexical relationship node pointing at the app-card
+      const content = {
+        root: {
+          type: 'root',
+          children: [
+            {
+              type: 'relationship',
+              version: 2,
+              format: '',
+              relationTo: 'app-cards',
+              value: appCard.id,
+            },
+          ],
+          direction: null,
+          format: '',
+          indent: 0,
+          version: 1,
+        },
+      } as unknown as Parameters<typeof testData.createPage>[1]['content']
+
+      const page = await testData.createPage(payload, {
+        title: 'Page with App Card Relationship',
+        content,
+      })
+
+      // Query with depth high enough to populate the app-card AND its image field
+      const fetched = await payload.findByID({
+        collection: 'pages',
+        id: page.id,
+        depth: 2,
+      })
+
+      const root = fetched.content?.root as { children: Array<Record<string, unknown>> }
+      const relationshipNode = root.children[0]
+      expect(relationshipNode.type).toBe('relationship')
+      expect(relationshipNode.relationTo).toBe('app-cards')
+
+      // The app-card document itself should be populated
+      const populatedCard = relationshipNode.value as Record<string, unknown>
+      expect(typeof populatedCard).toBe('object')
+      expect(populatedCard.id).toBe(appCard.id)
+      expect(populatedCard.title).toBe('Embedded App Card')
+
+      // The app-card's own `image` relationship should ALSO be populated (not just an ID).
+      // This verifies RelationshipFeature is not capping depth below the caller's request.
+      const populatedImage = populatedCard.image as Record<string, unknown> | number
+      expect(typeof populatedImage).toBe('object')
+      expect((populatedImage as Record<string, unknown>).id).toBe(image.id)
+      expect((populatedImage as Record<string, unknown>).alt).toBe('App card cover')
+    })
+  })
 })


### PR DESCRIPTION
## Summary

- Removed `maxDepth: 1` from the Lexical `RelationshipFeature` so queries honor the caller's requested `depth` when populating documents embedded via relationship nodes.
- App cards (and other relationship-embedded docs) now return fully populated sub-relationships such as `image` — not just their IDs — when a page is queried with `depth >= 2`.

## Root Cause

`RelationshipFeature` was configured with `maxDepth: 1` in [src/lib/richEditor.ts](src/lib/richEditor.ts). Under the hood the plugin computes `populateDepth = min(callerDepth, maxDepth)`, so every relationship inside Lexical content was capped to a single level regardless of the query. At depth 1, Payload populates the referenced document itself but its own sub-relationships stay as IDs — which is exactly what issue #277 reported for app-card's `image`.

## Test Results
- Unit/Integration tests: 774 passed, 2 skipped (pre-existing)
- Build: ✓ Success

Added a regression test in [tests/int/pages.int.spec.ts](tests/int/pages.int.spec.ts) that embeds an app-card via a Lexical relationship node and asserts both the card and its `image` are populated at `depth: 2`. Confirmed the test fails against the pre-fix `maxDepth: 1` configuration.

Closes #277

🤖 Generated with [Claude Code](https://claude.com/claude-code)