### PR TITLE
fix(rbac): let meditations-editor assign meditations on categories

### DIFF
--- a/src/collections/access/Managers.ts
+++ b/src/collections/access/Managers.ts
@@ -1,6 +1,6 @@
 import type { CollectionConfig } from 'payload'
 
-import { getRoleOptions, getProjectOptions } from '@/lib/access'
+import { adminOnlyFieldAccess, getRoleOptions, getProjectOptions } from '@/lib/access'
 import { getServerUrl } from '@/lib/serverUrl'
 
 export const Managers: CollectionConfig = {
@@ -104,9 +104,7 @@ export const Managers: CollectionConfig = {
       },
       access: {
         // Only admins can update the type field
-        update: ({ req: { user } }) => {
-          return user?.collection === 'managers' && user.type === 'admin'
-        },
+        update: adminOnlyFieldAccess,
       },
     },
 
@@ -127,9 +125,7 @@ export const Managers: CollectionConfig = {
       },
       access: {
         // Only admins can update roles
-        update: ({ req: { user } }) => {
-          return user?.collection === 'managers' && user.type === 'admin'
-        },
+        update: adminOnlyFieldAccess,
       },
     },
 
@@ -146,9 +142,7 @@ export const Managers: CollectionConfig = {
       },
       access: {
         // Only admins can update custom resource access
-        update: ({ req: { user } }) => {
-          return user?.collection === 'managers' && user.type === 'admin'
-        },
+        update: adminOnlyFieldAccess,
       },
     },
   ],

--- a/src/collections/tags/MeditationTags.ts
+++ b/src/collections/tags/MeditationTags.ts
@@ -1,4 +1,4 @@
-import type { CollectionBeforeChangeHook, CollectionConfig, FieldAccess } from 'payload'
+import type { CollectionBeforeChangeHook, CollectionConfig } from 'payload'
 
 import { colorField, slugField } from '@/fields'
 import {
@@ -6,16 +6,8 @@ import {
   maintainIsParent,
   validateNesting,
 } from '@/hooks/meditationTagHooks'
+import { adminOnlyFieldAccess, isAdminManager } from '@/lib/access'
 import { virtualUrlField } from '@/lib/storage/urlFields'
-
-/**
- * Field-level access that restricts updates to admin managers only.
- * Non-admin managers (e.g. meditations-editor) can only update the per-timing
- * meditation relationship fields on meditation-tags; everything else — title,
- * slug, icon upload, color, parent, isFeatured, order, timings — stays admin-only.
- */
-const adminOnlyUpdate: FieldAccess = ({ req }) =>
-  req.user?.collection === 'managers' && req.user?.type === 'admin'
 
 /**
  * Block non-admin managers from replacing the uploaded icon.
@@ -25,8 +17,7 @@ const adminOnlyUpdate: FieldAccess = ({ req }) =>
  */
 const restrictIconUploadToAdmin: CollectionBeforeChangeHook = ({ req, operation }) => {
   if (operation !== 'update') return
-  const isAdmin = req.user?.collection === 'managers' && req.user?.type === 'admin'
-  if (isAdmin) return
+  if (isAdminManager(req.user)) return
   if (req.file) {
     throw new Error('Only admins can replace the icon on a meditation category.')
   }
@@ -65,7 +56,7 @@ export const MeditationTags: CollectionConfig = {
       overrides: (field) => {
         for (const inner of field.fields) {
           if (inner.type === 'text' || inner.type === 'checkbox') {
-            inner.access = { ...(inner.access ?? {}), update: adminOnlyUpdate }
+            inner.access = { ...(inner.access ?? {}), update: adminOnlyFieldAccess }
           }
         }
         return field
@@ -77,7 +68,7 @@ export const MeditationTags: CollectionConfig = {
       type: 'text',
       required: true,
       localized: true,
-      access: { update: adminOnlyUpdate },
+      access: { update: adminOnlyFieldAccess },
       admin: {
         description: 'Localized title shown to public users',
       },
@@ -87,7 +78,7 @@ export const MeditationTags: CollectionConfig = {
       name: 'color',
       label: 'Color',
       required: true,
-      access: { update: adminOnlyUpdate },
+      access: { update: adminOnlyFieldAccess },
       admin: {
         description: 'Tag color for UI theming (hex format)',
       },
@@ -98,7 +89,7 @@ export const MeditationTags: CollectionConfig = {
       type: 'relationship',
       relationTo: 'meditation-tags',
       maxDepth: 1,
-      access: { update: adminOnlyUpdate },
+      access: { update: adminOnlyFieldAccess },
       admin: {
         condition: (data) => !data.isParent,
         position: 'sidebar',
@@ -119,7 +110,7 @@ export const MeditationTags: CollectionConfig = {
       type: 'checkbox',
       required: true,
       defaultValue: false,
-      access: { update: adminOnlyUpdate },
+      access: { update: adminOnlyFieldAccess },
       admin: {
         position: 'sidebar',
         description:
@@ -132,7 +123,7 @@ export const MeditationTags: CollectionConfig = {
       type: 'number',
       defaultValue: 1,
       min: 1,
-      access: { update: adminOnlyUpdate },
+      access: { update: adminOnlyFieldAccess },
       admin: {
         position: 'sidebar',
         description: 'Display order (lower numbers appear first)',
@@ -149,7 +140,7 @@ export const MeditationTags: CollectionConfig = {
         { label: 'Evening', value: 'evening' },
         { label: 'Night', value: 'night' },
       ],
-      access: { update: adminOnlyUpdate },
+      access: { update: adminOnlyFieldAccess },
       admin: {
         condition: (data) => !data.isParent,
         description: 'Which times of day this category offers meditations',
@@ -214,7 +205,7 @@ export const MeditationTags: CollectionConfig = {
       required: true,
       defaultValue: false,
       index: true,
-      access: { update: adminOnlyUpdate },
+      access: { update: adminOnlyFieldAccess },
       admin: {
         hidden: true,
         description: 'Automatically set when this tag has child categories',

--- a/src/collections/tags/MeditationTags.ts
+++ b/src/collections/tags/MeditationTags.ts
@@ -1,4 +1,4 @@
-import type { CollectionConfig } from 'payload'
+import type { CollectionBeforeChangeHook, CollectionConfig, FieldAccess } from 'payload'
 
 import { colorField, slugField } from '@/fields'
 import {
@@ -7,6 +7,30 @@ import {
   validateNesting,
 } from '@/hooks/meditationTagHooks'
 import { virtualUrlField } from '@/lib/storage/urlFields'
+
+/**
+ * Field-level access that restricts updates to admin managers only.
+ * Non-admin managers (e.g. meditations-editor) can only update the per-timing
+ * meditation relationship fields on meditation-tags; everything else — title,
+ * slug, icon upload, color, parent, isFeatured, order, timings — stays admin-only.
+ */
+const adminOnlyUpdate: FieldAccess = ({ req }) =>
+  req.user?.collection === 'managers' && req.user?.type === 'admin'
+
+/**
+ * Block non-admin managers from replacing the uploaded icon.
+ * Field-level access covers the scalar fields, but the upload's file payload
+ * isn't a field — it arrives via `req.file`. Reject the request before the
+ * storage adapter touches it.
+ */
+const restrictIconUploadToAdmin: CollectionBeforeChangeHook = ({ req, operation }) => {
+  if (operation !== 'update') return
+  const isAdmin = req.user?.collection === 'managers' && req.user?.type === 'admin'
+  if (isAdmin) return
+  if (req.file) {
+    throw new Error('Only admins can replace the icon on a meditation category.')
+  }
+}
 
 export const MeditationTags: CollectionConfig = {
   slug: 'meditation-tags',
@@ -22,6 +46,7 @@ export const MeditationTags: CollectionConfig = {
   },
   hooks: {
     beforeValidate: [validateNesting],
+    beforeChange: [restrictIconUploadToAdmin],
     afterChange: [maintainIsParent],
     afterDelete: [clearIsParentOnDelete],
   },
@@ -37,6 +62,14 @@ export const MeditationTags: CollectionConfig = {
     slugField({
       useAsSlug: 'title',
       description: 'URL-friendly identifier (auto-generated from {sourceField})',
+      overrides: (field) => {
+        for (const inner of field.fields) {
+          if (inner.type === 'text' || inner.type === 'checkbox') {
+            inner.access = { ...(inner.access ?? {}), update: adminOnlyUpdate }
+          }
+        }
+        return field
+      },
     }),
     // Title (localized, for public display)
     {
@@ -44,6 +77,7 @@ export const MeditationTags: CollectionConfig = {
       type: 'text',
       required: true,
       localized: true,
+      access: { update: adminOnlyUpdate },
       admin: {
         description: 'Localized title shown to public users',
       },
@@ -53,6 +87,7 @@ export const MeditationTags: CollectionConfig = {
       name: 'color',
       label: 'Color',
       required: true,
+      access: { update: adminOnlyUpdate },
       admin: {
         description: 'Tag color for UI theming (hex format)',
       },
@@ -63,6 +98,7 @@ export const MeditationTags: CollectionConfig = {
       type: 'relationship',
       relationTo: 'meditation-tags',
       maxDepth: 1,
+      access: { update: adminOnlyUpdate },
       admin: {
         condition: (data) => !data.isParent,
         position: 'sidebar',
@@ -83,6 +119,7 @@ export const MeditationTags: CollectionConfig = {
       type: 'checkbox',
       required: true,
       defaultValue: false,
+      access: { update: adminOnlyUpdate },
       admin: {
         position: 'sidebar',
         description:
@@ -95,6 +132,7 @@ export const MeditationTags: CollectionConfig = {
       type: 'number',
       defaultValue: 1,
       min: 1,
+      access: { update: adminOnlyUpdate },
       admin: {
         position: 'sidebar',
         description: 'Display order (lower numbers appear first)',
@@ -111,9 +149,7 @@ export const MeditationTags: CollectionConfig = {
         { label: 'Evening', value: 'evening' },
         { label: 'Night', value: 'night' },
       ],
-      access: {
-        update: ({ req }) => req.user?.collection === 'managers' && req.user?.type === 'admin',
-      },
+      access: { update: adminOnlyUpdate },
       admin: {
         condition: (data) => !data.isParent,
         description: 'Which times of day this category offers meditations',
@@ -178,6 +214,7 @@ export const MeditationTags: CollectionConfig = {
       required: true,
       defaultValue: false,
       index: true,
+      access: { update: adminOnlyUpdate },
       admin: {
         hidden: true,
         description: 'Automatically set when this tag has child categories',

--- a/src/fields/colorField.ts
+++ b/src/fields/colorField.ts
@@ -1,4 +1,4 @@
-import type { Field, TextFieldSingleValidation } from 'payload'
+import type { Field, FieldAccess, TextFieldSingleValidation } from 'payload'
 
 /**
  * Validates hex color format (#RRGGBB or #RGB)
@@ -16,6 +16,11 @@ export interface ColorFieldOptions {
   name?: string
   label?: string
   required?: boolean
+  access?: {
+    create?: FieldAccess
+    read?: FieldAccess
+    update?: FieldAccess
+  }
   admin?: {
     description?: string
     position?: 'sidebar'
@@ -34,7 +39,7 @@ export interface ColorFieldOptions {
  * ```
  */
 export function colorField(options: ColorFieldOptions = {}): Field {
-  const { name = 'color', label = 'Color', required = false, admin = {} } = options
+  const { name = 'color', label = 'Color', required = false, access, admin = {} } = options
 
   return {
     name,
@@ -43,6 +48,7 @@ export function colorField(options: ColorFieldOptions = {}): Field {
     required,
     validate: hexColorValidation,
     defaultValue: '#000000',
+    ...(access ? { access } : {}),
     admin: {
       description: admin.description || 'Hex color code (e.g., #FF5733)',
       position: admin.position,

--- a/src/lib/access/adminOnly.ts
+++ b/src/lib/access/adminOnly.ts
@@ -1,0 +1,29 @@
+import type { FieldAccess, PayloadRequest } from 'payload'
+
+/**
+ * Admin-only access helpers.
+ *
+ * Centralizes the "is this request from an admin manager?" check used by
+ * field-level access configs (e.g. `Managers.type`, `MeditationTags.title`)
+ * and by hooks that need the same predicate outside a FieldAccess context
+ * (e.g. blocking non-admin icon uploads on meditation-tags).
+ */
+
+/**
+ * True when the request user is an active admin manager.
+ *
+ * Use in hooks, resolvers, or any code that has access to the user object
+ * but is not itself a PayloadCMS `Access` / `FieldAccess` function.
+ */
+export function isAdminManager(user: PayloadRequest['user']): boolean {
+  return user?.collection === 'managers' && user?.type === 'admin'
+}
+
+/**
+ * Field-level access: only admin managers may update the field.
+ *
+ * Pass directly to `access.update` (or `access.create`/`access.read`) on an
+ * individual field to lock non-admin managers out of editing it. Read/create
+ * default to open; apply explicitly where you want them restricted too.
+ */
+export const adminOnlyFieldAccess: FieldAccess = ({ req }) => isAdminManager(req.user)

--- a/src/lib/access/config/roles.ts
+++ b/src/lib/access/config/roles.ts
@@ -36,6 +36,7 @@ const ROLES = {
     permissions: {
       meditations: ['update', 'create'] as PermissionLevel[],
       narrators: ['update', 'create'] as PermissionLevel[],
+      'meditation-tags': ['update'] as PermissionLevel[],
       images: ['create'] as PermissionLevel[],
       files: ['create'] as PermissionLevel[],
     },

--- a/src/lib/access/index.ts
+++ b/src/lib/access/index.ts
@@ -33,6 +33,7 @@ export { bypassPermissions } from './bypassPermissions'
 // ============================================================================
 
 export { filterAvailableLocales } from './filterAvailableLocales'
+export { adminOnlyFieldAccess, isAdminManager } from './adminOnly'
 
 // ============================================================================
 // HELPER FUNCTIONS (public API - consolidated from projects.ts and data.ts)

--- a/tests/int/role-based-access.int.spec.ts
+++ b/tests/int/role-based-access.int.spec.ts
@@ -1,11 +1,15 @@
 import type { Payload, PayloadRequest } from 'payload'
 
+import fs from 'fs'
+import path from 'path'
 import { describe, it, beforeAll, afterAll, expect } from 'vitest'
 
 import { bypassPermissions, hasAnyPermission, hasPermission } from '@/lib/access'
 
 import { createTestLexicalContent, testData } from '../utils/testData'
 import { createTestEnvironment } from '../utils/testHelpers'
+
+const SAMPLE_FILES_DIR = path.join(__dirname, '../files')
 
 function createTrustedPreviewRequest(
   payload: Payload,
@@ -1090,6 +1094,160 @@ describe('Role-Based Access Control', () => {
 
       const narratorIds = clientNarrators.docs.map((doc) => doc.id)
       expect(narratorIds).toContain(narrator.id)
+    })
+  })
+
+  describe('Meditation Categories (meditation-tags) Access', () => {
+    it('grants meditations-editor update access but not create or delete on meditation-tags', () => {
+      const editorUser = testData.dummyUser('managers', {
+        id: 200,
+        roles: ['meditations-editor'],
+      })
+
+      // Implicit read via wemeditate-app project membership
+      expect(
+        hasPermission(
+          { user: editorUser, collection: 'meditation-tags', operation: 'read' },
+          bypassPermissions,
+        ),
+      ).toBe(true)
+
+      // Explicit update
+      expect(
+        hasPermission(
+          { user: editorUser, collection: 'meditation-tags', operation: 'update' },
+          bypassPermissions,
+        ),
+      ).toBe(true)
+
+      // No create or delete — editors can only edit existing tag assignments
+      expect(
+        hasPermission(
+          { user: editorUser, collection: 'meditation-tags', operation: 'create' },
+          bypassPermissions,
+        ),
+      ).toBe(false)
+      expect(
+        hasPermission(
+          { user: editorUser, collection: 'meditation-tags', operation: 'delete' },
+          bypassPermissions,
+        ),
+      ).toBe(false)
+    })
+
+    it('allows meditations-editor to update per-timing meditation fields but strips edits to other fields', async () => {
+      // Seed tag with known admin-authored values
+      const tag = await testData.createMeditationTag(payload, {
+        title: 'Original Category Title',
+        color: '#AA0000',
+        order: 5,
+        isFeatured: true,
+        timings: ['morning'],
+      })
+
+      const meditation = await testData.createMeditation(payload, undefined, {
+        label: 'Seed Morning Meditation',
+        locale: 'en',
+        type: 'quick',
+      })
+
+      const editor = await testData.createManager(payload, {
+        name: 'Editor for Field-Level Access Test',
+        roles: { en: ['meditations-editor'] },
+      })
+
+      // Editor attempts to change title/color/order AND set morningMeditation.
+      // Field-level access should silently drop the non-allowed edits.
+      await payload.update({
+        collection: 'meditation-tags',
+        id: tag.id,
+        data: {
+          morningMeditation: meditation.id,
+          title: 'Hijacked Title',
+          color: '#00FF00',
+          order: 99,
+          isFeatured: false,
+        },
+        user: { ...editor, collection: 'managers' },
+        overrideAccess: false,
+      })
+
+      const updated = await payload.findByID({
+        collection: 'meditation-tags',
+        id: tag.id,
+        depth: 0,
+      })
+
+      // Allowed: morningMeditation updated
+      expect(updated.morningMeditation).toBe(meditation.id)
+
+      // Blocked: admin-authored fields unchanged
+      expect(updated.title).toBe('Original Category Title')
+      expect(updated.color).toBe('#AA0000')
+      expect(updated.order).toBe(5)
+      expect(updated.isFeatured).toBe(true)
+    })
+
+    it('allows admin managers to update any field on meditation-tags', async () => {
+      const tag = await testData.createMeditationTag(payload, {
+        title: 'Admin-Editable Tag',
+        color: '#112233',
+        order: 10,
+      })
+
+      const admin = await testData.createManager(payload, {
+        name: 'Admin for Field-Level Access Test',
+        type: 'admin' as const,
+      })
+
+      await payload.update({
+        collection: 'meditation-tags',
+        id: tag.id,
+        data: {
+          title: 'Updated by Admin',
+          color: '#445566',
+          order: 20,
+        },
+        user: { ...admin, collection: 'managers' },
+        overrideAccess: false,
+      })
+
+      const updated = await payload.findByID({
+        collection: 'meditation-tags',
+        id: tag.id,
+        depth: 0,
+      })
+
+      expect(updated.title).toBe('Updated by Admin')
+      expect(updated.color).toBe('#445566')
+      expect(updated.order).toBe(20)
+    })
+
+    it('blocks meditations-editor from replacing the uploaded icon', async () => {
+      const tag = await testData.createMeditationTag(payload, { title: 'Locked Icon Tag' })
+
+      const editor = await testData.createManager(payload, {
+        name: 'Editor for Icon Replace Block Test',
+        roles: { en: ['meditations-editor'] },
+      })
+
+      const replacementBuffer = fs.readFileSync(path.join(SAMPLE_FILES_DIR, 'icon-test.svg'))
+
+      await expect(
+        payload.update({
+          collection: 'meditation-tags',
+          id: tag.id,
+          data: {},
+          file: {
+            data: replacementBuffer,
+            mimetype: 'image/svg+xml',
+            name: 'replacement.svg',
+            size: replacementBuffer.length,
+          },
+          user: { ...editor, collection: 'managers' },
+          overrideAccess: false,
+        }),
+      ).rejects.toThrow(/Only admins can replace the icon/)
     })
   })
 })


### PR DESCRIPTION
## Summary

- Grants `meditations-editor` role `update` access on `meditation-tags` so editors can see "Meditation Categories" in the sidebar and assign per-timing meditations.
- Restricts field-level updates on `meditation-tags` to admin managers for every field except `morning/afternoon/evening/nightMeditation` — so editors can only change the per-timing meditation assignments; title, slug, color, parent, order, featured, timings, and `isParent` stay admin-only.
- Blocks non-admin managers from replacing the uploaded SVG icon via a `beforeChange` hook (field-level access can't cover `req.file`).
- Extends `colorField` factory with an `access` option so field-level access can be passed through without type-hostile spread gymnastics.

## Test Results
- Integration tests: **545 passed** (excluding the always-flaky `access-performance.int.spec.ts` CPU-bound benchmarks that pass in isolation)
- Unit tests: **221 passed**
- `meditation-tags` + `role-based-access` suites (post-change): **64 passed**
- Build: ✓ Success
- Lint: ✓ No warnings or errors

## Notes

- `meditations-editor` intentionally does **not** get `create` or `delete` on `meditation-tags`. Creating requires admin-only fields (title/color/icon), and delete risks orphaning meditations that reference a tag.
- The previously inline admin-only update on the `timings` field was refactored to reuse the new shared `adminOnlyUpdate` helper — same behavior.

Closes #306

🤖 Generated with [Claude Code](https://claude.com/claude-code)