### PR TITLE
fix(storage): align R2 filenames before upload

### DIFF
--- a/scripts/repair-r2-meditation-filenames.ts
+++ b/scripts/repair-r2-meditation-filenames.ts
@@ -1,0 +1,410 @@
+#!/usr/bin/env tsx
+/* eslint-disable no-console */
+/**
+ * Reconcile production meditation filenames with the actual R2 object keys.
+ *
+ * Dry run:
+ *   pnpm tsx scripts/repair-r2-meditation-filenames.ts
+ *
+ * Apply updates:
+ *   pnpm tsx scripts/repair-r2-meditation-filenames.ts --force
+ *
+ * R2 listing uses the configured Wrangler remote R2 binding by default.
+ * If that is unavailable, the script falls back to S3-compatible R2 env vars:
+ *   CLOUDFLARE_ACCOUNT_ID
+ *   CLOUDFLARE_R2_ACCESS_KEY_ID
+ *   CLOUDFLARE_R2_SECRET_ACCESS_KEY
+ *
+ * D1 reads/updates use the local Wrangler auth context.
+ */
+import { execFileSync } from 'child_process'
+import { mkdtempSync, writeFileSync } from 'fs'
+import { tmpdir } from 'os'
+import path from 'path'
+import { fileURLToPath } from 'url'
+
+import { ListObjectsV2Command, S3Client } from '@aws-sdk/client-s3'
+import { config as loadEnv } from 'dotenv'
+import slugify from 'slugify'
+
+const PROJECT_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
+
+loadEnv({ path: path.join(PROJECT_ROOT, '.env.local') })
+
+const D1_DATABASE = process.env.D1_DATABASE || 'sahajcloud'
+const R2_BUCKET = process.env.R2_BUCKET || 'sahajcloud'
+const AUDIO_EXTENSIONS = new Set(['.aac', '.mp3', '.ogg'])
+
+interface MeditationRow {
+  filesize: number | null
+  id: number
+  label: string | null
+  filename: string
+}
+
+interface R2AudioObject {
+  key: string
+  size?: number
+  uploaded?: string
+}
+
+interface RepairCandidate {
+  id: number
+  label: string | null
+  currentFilename: string
+  r2Key: string
+}
+
+interface PlatformProxy {
+  env?: Record<string, unknown>
+  dispose?: () => Promise<void>
+}
+
+interface R2BucketBinding {
+  list: (options?: { cursor?: string; limit?: number }) => Promise<{
+    cursor?: string
+    objects: Array<{ key: string; size?: number; uploaded?: Date | string }>
+    truncated: boolean
+  }>
+}
+
+const hasFlag = (flag: string): boolean => process.argv.includes(flag)
+
+const sqlString = (value: string): string => `'${value.replaceAll("'", "''")}'`
+
+const GENERATED_SUFFIX_PATTERN = /-([a-z0-9]{6})$/i
+const DURATION_TOKEN_PATTERN = /^\d{1,3}mins?$/i
+
+const requireEnv = (name: string): string => {
+  const value = process.env[name]
+  if (!value) {
+    throw new Error(`Missing required environment variable: ${name}`)
+  }
+  return value
+}
+
+const normalizeForMatch = (filename: string): string => {
+  const ext = path.extname(filename).toLowerCase()
+  const base = path.basename(filename, ext)
+  const withoutGeneratedSuffix = base.replace(GENERATED_SUFFIX_PATTERN, (match, suffix: string) =>
+    DURATION_TOKEN_PATTERN.test(suffix) ? match : '',
+  )
+  const slug = slugify(withoutGeneratedSuffix, { lower: true, strict: true })
+  return `${slug}${ext}`
+}
+
+const extractRowsFromWranglerJson = (output: string): MeditationRow[] => {
+  const parsed = JSON.parse(output) as unknown
+  const wrappers = Array.isArray(parsed) ? parsed : [parsed]
+  const rows: MeditationRow[] = []
+
+  for (const wrapper of wrappers) {
+    if (
+      typeof wrapper === 'object' &&
+      wrapper !== null &&
+      'results' in wrapper &&
+      Array.isArray(wrapper.results)
+    ) {
+      rows.push(...(wrapper.results as MeditationRow[]))
+    }
+  }
+
+  return rows
+}
+
+const getMeditationRows = (): MeditationRow[] => {
+  const output = execFileSync(
+    'pnpm',
+    [
+      'exec',
+      'wrangler',
+      'd1',
+      'execute',
+      D1_DATABASE,
+      '--remote',
+      '--json',
+      '--command',
+      'SELECT id, label, filename, filesize FROM meditations WHERE filename IS NOT NULL ORDER BY id;',
+    ],
+    { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] },
+  )
+
+  return extractRowsFromWranglerJson(output).filter(
+    (row): row is MeditationRow =>
+      typeof row.id === 'number' && typeof row.filename === 'string' && row.filename.length > 0,
+  )
+}
+
+const createR2Client = (): S3Client => {
+  const accountId = requireEnv('CLOUDFLARE_ACCOUNT_ID')
+  return new S3Client({
+    region: 'auto',
+    endpoint: `https://${accountId}.eu.r2.cloudflarestorage.com`,
+    credentials: {
+      accessKeyId: requireEnv('CLOUDFLARE_R2_ACCESS_KEY_ID'),
+      secretAccessKey: requireEnv('CLOUDFLARE_R2_SECRET_ACCESS_KEY'),
+    },
+  })
+}
+
+const listR2AudioObjectsWithS3 = async (): Promise<R2AudioObject[]> => {
+  const client = createR2Client()
+  const objects: R2AudioObject[] = []
+  let continuationToken: string | undefined
+
+  do {
+    const response = await client.send(
+      new ListObjectsV2Command({
+        Bucket: R2_BUCKET,
+        ContinuationToken: continuationToken,
+        MaxKeys: 1000,
+      }),
+    )
+
+    for (const object of response.Contents ?? []) {
+      if (!object.Key) continue
+      if (AUDIO_EXTENSIONS.has(path.extname(object.Key).toLowerCase())) {
+        objects.push({
+          key: object.Key,
+          size: object.Size,
+          uploaded: object.LastModified?.toISOString(),
+        })
+      }
+    }
+
+    continuationToken = response.NextContinuationToken
+  } while (continuationToken)
+
+  return objects
+}
+
+const listR2AudioObjectsWithPlatformProxy = async (): Promise<R2AudioObject[]> => {
+  const { getPlatformProxy } = (await import('wrangler')) as {
+    getPlatformProxy: (options: { remoteBindings: boolean }) => Promise<PlatformProxy>
+  }
+
+  const proxy = await getPlatformProxy({ remoteBindings: true })
+
+  try {
+    const bucket = proxy.env?.R2 as R2BucketBinding | undefined
+    if (!bucket?.list) {
+      throw new Error('Wrangler platform proxy did not provide an R2 binding named "R2".')
+    }
+
+    const objects: R2AudioObject[] = []
+    let cursor: string | undefined
+
+    do {
+      const result = await bucket.list({ cursor, limit: 1000 })
+
+      for (const object of result.objects) {
+        if (AUDIO_EXTENSIONS.has(path.extname(object.key).toLowerCase())) {
+          objects.push({
+            key: object.key,
+            size: object.size,
+            uploaded: object.uploaded ? String(object.uploaded) : undefined,
+          })
+        }
+      }
+
+      cursor = result.truncated ? result.cursor : undefined
+    } while (cursor)
+
+    return objects
+  } finally {
+    await proxy.dispose?.()
+  }
+}
+
+const listR2AudioObjects = async (): Promise<R2AudioObject[]> => {
+  try {
+    return await listR2AudioObjectsWithPlatformProxy()
+  } catch (error) {
+    console.warn(
+      `Wrangler R2 binding listing failed; falling back to S3 credentials: ${error instanceof Error ? error.message : String(error)}`,
+    )
+  }
+
+  try {
+    return await listR2AudioObjectsWithS3()
+  } catch (error) {
+    throw new Error(
+      `Unable to list R2 objects with Wrangler binding or S3 credentials. Check Wrangler login and/or CLOUDFLARE_R2_ACCESS_KEY_ID/CLOUDFLARE_R2_SECRET_ACCESS_KEY in .env.local. Last error: ${error instanceof Error ? error.message : String(error)}`,
+    )
+  }
+}
+
+const buildR2MatchIndex = (objects: R2AudioObject[]): Map<string, R2AudioObject[]> => {
+  const index = new Map<string, R2AudioObject[]>()
+
+  for (const object of objects) {
+    const normalized = normalizeForMatch(object.key)
+    const matches = index.get(normalized) ?? []
+    matches.push(object)
+    index.set(normalized, matches)
+  }
+
+  return index
+}
+
+const formatR2Object = (object: R2AudioObject): string =>
+  [
+    object.key,
+    typeof object.size === 'number' ? `size=${object.size}` : undefined,
+    object.uploaded ? `uploaded=${object.uploaded}` : undefined,
+  ]
+    .filter(Boolean)
+    .join(' ')
+
+const selectMatch = (row: MeditationRow, matches: R2AudioObject[]): R2AudioObject[] => {
+  if (row.filesize == null || matches.length <= 1) return matches
+
+  const sizeMatches = matches.filter((match) => match.size === row.filesize)
+  return sizeMatches.length > 0 ? sizeMatches : matches
+}
+
+const findRepairCandidates = (
+  rows: MeditationRow[],
+  r2Objects: R2AudioObject[],
+): RepairCandidate[] => {
+  const r2KeySet = new Set(r2Objects.map((object) => object.key))
+  const r2MatchIndex = buildR2MatchIndex(r2Objects)
+  const dbFilenameOwners = new Map(rows.map((row) => [row.filename, row.id]))
+  const candidates: RepairCandidate[] = []
+  const missingRows: MeditationRow[] = []
+
+  let alreadyValid = 0
+  let ambiguous = 0
+  let missing = 0
+  let conflicts = 0
+
+  for (const row of rows) {
+    if (r2KeySet.has(row.filename)) {
+      alreadyValid += 1
+      continue
+    }
+
+    const matches = r2MatchIndex.get(normalizeForMatch(row.filename)) ?? []
+
+    if (matches.length === 0) {
+      missing += 1
+      missingRows.push(row)
+      continue
+    }
+
+    const selectedMatches = selectMatch(row, matches)
+
+    if (selectedMatches.length > 1) {
+      ambiguous += 1
+      console.warn(
+        `Ambiguous R2 match for meditation ${row.id} (${row.filename}, filesize=${row.filesize ?? 'unknown'}):`,
+      )
+      for (const match of matches) console.warn(`  - ${formatR2Object(match)}`)
+      continue
+    }
+
+    const r2Key = selectedMatches[0].key
+    const owner = dbFilenameOwners.get(r2Key)
+    if (owner !== undefined && owner !== row.id) {
+      conflicts += 1
+      console.warn(
+        `Skipping meditation ${row.id}: matched R2 key already belongs to meditation ${owner}: ${r2Key}`,
+      )
+      continue
+    }
+
+    candidates.push({
+      id: row.id,
+      label: row.label,
+      currentFilename: row.filename,
+      r2Key,
+    })
+  }
+
+  console.log(`Meditations checked: ${rows.length}`)
+  console.log(`Already valid: ${alreadyValid}`)
+  console.log(`Repair candidates: ${candidates.length}`)
+  console.log(`Missing R2 match: ${missing}`)
+  console.log(`Ambiguous R2 match: ${ambiguous}`)
+  console.log(`Conflicts: ${conflicts}`)
+
+  if (missingRows.length > 0) {
+    console.log('\nMissing R2 matches:')
+    for (const row of missingRows.slice(0, 25)) {
+      console.log(
+        `- #${row.id} ${row.label ?? '(untitled)'}\n  ${row.filename}\n  normalized=${normalizeForMatch(row.filename)} filesize=${row.filesize ?? 'unknown'}`,
+      )
+    }
+    if (missingRows.length > 25) {
+      console.log(`...and ${missingRows.length - 25} more`)
+    }
+  }
+
+  return candidates
+}
+
+const printCandidates = (candidates: RepairCandidate[]): void => {
+  for (const candidate of candidates.slice(0, 25)) {
+    console.log(
+      `- #${candidate.id} ${candidate.label ?? '(untitled)'}\n  ${candidate.currentFilename}\n  -> ${candidate.r2Key}`,
+    )
+  }
+
+  if (candidates.length > 25) {
+    console.log(`...and ${candidates.length - 25} more`)
+  }
+}
+
+const applyCandidates = (candidates: RepairCandidate[]): void => {
+  const tempDir = mkdtempSync(path.join(tmpdir(), 'r2-meditation-repair-'))
+  const sqlPath = path.join(tempDir, 'repair.sql')
+  const statements = [
+    'PRAGMA foreign_keys=OFF;',
+    ...candidates.flatMap((candidate) => [
+      `UPDATE meditations SET filename = ${sqlString(candidate.r2Key)} WHERE id = ${candidate.id} AND filename = ${sqlString(candidate.currentFilename)};`,
+      `UPDATE _meditations_v SET version_filename = ${sqlString(candidate.r2Key)} WHERE parent_id = ${candidate.id} AND version_filename = ${sqlString(candidate.currentFilename)};`,
+    ]),
+    'PRAGMA foreign_keys=ON;',
+  ]
+
+  writeFileSync(sqlPath, statements.join('\n'))
+
+  console.warn(
+    `Applying ${candidates.length} production D1 filename repairs to ${D1_DATABASE}. This is irreversible except by another SQL update.`,
+  )
+  execFileSync(
+    'pnpm',
+    ['exec', 'wrangler', 'd1', 'execute', D1_DATABASE, '--remote', '--file', sqlPath],
+    {
+      stdio: 'inherit',
+    },
+  )
+}
+
+async function main(): Promise<void> {
+  const force = hasFlag('--force')
+
+  console.log(`D1 database: ${D1_DATABASE}`)
+  console.log(`R2 bucket: ${R2_BUCKET}`)
+  console.log(force ? 'Mode: apply (--force)' : 'Mode: dry run')
+
+  const rows = getMeditationRows()
+  const r2Objects = await listR2AudioObjects()
+  const candidates = findRepairCandidates(rows, r2Objects)
+
+  if (candidates.length === 0) return
+
+  printCandidates(candidates)
+
+  if (!force) {
+    console.log('\nDry run only. Re-run with --force to apply these D1 updates.')
+    return
+  }
+
+  applyCandidates(candidates)
+}
+
+main().catch((error) => {
+  console.error(error)
+  process.exit(1)
+})

--- a/src/lib/storage/r2FilenameHook.ts
+++ b/src/lib/storage/r2FilenameHook.ts
@@ -1,0 +1,39 @@
+import type { CollectionBeforeOperationHook } from 'payload'
+
+import { generateR2Key } from './filenameUtils'
+import { getMimeCategory } from './mimeUtils'
+
+export const R2_PREASSIGNED_FILENAME_CONTEXT_KEY = '_r2PreassignedFilename'
+
+type R2FilenameMode = 'always' | 'other-only'
+
+const shouldPreassignFilename = (mode: R2FilenameMode, mimeType: string | undefined): boolean =>
+  mode === 'always' || getMimeCategory(mimeType) === 'other'
+
+/**
+ * Assign the final R2 object key before Payload generates upload metadata.
+ *
+ * Payload writes `filename` to the document before the cloud-storage adapter's
+ * `afterChange` upload runs. Preassigning here keeps the DB row and R2 object
+ * key aligned even if the plugin's follow-up metadata update is skipped/fails.
+ */
+export const createR2FilenameBeforeOperationHook = (
+  mode: R2FilenameMode,
+): CollectionBeforeOperationHook => {
+  return ({ args, operation }) => {
+    if (operation !== 'create' && operation !== 'update') return args
+
+    const file = args.req?.file
+    if (!file?.name || !shouldPreassignFilename(mode, file.mimetype)) {
+      return args
+    }
+
+    file.name = generateR2Key(file.name)
+    args.req.context = {
+      ...(args.req.context ?? {}),
+      [R2_PREASSIGNED_FILENAME_CONTEXT_KEY]: true,
+    }
+
+    return args
+  }
+}

--- a/src/lib/storage/r2NativeAdapter.ts
+++ b/src/lib/storage/r2NativeAdapter.ts
@@ -11,6 +11,7 @@ import type { Adapter } from '@payloadcms/plugin-cloud-storage/types'
 import { serverEnv } from '@/lib/env'
 
 import { applyFilename, generateR2Key } from './filenameUtils'
+import { R2_PREASSIGNED_FILENAME_CONTEXT_KEY } from './r2FilenameHook'
 
 /**
  * Get R2 storage URL for a filename
@@ -59,7 +60,8 @@ export const r2NativeAdapter = (config: R2NativeConfig): Adapter => {
 
     handleUpload: async ({ data, file, req }) => {
       try {
-        const finalFilename = generateR2Key(file.filename)
+        const filenamePreassigned = Boolean(req.context?.[R2_PREASSIGNED_FILENAME_CONTEXT_KEY])
+        const finalFilename = filenamePreassigned ? file.filename : generateR2Key(file.filename)
 
         applyFilename(file, data, req, finalFilename)
 

--- a/src/lib/storage/storagePlugin.ts
+++ b/src/lib/storage/storagePlugin.ts
@@ -20,6 +20,7 @@ import { requireBinding, serverEnv } from '@/lib/env'
 import { cloudflareImagesAdapter } from './cloudflareImagesAdapter'
 import { cloudflareStreamAdapter } from './cloudflareStreamAdapter'
 import { mixedMediaAdapter } from './mixedMediaAdapter'
+import { createR2FilenameBeforeOperationHook } from './r2FilenameHook'
 import { r2NativeAdapter } from './r2NativeAdapter'
 
 interface StoragePluginOptions {
@@ -34,6 +35,20 @@ interface StoragePluginOptions {
    * @default true
    */
   enabled?: boolean
+}
+
+const r2FilenameHooks = {
+  always: createR2FilenameBeforeOperationHook('always'),
+  'other-only': createR2FilenameBeforeOperationHook('other-only'),
+}
+
+const r2FilenameHookModes: Record<string, keyof typeof r2FilenameHooks> = {
+  frames: 'other-only',
+  files: 'other-only',
+  'meditation-tags': 'always',
+  'song-tags': 'always',
+  meditations: 'always',
+  songs: 'always',
 }
 
 /**
@@ -95,6 +110,22 @@ export const storagePlugin = (options: StoragePluginOptions = {}): Plugin => {
       bucket: r2Bucket,
       publicUrl: serverEnv.CLOUDFLARE_R2_DELIVERY_URL || '',
     })
+
+    const configWithR2FilenameHooks = {
+      ...config,
+      collections: config.collections?.map((collection) => {
+        const mode = r2FilenameHookModes[collection.slug]
+        if (!mode) return collection
+
+        return {
+          ...collection,
+          hooks: {
+            ...collection.hooks,
+            beforeOperation: [...(collection.hooks?.beforeOperation ?? []), r2FilenameHooks[mode]],
+          },
+        }
+      }),
+    }
 
     // Return a single cloudStoragePlugin with all adapters configured
     return cloudStoragePlugin({
@@ -165,6 +196,6 @@ export const storagePlugin = (options: StoragePluginOptions = {}): Plugin => {
           disablePayloadAccessControl: true,
         },
       },
-    })(config)
+    })(configWithR2FilenameHooks)
   }
 }

--- a/tests/int/storage-utils.int.spec.ts
+++ b/tests/int/storage-utils.int.spec.ts
@@ -13,6 +13,10 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 
 import { generateCloudflareImageId, generateR2Key } from '@/lib/storage/filenameUtils'
 import { getMimeCategory } from '@/lib/storage/mimeUtils'
+import {
+  createR2FilenameBeforeOperationHook,
+  R2_PREASSIGNED_FILENAME_CONTEXT_KEY,
+} from '@/lib/storage/r2FilenameHook'
 
 // Helper to extract the afterRead hook from a field
 const getAfterReadHook = (field: Field): FieldHook | undefined => {
@@ -534,6 +538,57 @@ describe('Filename Utilities', () => {
   })
 })
 
+describe('R2 filename preassignment hook', () => {
+  const callR2Hook = async (
+    mode: 'always' | 'other-only',
+    req: Record<string, unknown>,
+    operation: 'create' | 'update' = 'create',
+  ) => {
+    const hook = createR2FilenameBeforeOperationHook(mode)
+    const args = { req }
+    const result = await hook({ args, operation } as never)
+    return { args, result }
+  }
+
+  it('preassigns a generated R2 key before Payload derives upload metadata', async () => {
+    const req = {
+      file: {
+        name: 'Ready to Upload -- Meditation -- Path Step 18.mp3',
+        mimetype: 'audio/mpeg',
+      },
+    }
+
+    const { args, result } = await callR2Hook('always', req)
+
+    expect(req.file.name).toMatch(/^ready-to-upload-meditation-path-step-18-[a-z0-9]{6}\.mp3$/)
+    expect(req).toHaveProperty(['context', R2_PREASSIGNED_FILENAME_CONTEXT_KEY], true)
+    expect(result).toBe(args)
+  })
+
+  it('only preassigns other-file keys for mixed media collections', async () => {
+    const imageReq = {
+      file: {
+        name: 'Hero Image.png',
+        mimetype: 'image/png',
+      },
+    }
+    const audioReq = {
+      file: {
+        name: 'Intro Audio.mp3',
+        mimetype: 'audio/mpeg',
+      },
+    }
+
+    await callR2Hook('other-only', imageReq)
+    await callR2Hook('other-only', audioReq)
+
+    expect(imageReq.file.name).toBe('Hero Image.png')
+    expect(imageReq).not.toHaveProperty('context')
+    expect(audioReq.file.name).toMatch(/^intro-audio-[a-z0-9]{6}\.mp3$/)
+    expect(audioReq).toHaveProperty(['context', R2_PREASSIGNED_FILENAME_CONTEXT_KEY], true)
+  })
+})
+
 describe('Storage Adapter handleUpload', () => {
   const originalEnv = process.env
   const originalFetch = globalThis.fetch
@@ -565,6 +620,7 @@ describe('Storage Adapter handleUpload', () => {
       },
     },
     file: { name: 'original-input.jpg' },
+    context: {} as Record<string, unknown>,
   })
 
   const makeImageFile = (filename = 'lecture-thumbnail-167289004.jpg') => ({
@@ -743,11 +799,48 @@ describe('Storage Adapter handleUpload', () => {
         collection: { slug: 'meditations' } as never,
       })
 
-      expect(result).toMatchObject({ filename: expect.stringMatching(/^my-audio-1-[a-z0-9]{6}\.mp3$/) })
+      expect(result).toMatchObject({
+        filename: expect.stringMatching(/^my-audio-1-[a-z0-9]{6}\.mp3$/),
+      })
       expect(put).toHaveBeenCalledOnce()
       const [key] = put.mock.calls[0]
       expect(key).toBe(`meditations/${(result as { filename: string }).filename}`)
       expect(data.filename).toBe((result as { filename: string }).filename)
+    })
+
+    it('reuses a preassigned R2 key instead of appending a second suffix', async () => {
+      const { r2NativeAdapter } = await import('@/lib/storage/r2NativeAdapter')
+
+      const put = vi.fn().mockResolvedValue(null)
+      const bucket = { put } as unknown as R2Bucket
+
+      const adapter = r2NativeAdapter({
+        bucket,
+        publicUrl: 'https://assets.test',
+      })({ collection: { slug: 'meditations' } as never, prefix: 'meditations' })
+
+      const data: Record<string, unknown> = {}
+      const file = {
+        filename: 'my-audio-1-abc123.mp3',
+        buffer: Buffer.from([0x00, 0x01]),
+        mimeType: 'audio/mpeg',
+        filesize: 2,
+      }
+      const req = makeReq()
+      req.context[R2_PREASSIGNED_FILENAME_CONTEXT_KEY] = true
+
+      const result = await adapter.handleUpload({
+        data,
+        file: file as never,
+        req: req as never,
+        clientUploadContext: undefined,
+        collection: { slug: 'meditations' } as never,
+      })
+
+      expect(result).toEqual({ filename: 'my-audio-1-abc123.mp3' })
+      expect(put).toHaveBeenCalledOnce()
+      expect(put.mock.calls[0][0]).toBe('meditations/my-audio-1-abc123.mp3')
+      expect(data.filename).toBe('my-audio-1-abc123.mp3')
     })
   })
 


### PR DESCRIPTION
## Summary
- Preassign final R2 object keys before Payload generates upload metadata, keeping CMS filenames aligned with R2 keys.
- Reuse preassigned R2 keys in the native adapter to avoid appending a second random suffix.
- Add a dry-run-first repair script for existing production meditation filename mismatches.
- Add integration coverage for preassignment and adapter behavior.

## Repair Script Dry Run
- Command: `pnpm tsx scripts/repair-r2-meditation-filenames.ts`
- Meditations checked: 89
- Already valid: 76
- Repair candidates: 13
- Missing R2 match: 0
- Ambiguous R2 match: 0
- Conflicts: 0

## Test Results
- Lint: ✓ `pnpm lint`
- Type check: ✓ `pnpm tsc --noEmit`
- Unit tests: 221 passed
- Integration tests: 578 passed
- Build: ✓ `pnpm build`