### PR TITLE
feat(content-index): add limit field, switch lectures to /for-audience, drop lecture-clips

### DIFF
--- a/.claude/docs/collections/pages.md
+++ b/.claude/docs/collections/pages.md
@@ -70,15 +70,14 @@ Content catalog component:
 ### 7. ContentIndexBlock (`ContentIndexBlock.ts`)
 
 Content index grid component with type-based filtering:
-- `type` (select, required, default: 'meditations') - Content type: meditations, pages, songs, lectures, lecture-clips
+- `type` (select, required, default: 'meditations') - Content type: meditations, pages, songs, lectures
+- `limit` (number, required, default: 10, min: 1, max: 100) - Maximum number of items to return; applied across every type
 - `meditationFilters` (relationship to meditation-tags, hasMany, minRows: 1) - Visible when type is meditations
 - `pageFilters` (select, hasMany, required) - Uses PAGE_TAGS values, visible when type is pages
 - `songFilters` (relationship to song-tags, hasMany, minRows: 1) - Visible when type is songs
-- `lectureFilters` (relationship to audiences, hasMany, minRows: 1) - Visible when type is lectures. Query string uses `where[audiences][in]`.
-- `lectureClipFilters` (relationship to audiences, hasMany, minRows: 1) - Visible when type is lecture-clips. Query string uses `where[audiences][in]`.
 - `apiEndpoint` (text, virtual, hidden) - Computed API endpoint URL for frontend consumption
 
-The virtual `apiEndpoint` field uses an `afterRead` hook (`computeApiEndpoint` in `src/blocks/pages/ContentIndexBlock.ts`) to generate a ready-to-use API URL from the block's type and selected filters. Meditations query `/api/meditation-tags` (reverse relationship), while pages/songs/lectures/lecture-clips query their own collection endpoints. Each filter field has `beforeChange` and `afterRead` hooks (`clearWhenTypeNot`) that clear stale values when the block's type doesn't match, ensuring only the active filter appears in the API response.
+The virtual `apiEndpoint` field uses an `afterRead` hook (`computeApiEndpoint` in `src/blocks/pages/ContentIndexBlock.ts`) to generate a ready-to-use API URL from the block's type, selected filters, and `limit`. Meditations query `/api/meditation-tags` (reverse relationship); pages and songs query their own collection endpoints with a `where[tags][in]` filter; lectures hit `/api/lectures/for-audience`, which evaluates audiences from the runtime user context (no editor-selected audience list). Every generated URL ends with `&limit=<N>` (or `?limit=<N>` for lectures, which has no preceding query params). If `limit` is missing or outside `[1, 100]`, the hook returns `null`. Each filter field has `beforeChange` and `afterRead` hooks (`clearWhenTypeNot`) that clear stale values when the block's type doesn't match, ensuring only the active filter appears in the API response.
 
 ## Key Features
 

--- a/scripts/create-sample-page.ts
+++ b/scripts/create-sample-page.ts
@@ -192,9 +192,7 @@ async function fetchSeedData(payload: Payload): Promise<SeedData> {
   console.log(`  Meditations: ${data.meditationIds.length} found`)
   console.log(`  Meditation Tags: ${data.meditationTagIds.length} found (IDs: ${data.meditationTagIds.join(', ')})`)
   console.log(`  Song Tags: ${data.songTagIds.length} found (IDs: ${data.songTagIds.join(', ')})`)
-  console.log(
-    `  Audiences: ${data.audienceIds.length} found${data.audienceIds.length === 0 ? ' (skipping ContentIndex lectures variant)' : ''}`,
-  )
+  console.log(`  Audiences: ${data.audienceIds.length} found`)
   console.log(
     `  App Cards: ${data.appCardIds.length} found${data.appCardIds.length === 0 ? ' (will not include in Showcase)' : ''}`,
   )
@@ -481,6 +479,7 @@ function buildContentIndexBlocks(data: SeedData): unknown[] {
   blocks.push(
     blockNode('content-index', {
       type: 'meditations',
+      limit: 10,
       meditationFilters: data.meditationTagIds.slice(0, 3),
     }),
   )
@@ -489,6 +488,7 @@ function buildContentIndexBlocks(data: SeedData): unknown[] {
   blocks.push(
     blockNode('content-index', {
       type: 'pages',
+      limit: 10,
       pageFilters: ['wisdom', 'lifestyle', 'creativity'],
     }),
   )
@@ -498,6 +498,7 @@ function buildContentIndexBlocks(data: SeedData): unknown[] {
     blocks.push(
       blockNode('content-index', {
         type: 'songs',
+        limit: 10,
         songFilters: data.songTagIds.slice(0, 2),
       }),
     )
@@ -505,17 +506,13 @@ function buildContentIndexBlocks(data: SeedData): unknown[] {
     console.log('  Skipping ContentIndex songs variant (no song-tags)')
   }
 
-  // Lectures (if audiences exist)
-  if (data.audienceIds.length > 0) {
-    blocks.push(
-      blockNode('content-index', {
-        type: 'lectures',
-        lectureFilters: data.audienceIds.slice(0, 2),
-      }),
-    )
-  } else {
-    console.log('  Skipping ContentIndex lectures variant (no audiences)')
-  }
+  // Lectures — uses /api/lectures/for-audience; no editor-selected audience list.
+  blocks.push(
+    blockNode('content-index', {
+      type: 'lectures',
+      limit: 10,
+    }),
+  )
 
   return blocks
 }

--- a/src/blocks/pages/ContentIndexBlock.ts
+++ b/src/blocks/pages/ContentIndexBlock.ts
@@ -6,10 +6,12 @@ import { PAGE_TAGS } from '@/lib/constants'
 
 /**
  * Configuration for each content type's API endpoint generation.
+ * `filterField` / `queryParam` are optional — `lectures` hits `/for-audience`,
+ * which evaluates audiences from runtime user context and ignores `where`.
  */
 const CONTENT_TYPE_CONFIG: Record<
   string,
-  { basePath: string; filterField: string; queryParam: string; extraParams?: string }
+  { basePath: string; filterField?: string; queryParam?: string; extraParams?: string }
 > = {
   meditations: {
     basePath: '/api/meditation-tags',
@@ -28,20 +30,13 @@ const CONTENT_TYPE_CONFIG: Record<
     queryParam: 'where[tags][in]',
   },
   lectures: {
-    basePath: '/api/lectures',
-    filterField: 'lectureFilters',
-    queryParam: 'where[audiences][in]',
-  },
-  'lecture-clips': {
-    basePath: '/api/lecture-clips',
-    filterField: 'lectureClipFilters',
-    queryParam: 'where[audiences][in]',
+    basePath: '/api/lectures/for-audience',
   },
 }
 
 /**
  * afterRead hook for the virtual `apiEndpoint` field.
- * Computes a ready-to-use API endpoint URL from the block's type and selected filters.
+ * Computes a ready-to-use API endpoint URL from the block's type, selected filters, and limit.
  */
 export const computeApiEndpoint: FieldHook = ({ siblingData }) => {
   const type = siblingData?.type as string | undefined
@@ -50,18 +45,32 @@ export const computeApiEndpoint: FieldHook = ({ siblingData }) => {
   const config = CONTENT_TYPE_CONFIG[type]
   if (!config) return null
 
-  const filters = siblingData?.[config.filterField]
-  if (!filters || (Array.isArray(filters) && filters.length === 0)) return null
+  const rawLimit = siblingData?.limit
+  const limit =
+    typeof rawLimit === 'number' &&
+    Number.isInteger(rawLimit) &&
+    rawLimit >= 1 &&
+    rawLimit <= 100
+      ? rawLimit
+      : null
+  if (limit === null) return null
 
-  const filterValues = (Array.isArray(filters) ? filters : [filters]).filter(Boolean)
-  const ids = filterValues.map(extractID)
+  if (config.filterField && config.queryParam) {
+    const filters = siblingData?.[config.filterField]
+    if (!filters || (Array.isArray(filters) && filters.length === 0)) return null
 
-  if (ids.length === 0) return null
+    const filterValues = (Array.isArray(filters) ? filters : [filters]).filter(Boolean)
+    const ids = filterValues.map(extractID)
+    if (ids.length === 0) return null
 
-  const queryValue = ids.map((id) => encodeURIComponent(id)).join(',')
-  const endpoint = `${config.basePath}?${config.queryParam}=${queryValue}`
+    const queryValue = ids.map((id) => encodeURIComponent(id)).join(',')
+    let url = `${config.basePath}?${config.queryParam}=${queryValue}`
+    if (config.extraParams) url = `${url}${config.extraParams}`
+    return `${url}&limit=${limit}`
+  }
 
-  return config.extraParams ? `${endpoint}${config.extraParams}` : endpoint
+  // No filter field → limit is the first query param
+  return `${config.basePath}?limit=${limit}`
 }
 
 /**
@@ -103,12 +112,22 @@ export const ContentIndexBlock: Block = {
         { label: 'Pages', value: 'pages' },
         { label: 'Songs', value: 'songs' },
         { label: 'Lectures', value: 'lectures' },
-        { label: 'Lecture Clips', value: 'lecture-clips' },
       ],
       admin: {
         components: {
           Field: '@/components/admin/ToggleGroupField',
         },
+      },
+    },
+    {
+      name: 'limit',
+      type: 'number',
+      required: true,
+      defaultValue: 10,
+      min: 1,
+      max: 100,
+      admin: {
+        description: 'Maximum number of items to return (1–100)',
       },
     },
     {
@@ -147,32 +166,6 @@ export const ContentIndexBlock: Block = {
       admin: {
         condition: (_, siblingData) => siblingData?.type === 'songs',
         description: 'Select music tags to use as filters for this index grid',
-      },
-    },
-    {
-      name: 'lectureFilters',
-      type: 'relationship',
-      relationTo: 'audiences',
-      hasMany: true,
-      minRows: 1,
-      maxDepth: 0,
-      hooks: clearWhenTypeNot('lectures'),
-      admin: {
-        condition: (_, siblingData) => siblingData?.type === 'lectures',
-        description: 'Select audiences to use as filters for this index grid',
-      },
-    },
-    {
-      name: 'lectureClipFilters',
-      type: 'relationship',
-      relationTo: 'audiences',
-      hasMany: true,
-      minRows: 1,
-      maxDepth: 0,
-      hooks: clearWhenTypeNot('lecture-clips'),
-      admin: {
-        condition: (_, siblingData) => siblingData?.type === 'lecture-clips',
-        description: 'Select audiences to use as filters for this clip index grid',
       },
     },
     {

--- a/tests/int/content-index-block.int.spec.ts
+++ b/tests/int/content-index-block.int.spec.ts
@@ -27,25 +27,28 @@ describe('computeApiEndpoint hook (pure)', () => {
     it('generates meditation-tags endpoint with raw IDs', () => {
       const result = callHook({
         type: 'meditations',
+        limit: 10,
         meditationFilters: [1, 2, 3],
       })
-      expect(result).toBe('/api/meditation-tags?where[id][in]=1,2,3&depth=1')
+      expect(result).toBe('/api/meditation-tags?where[id][in]=1,2,3&depth=1&limit=10')
     })
 
     it('generates meditation-tags endpoint with populated objects', () => {
       const result = callHook({
         type: 'meditations',
+        limit: 10,
         meditationFilters: [{ id: 10, title: 'Tag A' }, { id: 20, title: 'Tag B' }],
       })
-      expect(result).toBe('/api/meditation-tags?where[id][in]=10,20&depth=1')
+      expect(result).toBe('/api/meditation-tags?where[id][in]=10,20&depth=1&limit=10')
     })
 
-    it('appends depth=1 for meditation-tags queries', () => {
+    it('appends depth=1 and limit in the correct order', () => {
       const result = callHook({
         type: 'meditations',
+        limit: 25,
         meditationFilters: [5],
       })
-      expect(result).toContain('&depth=1')
+      expect(result).toBe('/api/meditation-tags?where[id][in]=5&depth=1&limit=25')
     })
   })
 
@@ -53,14 +56,16 @@ describe('computeApiEndpoint hook (pure)', () => {
     it('generates pages endpoint with string tag values', () => {
       const result = callHook({
         type: 'pages',
+        limit: 10,
         pageFilters: ['wisdom', 'lifestyle'],
       })
-      expect(result).toBe('/api/pages?where[tags][in]=wisdom,lifestyle')
+      expect(result).toBe('/api/pages?where[tags][in]=wisdom,lifestyle&limit=10')
     })
 
     it('does not append depth for pages', () => {
       const result = callHook({
         type: 'pages',
+        limit: 10,
         pageFilters: ['creativity'],
       })
       expect(result).not.toContain('depth')
@@ -71,75 +76,125 @@ describe('computeApiEndpoint hook (pure)', () => {
     it('generates songs endpoint with raw IDs', () => {
       const result = callHook({
         type: 'songs',
+        limit: 10,
         songFilters: [5, 6],
       })
-      expect(result).toBe('/api/songs?where[tags][in]=5,6')
+      expect(result).toBe('/api/songs?where[tags][in]=5,6&limit=10')
     })
 
     it('generates songs endpoint with populated objects', () => {
       const result = callHook({
         type: 'songs',
+        limit: 10,
         songFilters: [{ id: 7, title: 'Jazz' }],
       })
-      expect(result).toBe('/api/songs?where[tags][in]=7')
+      expect(result).toBe('/api/songs?where[tags][in]=7&limit=10')
     })
   })
 
   describe('lectures type', () => {
-    it('generates lectures endpoint with raw IDs', () => {
-      const result = callHook({
-        type: 'lectures',
-        lectureFilters: [10, 11],
-      })
-      expect(result).toBe('/api/lectures?where[audiences][in]=10,11')
+    it('emits /for-audience with only limit — no where clause, no filter field required', () => {
+      const result = callHook({ type: 'lectures', limit: 10 })
+      expect(result).toBe('/api/lectures/for-audience?limit=10')
     })
 
-    it('generates lectures endpoint with populated objects', () => {
+    it('ignores any stale lecture filter data that may still be in siblingData', () => {
       const result = callHook({
         type: 'lectures',
-        lectureFilters: [{ id: 100, label: 'Beginner' }],
+        limit: 10,
+        // simulate stale editor state from before the lectureFilters removal
+        lectureFilters: [10, 11],
       })
-      expect(result).toBe('/api/lectures?where[audiences][in]=100')
+      expect(result).toBe('/api/lectures/for-audience?limit=10')
+      expect(result).not.toContain('where')
+    })
+  })
+
+  describe('limit field coverage', () => {
+    it('threads limit=100 through a filtered type', () => {
+      const result = callHook({
+        type: 'pages',
+        limit: 100,
+        pageFilters: ['wisdom'],
+      })
+      expect(result).toBe('/api/pages?where[tags][in]=wisdom&limit=100')
+    })
+
+    it('threads limit=25 through lectures (no-filter type)', () => {
+      const result = callHook({ type: 'lectures', limit: 25 })
+      expect(result).toBe('/api/lectures/for-audience?limit=25')
+    })
+  })
+
+  describe('invalid limit', () => {
+    it('returns null when limit is missing', () => {
+      expect(callHook({ type: 'pages', pageFilters: ['wisdom'] })).toBeNull()
+    })
+
+    it('returns null when limit is 0', () => {
+      expect(callHook({ type: 'pages', limit: 0, pageFilters: ['wisdom'] })).toBeNull()
+    })
+
+    it('returns null when limit exceeds 100', () => {
+      expect(callHook({ type: 'pages', limit: 101, pageFilters: ['wisdom'] })).toBeNull()
+    })
+
+    it('returns null when limit is a string', () => {
+      expect(callHook({ type: 'pages', limit: 'ten', pageFilters: ['wisdom'] })).toBeNull()
+    })
+
+    it('returns null when limit is a non-integer float', () => {
+      expect(callHook({ type: 'pages', limit: 10.5, pageFilters: ['wisdom'] })).toBeNull()
+    })
+
+    it('returns null when limit is negative', () => {
+      expect(callHook({ type: 'pages', limit: -1, pageFilters: ['wisdom'] })).toBeNull()
     })
   })
 
   describe('null/empty cases', () => {
     it('returns null when type is missing', () => {
-      expect(callHook({})).toBeNull()
+      expect(callHook({ limit: 10 })).toBeNull()
     })
 
     it('returns null when type is unknown', () => {
-      expect(callHook({ type: 'unknown' })).toBeNull()
+      expect(callHook({ type: 'unknown', limit: 10 })).toBeNull()
     })
 
-    it('returns null when filters are missing', () => {
-      expect(callHook({ type: 'songs' })).toBeNull()
+    it('returns null when type is the removed lecture-clips (stale block data)', () => {
+      expect(callHook({ type: 'lecture-clips', limit: 10 })).toBeNull()
+    })
+
+    it('returns null when filters are missing for a filtered type', () => {
+      expect(callHook({ type: 'songs', limit: 10 })).toBeNull()
     })
 
     it('returns null when filters are empty array', () => {
-      expect(callHook({ type: 'songs', songFilters: [] })).toBeNull()
+      expect(callHook({ type: 'songs', limit: 10, songFilters: [] })).toBeNull()
     })
 
     it('returns null when all filter values are null', () => {
-      expect(callHook({ type: 'songs', songFilters: [null, undefined] })).toBeNull()
+      expect(callHook({ type: 'songs', limit: 10, songFilters: [null, undefined] })).toBeNull()
     })
   })
 
   describe('mixed ID formats', () => {
     it('handles mix of raw IDs and populated objects', () => {
       const result = callHook({
-        type: 'lectures',
-        lectureFilters: [1, { id: 2, label: 'Tag' }, 3],
+        type: 'songs',
+        limit: 10,
+        songFilters: [1, { id: 2, title: 'Tag' }, 3],
       })
-      expect(result).toBe('/api/lectures?where[audiences][in]=1,2,3')
+      expect(result).toBe('/api/songs?where[tags][in]=1,2,3&limit=10')
     })
 
     it('skips null values in mixed filters', () => {
       const result = callHook({
         type: 'songs',
+        limit: 10,
         songFilters: [1, null, 3],
       })
-      expect(result).toBe('/api/songs?where[tags][in]=1,3')
+      expect(result).toBe('/api/songs?where[tags][in]=1,3&limit=10')
     })
   })
 })
@@ -205,11 +260,12 @@ describe('ContentIndexBlock apiEndpoint (integration)', () => {
   it('computes apiEndpoint for pages with pageFilters', async () => {
     const page = await createPageWithBlock({
       type: 'pages',
+      limit: 10,
       pageFilters: ['wisdom', 'lifestyle'],
     })
     const fetched = await payload.findByID({ collection: 'pages', id: page.id, depth: 0 })
     expect(getBlockFields(fetched).apiEndpoint).toBe(
-      '/api/pages?where[tags][in]=wisdom,lifestyle',
+      '/api/pages?where[tags][in]=wisdom,lifestyle&limit=10',
     )
   })
 
@@ -217,11 +273,12 @@ describe('ContentIndexBlock apiEndpoint (integration)', () => {
     const songTag = await testData.createSongTag(payload)
     const page = await createPageWithBlock({
       type: 'songs',
+      limit: 10,
       songFilters: [songTag.id],
     })
     const fetched = await payload.findByID({ collection: 'pages', id: page.id, depth: 0 })
     expect(getBlockFields(fetched).apiEndpoint).toBe(
-      `/api/songs?where[tags][in]=${songTag.id}`,
+      `/api/songs?where[tags][in]=${songTag.id}&limit=10`,
     )
   })
 
@@ -229,28 +286,35 @@ describe('ContentIndexBlock apiEndpoint (integration)', () => {
     const meditationTag = await testData.createMeditationTag(payload)
     const page = await createPageWithBlock({
       type: 'meditations',
+      limit: 10,
       meditationFilters: [meditationTag.id],
     })
     const fetched = await payload.findByID({ collection: 'pages', id: page.id, depth: 0 })
     expect(getBlockFields(fetched).apiEndpoint).toBe(
-      `/api/meditation-tags?where[id][in]=${meditationTag.id}&depth=1`,
+      `/api/meditation-tags?where[id][in]=${meditationTag.id}&depth=1&limit=10`,
     )
   })
 
-  it('computes apiEndpoint for lectures with audiences filters', async () => {
-    const audience = await testData.createAudience(payload)
+  it('computes apiEndpoint for lectures — /for-audience with only limit, no filter required', async () => {
     const page = await createPageWithBlock({
       type: 'lectures',
-      lectureFilters: [audience.id],
+      limit: 10,
     })
     const fetched = await payload.findByID({ collection: 'pages', id: page.id, depth: 0 })
-    expect(getBlockFields(fetched).apiEndpoint).toBe(
-      `/api/lectures?where[audiences][in]=${audience.id}`,
-    )
+    expect(getBlockFields(fetched).apiEndpoint).toBe('/api/lectures/for-audience?limit=10')
   })
 
-  it('returns null apiEndpoint when no filters are set', async () => {
-    const page = await createPageWithBlock({ type: 'songs' })
+  it('returns null apiEndpoint when no filters are set for a filtered type', async () => {
+    const page = await createPageWithBlock({ type: 'songs', limit: 10 })
+    const fetched = await payload.findByID({ collection: 'pages', id: page.id, depth: 0 })
+    expect(getBlockFields(fetched).apiEndpoint).toBeNull()
+  })
+
+  it('returns null apiEndpoint when limit is missing', async () => {
+    const page = await createPageWithBlock({
+      type: 'pages',
+      pageFilters: ['wisdom'],
+    })
     const fetched = await payload.findByID({ collection: 'pages', id: page.id, depth: 0 })
     expect(getBlockFields(fetched).apiEndpoint).toBeNull()
   })
@@ -260,6 +324,7 @@ describe('ContentIndexBlock apiEndpoint (integration)', () => {
     // Create a page with songs type and songFilters
     const page = await createPageWithBlock({
       type: 'songs',
+      limit: 10,
       songFilters: [songTag.id],
       // Simulate stale data: pageFilters left over from a previous type selection
       pageFilters: ['wisdom'],
@@ -268,7 +333,7 @@ describe('ContentIndexBlock apiEndpoint (integration)', () => {
     const fields = getBlockFields(fetched)
 
     // Active filter should be present
-    expect(fields.apiEndpoint).toBe(`/api/songs?where[tags][in]=${songTag.id}`)
+    expect(fields.apiEndpoint).toBe(`/api/songs?where[tags][in]=${songTag.id}&limit=10`)
     // Stale filter should be removed entirely by afterRead hook
     expect(fields).not.toHaveProperty('pageFilters')
   })


### PR DESCRIPTION
## Summary

- Adds a required `limit` field (default 10, min 1, max 100) to `ContentIndexBlock`; always appended as `&limit=<N>` (or `?limit=<N>` for lectures) on the generated `apiEndpoint`.
- Switches the `lectures` type to hit `/api/lectures/for-audience` and drops the `lectureFilters` audience picker — `/for-audience` evaluates audiences from runtime user context, so editor-selected IDs were meaningless.
- Removes the `lecture-clips` type + `lectureClipFilters` field; clips are consumed inline via the lecture viewer feed. Stale `lecture-clips`-type blocks already in saved page content land on the null branch and render nothing — no migration needed (per the issue).
- Updates `scripts/create-sample-page.ts` to drop `lectureFilters` and thread `limit: 10` through every ContentIndex variant.

Closes #302

## Test Results
- Unit/Integration tests: 556 passed, 0 skipped (1 pre-existing flake in `access-performance.int.spec.ts` — CPU-timing benchmark ran 105ms against 100ms threshold, unrelated to this change; reproduces intermittently on `main` under full-suite load, runs in 5ms in isolation)
- Build: ✓ Success
- Lint: ✓ No warnings or errors
- TypeScript: ✓ No errors

## Test plan

- [x] `computeApiEndpoint` returns the expected URL for every type with `limit` threaded through
- [x] `computeApiEndpoint` returns `null` for invalid `limit` (missing, 0, 101, non-integer, string, negative)
- [x] `computeApiEndpoint` returns `null` for the removed `lecture-clips` type (stale-block safety)
- [x] Lectures type resolves with only `type + limit` — no filter field required; ignores any stale `lectureFilters` left in siblingData
- [x] `clearWhenTypeNot` still clears stale filters for meditations/pages/songs
- [x] Integration: block fields round-trip through Lexical content and the virtual `apiEndpoint` field emits the right URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)