### PR TITLE
fix(e2e): reset SQLite DB at setup to avoid drizzle push prompt hang

### DIFF
--- a/.claude/docs/testing.md
+++ b/.claude/docs/testing.md
@@ -87,21 +87,21 @@ pnpm exec playwright test tests/e2e/clients.e2e.spec.ts
 # Run with UI mode for debugging
 pnpm exec playwright test --ui
 
-# Clean E2E database before run
+# Also remove E2E database after the run completes
 CLEAN_E2E_DB=true pnpm test:e2e
 ```
 
 ### Environment Variables
 
 - `E2E_TEST=true` - Enables E2E test mode (uses file-based SQLite instead of D1)
-- `CLEAN_E2E_DB=true` - Removes E2E database in global teardown
+- `CLEAN_E2E_DB=true` - Additionally removes the E2E database after teardown. Setup always resets at the start of each run.
 - `PAYLOAD_SECRET` - Set to `e2e-test-secret-key` for E2E tests
 
 ### Key Implementation Details
 
 - E2E tests run on port 4567 (separate from dev server)
 - Manager must have `_verified: true` for login to work (bypasses email verification)
-- Database is preserved between runs for faster iteration (use `CLEAN_E2E_DB=true` to reset)
+- Database is reset at the start of every run to prevent `drizzle-kit push` from prompting on stale schemas (which would hang Playwright's subprocess). Post-run cleanup via `CLEAN_E2E_DB=true` is optional.
 - Test files directory: `tests/files/` contains sample audio/image files for seeding
 
 ## Integration Test Isolation (In-Memory SQLite)

--- a/tests/e2e/frontend.e2e.spec.ts
+++ b/tests/e2e/frontend.e2e.spec.ts
@@ -4,7 +4,7 @@ test.describe('Frontend', () => {
   test('can go on homepage', async ({ page }) => {
     await page.goto('/')
 
-    await expect(page).toHaveTitle(/We Meditate Admin/)
+    await expect(page).toHaveTitle(/Sahaj Cloud/)
 
     const heading = page.locator('h1').first()
 

--- a/tests/setup/playwright.global-setup.ts
+++ b/tests/setup/playwright.global-setup.ts
@@ -12,6 +12,7 @@
 /* eslint-disable no-console */
 import type { FullConfig } from '@playwright/test'
 
+import fs from 'fs'
 import path from 'path'
 
 import { getPayload } from 'payload'
@@ -234,6 +235,15 @@ async function seedTestFrames(payload: Awaited<ReturnType<typeof getPayload>>) {
 async function globalSetup(_config: FullConfig) {
   console.log('\n🧪 E2E Test Setup: Initializing database...')
 
+  // Remove any stale E2E SQLite file (and sidecar journal/WAL/SHM files) before
+  // initializing Payload. A stale schema on disk causes drizzle-kit push to
+  // emit warnings and open an interactive prompt that hangs indefinitely in
+  // Playwright's subprocess (no TTY). Starting fresh guarantees no warnings.
+  console.log('🧹 Resetting E2E database to prevent drizzle push prompts...')
+  for (const suffix of ['', '-journal', '-shm', '-wal']) {
+    fs.rmSync(`${E2E_DATABASE_PATH}${suffix}`, { force: true })
+  }
+
   // Initialize Payload with E2E config
   console.log('   Database path:', E2E_DATABASE_PATH)
   const payload = await getPayload({ config: e2ePayloadConfig })
@@ -278,7 +288,6 @@ async function globalSetup(_config: FullConfig) {
     } else {
       console.log(`\n⚠️ E2E setup partially complete (${seededCount}/${totalItems} items seeded)`)
       console.log('   Status:', JSON.stringify(status, null, 2))
-      console.log('   Run with CLEAN_E2E_DB=true to reset and retry\n')
       hasErrors = true
     }
   } catch (error) {

--- a/tests/setup/playwright.global-setup.ts
+++ b/tests/setup/playwright.global-setup.ts
@@ -12,7 +12,6 @@
 /* eslint-disable no-console */
 import type { FullConfig } from '@playwright/test'
 
-import fs from 'fs'
 import path from 'path'
 
 import { getPayload } from 'payload'
@@ -25,6 +24,7 @@ import {
   createSeedStatus,
   type SeedStatus,
 } from '../utils/e2e-helpers'
+import { removeSqliteFiles } from './sqliteCleanup'
 
 /**
  * Seed the default manager user for authentication
@@ -235,14 +235,12 @@ async function seedTestFrames(payload: Awaited<ReturnType<typeof getPayload>>) {
 async function globalSetup(_config: FullConfig) {
   console.log('\n🧪 E2E Test Setup: Initializing database...')
 
-  // Remove any stale E2E SQLite file (and sidecar journal/WAL/SHM files) before
-  // initializing Payload. A stale schema on disk causes drizzle-kit push to
-  // emit warnings and open an interactive prompt that hangs indefinitely in
-  // Playwright's subprocess (no TTY). Starting fresh guarantees no warnings.
+  // Remove any stale E2E SQLite file before initializing Payload. A stale
+  // schema on disk causes drizzle-kit push to emit warnings and open an
+  // interactive prompt that hangs indefinitely in Playwright's subprocess
+  // (no TTY). Starting fresh guarantees no warnings.
   console.log('🧹 Resetting E2E database to prevent drizzle push prompts...')
-  for (const suffix of ['', '-journal', '-shm', '-wal']) {
-    fs.rmSync(`${E2E_DATABASE_PATH}${suffix}`, { force: true })
-  }
+  removeSqliteFiles(E2E_DATABASE_PATH)
 
   // Initialize Payload with E2E config
   console.log('   Database path:', E2E_DATABASE_PATH)

--- a/tests/setup/playwright.global-teardown.ts
+++ b/tests/setup/playwright.global-teardown.ts
@@ -2,8 +2,11 @@
  * Playwright Global Teardown
  *
  * Cleans up E2E test resources after all tests complete.
- * Currently preserves the database for debugging failed tests.
- * Set CLEAN_E2E_DB=true to delete the database after tests.
+ *
+ * Note: global-setup now resets the E2E database at the start of each run
+ * (to prevent drizzle push prompts from hanging on stale schemas). This
+ * teardown is only needed when you additionally want the DB removed after
+ * the run — set CLEAN_E2E_DB=true to opt in.
  */
 import fs from 'fs'
 
@@ -35,8 +38,9 @@ async function globalTeardown(_config: FullConfig) {
 
     console.log('   E2E database cleaned up')
   } else {
-    console.log('   Database preserved at:', E2E_DATABASE_PATH)
-    console.log('   Set CLEAN_E2E_DB=true to delete after tests')
+    console.log('   Database left in place at:', E2E_DATABASE_PATH)
+    console.log('   (It will be reset at the start of the next run.)')
+    console.log('   Set CLEAN_E2E_DB=true to also delete it now.')
   }
 
   console.log('✅ E2E teardown complete\n')

--- a/tests/setup/playwright.global-teardown.ts
+++ b/tests/setup/playwright.global-teardown.ts
@@ -8,34 +8,17 @@
  * teardown is only needed when you additionally want the DB removed after
  * the run — set CLEAN_E2E_DB=true to opt in.
  */
-import fs from 'fs'
-
 import type { FullConfig } from '@playwright/test'
 
 import { E2E_DATABASE_PATH } from '../config/e2e-payload.config'
+import { removeSqliteFiles } from './sqliteCleanup'
 
 async function globalTeardown(_config: FullConfig) {
   console.log('\n🧹 E2E Test Teardown...')
 
-  // Optionally clean up the database
-  // By default, we preserve it for debugging failed tests
   if (process.env.CLEAN_E2E_DB === 'true') {
-    if (fs.existsSync(E2E_DATABASE_PATH)) {
-      console.log('   Removing E2E database...')
-      fs.unlinkSync(E2E_DATABASE_PATH)
-    }
-
-    // Also remove SQLite WAL files if they exist
-    const walPath = `${E2E_DATABASE_PATH}-wal`
-    const shmPath = `${E2E_DATABASE_PATH}-shm`
-
-    if (fs.existsSync(walPath)) {
-      fs.unlinkSync(walPath)
-    }
-    if (fs.existsSync(shmPath)) {
-      fs.unlinkSync(shmPath)
-    }
-
+    console.log('   Removing E2E database...')
+    removeSqliteFiles(E2E_DATABASE_PATH)
     console.log('   E2E database cleaned up')
   } else {
     console.log('   Database left in place at:', E2E_DATABASE_PATH)

--- a/tests/setup/sqliteCleanup.ts
+++ b/tests/setup/sqliteCleanup.ts
@@ -1,0 +1,16 @@
+import fs from 'fs'
+
+/**
+ * Remove a SQLite database file and all standard sidecars.
+ * Uses fs.rmSync with `force: true` — no error if any file is missing.
+ *
+ * Sidecars:
+ *   -journal  rollback journal (can survive a crashed prior run)
+ *   -wal      write-ahead log
+ *   -shm      shared memory
+ */
+export function removeSqliteFiles(basePath: string): void {
+  for (const suffix of ['', '-journal', '-shm', '-wal']) {
+    fs.rmSync(`${basePath}${suffix}`, { force: true })
+  }
+}


### PR DESCRIPTION
## Summary

Closes #272.

`pnpm test:e2e` hangs indefinitely whenever the on-disk `tests/.e2e.sqlite` schema drifts from the code schema (e.g., after a collection field change between runs). Root cause: `@payloadcms/drizzle`'s `pushDevSchema` calls drizzle-kit's `pushSchema`, and on schema ambiguity it opens an interactive `prompts()` confirm. Playwright's subprocess has no TTY, so the prompt never resolves.

**Fix:** delete the DB file (plus `-journal`, `-shm`, `-wal` sidecars) at the very start of `globalSetup`, before `getPayload(...)` runs. Fresh file → no ambiguity → no warnings → no prompt.

The `PAYLOAD_FORCE_DRIZZLE_PUSH` env var (seen in the drizzle source) does **not** suppress the prompt — it only bypasses an in-memory fast-path. Verified against `node_modules/.pnpm/@payloadcms+drizzle@3.82.1_.../dist/utilities/pushDevSchema.js`.

### Also included (separate commit)

`tests/e2e/frontend.e2e.spec.ts` was asserting `page.toHaveTitle(/We Meditate Admin/)` but `layout.tsx` sets the document title to `Sahaj Cloud`. Pre-existing failure on `main`; fixed here so the branch reaches 0 E2E failures (per `pr-requirements.md`).

## Changes

- `tests/setup/playwright.global-setup.ts` — unconditionally `fs.rmSync` the E2E SQLite file and its sidecars at the top of `globalSetup`; remove the now-misleading "Run with CLEAN_E2E_DB=true" hint.
- `tests/setup/playwright.global-teardown.ts` — update header + runtime messages to reflect the new reset-on-setup behavior. `CLEAN_E2E_DB=true` still works as opt-in post-run cleanup.
- `.claude/docs/testing.md` — rewrite the "preserved between runs" language; clarify `CLEAN_E2E_DB=true` is additive.
- `tests/e2e/frontend.e2e.spec.ts` — title regex `/We Meditate Admin/` → `/Sahaj Cloud/` (separate commit, pre-existing fix).

## Test plan

- [x] `pnpm lint`
- [x] `pnpm tsc --noEmit`
- [x] `pnpm test:int` — 774 passed, 2 skipped (pre-existing)
- [x] `pnpm test:e2e` with a stale/garbage `tests/.e2e.sqlite` present — completes in ~50s (hang reproduced without fix, gone with fix)
- [x] `pnpm test:e2e` clean run — 2 passed, 2 skipped (pre-existing), 0 failures
- [ ] `CLEAN_E2E_DB=true pnpm test:e2e` — optional smoke of post-run cleanup path

## Test Results

- Unit/Integration tests: 774 passed, 2 skipped (pre-existing)
- E2E tests: 2 passed, 2 skipped (pre-existing `test.skip()` in `tests/e2e/clients.e2e.spec.ts` — out of scope for this fix)
- Build: lint + `tsc --noEmit` ✓ Success
- Pre-existing failures fixed: `frontend.e2e.spec.ts` title assertion

## Notes

- Issue #272's body described implementing `/api/app-cards/for-user`, but that work shipped in PRs #273/#275 (endpoint renamed to `/for-viewer`). Working to the issue's **title** instead.
- The two `test.skip()` calls in `tests/e2e/clients.e2e.spec.ts` predate this PR; leaving them untouched to keep scope tight.
- Tradeoff: every E2E run now re-seeds (small, ~2s of file I/O). Acceptable vs. indeterminate hangs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)