### PR TITLE
fix(admin): preserve frame editor playhead across tab switches

### DIFF
--- a/src/components/admin/FrameEditor/hooks.ts
+++ b/src/components/admin/FrameEditor/hooks.ts
@@ -6,24 +6,29 @@ import useSWR from 'swr'
 
 import type { Frame } from '@/payload-types'
 
+import {
+  getCachedPlaybackTime,
+  subscribePlaybackTime,
+} from './playbackTimeStore'
+
 /**
- * Hook to listen for playback time updates from the live preview iframe
- * Receives PLAYBACK_TIME_UPDATE messages via PostMessage API
+ * Hook to listen for playback time updates from the live preview iframe.
+ *
+ * Backed by a module-level singleton ([playbackTimeStore]) so the cached
+ * value survives component remounts — required because the Frames /
+ * Add New tabs each render in their own subtree and unmount when
+ * inactive. Without the singleton, switching tabs while audio was paused
+ * would reset the playhead state to 0.
  */
 export const usePlaybackTime = (): number => {
-  const [currentPlaybackTime, setCurrentPlaybackTime] = useState(0)
+  const [time, setTime] = useState<number>(getCachedPlaybackTime)
 
   useEffect(() => {
-    const handleMessage = (event: MessageEvent) => {
-      if (event.data?.type === 'PLAYBACK_TIME_UPDATE') {
-        setCurrentPlaybackTime(event.data.currentTime)
-      }
-    }
-    window.addEventListener('message', handleMessage)
-    return () => window.removeEventListener('message', handleMessage)
+    setTime(getCachedPlaybackTime())
+    return subscribePlaybackTime(setTime)
   }, [])
 
-  return currentPlaybackTime
+  return time
 }
 
 /**

--- a/src/components/admin/FrameEditor/playbackTimeStore.ts
+++ b/src/components/admin/FrameEditor/playbackTimeStore.ts
@@ -1,0 +1,58 @@
+/**
+ * Module-level store for the live-preview playback time.
+ *
+ * The PayloadCMS admin renders the FrameEditor's "Frames" and "Add New"
+ * tabs as siblings inside a tabs field; switching tabs unmounts the
+ * inactive subtree. Without a shared store, each remount resets local
+ * React state to 0, so a frame inserted while audio was paused would
+ * land at 0:00 instead of the current playhead.
+ *
+ * The store keeps the latest `PLAYBACK_TIME_UPDATE` value cached at
+ * module scope and fans it out to all subscribers. The window listener
+ * is attached lazily on first subscribe and then left attached for the
+ * lifetime of the document — it's a UI singleton, not a leak.
+ */
+
+type Subscriber = (time: number) => void
+
+let cachedPlaybackTime = 0
+const subscribers = new Set<Subscriber>()
+let listenerAttached = false
+
+const handleMessage = (event: MessageEvent): void => {
+  if (event.data?.type !== 'PLAYBACK_TIME_UPDATE') return
+  const next = event.data.currentTime
+  if (typeof next !== 'number' || !Number.isFinite(next)) return
+  cachedPlaybackTime = next
+  subscribers.forEach((cb) => cb(next))
+}
+
+const ensureListener = (): void => {
+  if (listenerAttached) return
+  if (typeof window === 'undefined') return
+  listenerAttached = true
+  window.addEventListener('message', handleMessage)
+}
+
+export const getCachedPlaybackTime = (): number => cachedPlaybackTime
+
+export const subscribePlaybackTime = (cb: Subscriber): (() => void) => {
+  ensureListener()
+  subscribers.add(cb)
+  return () => {
+    subscribers.delete(cb)
+  }
+}
+
+/**
+ * Test-only reset hook. Not exported from any barrel — accessed by
+ * tests via the direct module path.
+ */
+export const __resetPlaybackTimeStoreForTests = (): void => {
+  cachedPlaybackTime = 0
+  subscribers.clear()
+  if (listenerAttached && typeof window !== 'undefined') {
+    window.removeEventListener('message', handleMessage)
+  }
+  listenerAttached = false
+}

--- a/tests/unit/playbackTimeStore.spec.ts
+++ b/tests/unit/playbackTimeStore.spec.ts
@@ -1,0 +1,132 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Tests for the FrameEditor playback-time singleton.
+ *
+ * The store backs `usePlaybackTime` and must survive component remounts
+ * so a frame inserted while audio is paused (after a tab switch) lands
+ * at the actual playhead, not 0:00 — the bug from #328.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  __resetPlaybackTimeStoreForTests,
+  getCachedPlaybackTime,
+  subscribePlaybackTime,
+} from '@/components/admin/FrameEditor/playbackTimeStore'
+
+const dispatchPlaybackUpdate = (currentTime: unknown) => {
+  window.dispatchEvent(
+    new MessageEvent('message', {
+      data: { type: 'PLAYBACK_TIME_UPDATE', currentTime },
+    }),
+  )
+}
+
+describe('playbackTimeStore', () => {
+  beforeEach(() => {
+    __resetPlaybackTimeStoreForTests()
+  })
+
+  afterEach(() => {
+    __resetPlaybackTimeStoreForTests()
+  })
+
+  it('starts with cached time of 0', () => {
+    expect(getCachedPlaybackTime()).toBe(0)
+  })
+
+  it('updates the cached time when a PLAYBACK_TIME_UPDATE message arrives', () => {
+    const cb = vi.fn()
+    subscribePlaybackTime(cb)
+
+    dispatchPlaybackUpdate(90)
+
+    expect(getCachedPlaybackTime()).toBe(90)
+    expect(cb).toHaveBeenCalledExactlyOnceWith(90)
+  })
+
+  it('preserves the cached time across "remounts" (subscribe → unsubscribe → resubscribe)', () => {
+    const firstSubscriber = vi.fn()
+    const unsubscribe = subscribePlaybackTime(firstSubscriber)
+    dispatchPlaybackUpdate(45)
+    unsubscribe()
+
+    // Simulate the tab-switch case from #328: the first component
+    // unmounts, audio is paused (no more messages), then a sibling
+    // component mounts. It must see the last known playhead.
+    const secondSubscriber = vi.fn()
+    subscribePlaybackTime(secondSubscriber)
+
+    expect(getCachedPlaybackTime()).toBe(45)
+  })
+
+  it('stops notifying a subscriber after unsubscribe', () => {
+    const cb = vi.fn()
+    const unsubscribe = subscribePlaybackTime(cb)
+    dispatchPlaybackUpdate(10)
+    expect(cb).toHaveBeenCalledExactlyOnceWith(10)
+
+    unsubscribe()
+    dispatchPlaybackUpdate(20)
+    expect(cb).toHaveBeenCalledTimes(1)
+    expect(getCachedPlaybackTime()).toBe(20)
+  })
+
+  it('fans updates out to multiple subscribers', () => {
+    const a = vi.fn()
+    const b = vi.fn()
+    subscribePlaybackTime(a)
+    subscribePlaybackTime(b)
+
+    dispatchPlaybackUpdate(7)
+
+    expect(a).toHaveBeenCalledExactlyOnceWith(7)
+    expect(b).toHaveBeenCalledExactlyOnceWith(7)
+  })
+
+  it('ignores unrelated message types (e.g. payload-live-preview traffic)', () => {
+    const cb = vi.fn()
+    subscribePlaybackTime(cb)
+
+    window.dispatchEvent(
+      new MessageEvent('message', {
+        data: { type: 'payload-live-preview', ready: true },
+      }),
+    )
+    window.dispatchEvent(
+      new MessageEvent('message', { data: 'string-payload' }),
+    )
+    window.dispatchEvent(new MessageEvent('message', { data: null }))
+
+    expect(cb).not.toHaveBeenCalled()
+    expect(getCachedPlaybackTime()).toBe(0)
+  })
+
+  it('ignores messages with non-finite or non-numeric currentTime', () => {
+    const cb = vi.fn()
+    subscribePlaybackTime(cb)
+
+    dispatchPlaybackUpdate('30')
+    dispatchPlaybackUpdate(NaN)
+    dispatchPlaybackUpdate(Infinity)
+    dispatchPlaybackUpdate(undefined)
+
+    expect(cb).not.toHaveBeenCalled()
+    expect(getCachedPlaybackTime()).toBe(0)
+  })
+
+  it('attaches the window listener only once across many subscribers', () => {
+    const addSpy = vi.spyOn(window, 'addEventListener')
+
+    subscribePlaybackTime(vi.fn())
+    subscribePlaybackTime(vi.fn())
+    subscribePlaybackTime(vi.fn())
+
+    const messageCalls = addSpy.mock.calls.filter(([type]) => type === 'message')
+    expect(messageCalls).toHaveLength(1)
+
+    addSpy.mockRestore()
+  })
+})


### PR DESCRIPTION
Closes #328

## Summary

When adding a frame to a meditation, if the audio was paused — or if the user switched between the **Frames** and **Add New** tabs without keeping audio playing — the new frame was inserted at `0:00` instead of the current playhead.

PayloadCMS unmounts inactive tab content, so `usePlaybackTime`'s `useState(0)` reset on every tab switch. Since the WeMeditate Web preview iframe only emits `PLAYBACK_TIME_UPDATE` while audio is playing (and once on pause/seek), a remount during a paused state never received another message and stayed at 0.

This PR hoists the playback time into a module-level singleton store (`playbackTimeStore.ts`) with subscriber fan-out and a single lazily-attached `window` message listener, so the cached time survives remounts and is shared across both tabs. `usePlaybackTime` now reads from the store and subscribes for updates.

- `src/components/admin/FrameEditor/playbackTimeStore.ts` — new singleton.
- `src/components/admin/FrameEditor/hooks.ts` — `usePlaybackTime` consumes the store.
- `tests/unit/playbackTimeStore.spec.ts` — 8 unit tests covering caching, remount, fan-out, unsubscribe, message filtering.

No iframe-side change required; no schema change.

## Test Results

- Unit tests: **241 passed** (8 new)
- Integration tests: **583 passed**
- E2E tests: not applicable (no specs in repo)
- Build: ✓ Success
- Lint: ✓ Clean
- Types (`tsc --noEmit`): ✓ Clean

## Test plan

- [ ] Reproduce on `main`: open a meditation, play audio, pause at ~30s, switch to "Add New" tab, click a frame → confirm bug (lands at 0:00).
- [ ] On this branch, same flow → frame lands at ~30s.
- [ ] Open meditation without ever playing → click frame → still lands at 0:00 (intentional).
- [ ] Drag the playhead in the iframe to 1:00 (no play), switch to "Add New", click a frame → lands at 1:00.
- [ ] Insert a second frame at the same timestamp → toast says "Frame replaced at MM:SS".
- [ ] Frames tab active-frame highlight still tracks the playhead while audio plays.

🤖 Generated with [Claude Code](https://claude.com/claude-code)