### PR TITLE
fix(api): relax related-lectures chakra filter when userChoice is set

### DIFF
--- a/.claude/docs/architecture.md
+++ b/.claude/docs/architecture.md
@@ -17,7 +17,7 @@ local-file fallback in development.
 
 ### Canonical URL field names (#319)
 
-`videos`, `frames`, and `files` expose the canonical `hlsUrl` (HLS manifest) and `mp4Url` (MP4 download) virtual fields. The legacy `streamUrl` and — on Videos only — `url` (MP4 download) are kept as deprecated aliases until the mobile app cuts over. On `frames` and `files` the generic `url` field is *not* deprecated: it remains the mixed-media file URL (image / R2 / MP4 by MIME); read `mp4Url` when you specifically need the MP4. Lecture player-data responses (`/api/lectures/for-audience`, `/api/meditations/:id/related-lecture-clips`) likewise expose both `hlsUrl` (canonical) and `videoUrl` (deprecated alias) holding the same HLS URL.
+`videos`, `frames`, and `files` expose the canonical `hlsUrl` (HLS manifest) and `mp4Url` (MP4 download) virtual fields. The legacy `streamUrl` and — on Videos only — `url` (MP4 download) are kept as deprecated aliases until the mobile app cuts over. On `frames` and `files` the generic `url` field is *not* deprecated: it remains the mixed-media file URL (image / R2 / MP4 by MIME); read `mp4Url` when you specifically need the MP4. Lecture player-data responses (`/api/lectures/for-audience`, `/api/meditations/:id/related-lectures`) likewise expose both `hlsUrl` (canonical) and `videoUrl` (deprecated alias) holding the same HLS URL.
 
 Adapter routing, the R2 filename preassignment hook, the
 Cloudflare Stream webhook, and Zod-validated Cloudflare API responses
@@ -44,7 +44,7 @@ Two places to add HTTP endpoints, chosen by scope:
 | `framesByNarrator` | `/api/frames/by-narrator/:narratorId` | frames filtered by narrator gender |
 | `lecturesForAudience` | `/api/lectures/for-audience` | lectures filtered by runtime audience eligibility |
 | `appCardsForAudience` | `/api/app-cards/for-audience` | app cards filtered by runtime audience eligibility |
-| `meditationLectures` | `/api/meditations/:id/related-lecture-clips` | clips ranked by topical overlap between the meditation's frames and each clip's own `subtleSystemNodes`; optional `userChoice` gate restricts candidates to clips whose parent lecture has that user-choice |
+| `meditationLectures` | `/api/meditations/:id/related-lectures` | lectures ranked by topical overlap between the meditation's frames and each lecture's own `subtleSystemNodes` (zero-overlap lectures dropped). Optional `userChoice` query restricts candidates to lectures with that user-choice and **relaxes** the chakra filter so zero-overlap matches are kept (ranked after weighted ones). |
 
 | Next.js app-router routes | Path | Purpose |
 |---|---|---|
@@ -68,7 +68,7 @@ shim, and the known-limitations list are in `.claude/rules/openapi.md`
 
 ### Content
 - **Pages** — Lexical rich text with embedded blocks; drafts (60 s autosave), version history, scheduled publishing, per-locale publishing.
-- **Meditations** — guided audio with `type` select (quick / daily / lesson), `timings` multi-select, `duration` (auto-extracted via `music-metadata`), frame relationships with timestamps, locale-specific filtering, drafts. A denormalized `subtleSystemNodeWeights` JSON field (`{ slug → on-screen seconds }`) caches per-meditation topical fingerprints; recomputed by an `afterChange` hook when `frames`/`duration` change, and cascaded by Frames' `afterChange` when a frame's `subtleSystemNode` is repointed. Drives the topical-overlap ranking in `/api/meditations/:id/related-lecture-clips`.
+- **Meditations** — guided audio with `type` select (quick / daily / lesson), `timings` multi-select, `duration` (auto-extracted via `music-metadata`), frame relationships with timestamps, locale-specific filtering, drafts. A denormalized `subtleSystemNodeWeights` JSON field (`{ slug → on-screen seconds }`) caches per-meditation topical fingerprints; recomputed by an `afterChange` hook when `frames`/`duration` change, and cascaded by Frames' `afterChange` when a frame's `subtleSystemNode` is repointed. Drives the topical-overlap ranking in `/api/meditations/:id/related-lectures`.
 - **Albums** — music album groupings with `artwork` relationship to Images and a join field for related songs.
 - **Songs** — background music tracks with audio upload, required album relationship, hidden from sidebar (managed via Albums).
 - **Lessons** ("Path Steps") — audio + panels array, unit selection (1–4), step number, optional meditation relationship, localized rich text article.
@@ -79,8 +79,7 @@ shim, and the known-limitations list are in `.claude/rules/openapi.md`
 - **Images** — Cloudflare Images uploads with virtual `url`.
 - **Narrators** — meditation guide profiles (name, gender, slug).
 - **Authors** — article author profiles.
-- **Lectures** — full-talk lecture content integrated with Nirmala Vidya API. No drafts. Time-range excerpts live on the child `lecture-clips` collection. Optional `userChoices` (drives the user-choice gate on `/api/meditations/:id/related-lecture-clips`) and `subtleSystemNodes` hasMany (admin browsing — not used for clip ranking; that lives on LectureClips).
-- **LectureClips** — child of Lecture: `startTime`/`endTime` excerpts, optional thumbnail/subtitles overrides, `audiences` hasMany, `subtleSystemNodes` hasMany (drives the topical-overlap ranking on `/api/meditations/:id/related-lecture-clips` — clips with no nodes are excluded from that endpoint). Sidebar-hidden; managed through the parent Lecture's `clips` join.
+- **Lectures** — full-talk lecture content integrated with Nirmala Vidya API. No drafts. Optional `startTime`/`endTime` excerpt fields, `audiences` hasMany, `subtleSystemNodes` hasMany (drives the topical-overlap ranking on `/api/meditations/:id/related-lectures`), and optional `userChoices` (drives the user-choice gate on the same endpoint, where setting a `userChoice` query also relaxes the chakra filter so zero-overlap matches are kept).
 
 ### System
 - **Frames** — mixed-media uploads (images/videos) with virtual `url` and `previewUrl`, `tags` enum filtering, `imageSet` selection, and a `subtleSystemNode` relationship classifying each frame by chakra/nadi.
@@ -88,9 +87,9 @@ shim, and the known-limitations list are in `.claude/rules/openapi.md`
 
 ### Tags / Audiences
 - **UserChoices** (formerly MeditationTags) — upload collection with SVG icons, color picker, single-level parent/child nesting, required `type` (`mood` | `goal`), `timings`, per-timing localized meditation relationships, `isParent` auto-maintained by hooks. Mood-only fields hide via `admin.condition` on goal-type rows. Reverse joins expose attached `lectures`.
-- **SubtleSystemNodes** — closed enum of 12 chakras + nadis. Each row has a unique `slug` and a required relationship to a `pages` doc that describes it. Reverse joins expose attached `lectures` and `frames`. Referenced by Lectures (`subtleSystemNodes` hasMany — admin browsing), LectureClips (`subtleSystemNodes` hasMany — drives the meditationLectures ranking), and Frames (`subtleSystemNode` single relationship — replaces the old enum `category` field).
+- **SubtleSystemNodes** — closed enum of 12 chakras + nadis. Each row has a unique `slug` and a required relationship to a `pages` doc that describes it. Reverse joins expose attached `lectures` and `frames`. Referenced by Lectures (`subtleSystemNodes` hasMany — drives the meditationLectures ranking) and Frames (`subtleSystemNode` single relationship — replaces the old enum `category` field).
 - **SongTags** — upload collection with SVG icons (no color field). Admin labels say "Music Category".
-- **Audiences** — reusable visibility/targeting rules referenced by AppCards, Lectures, and LectureClips. JSON-based rules (`pathProgress`, `meditationsPerWeek`, `totalMeditationsViewed`, `totalLecturesViewed` — all range type). Three bidirectional joins. The `for-audience` endpoints apply OR-match across attached audiences.
+- **Audiences** — reusable visibility/targeting rules referenced by AppCards and Lectures. JSON-based rules (`pathProgress`, `meditationsPerWeek`, `totalMeditationsViewed`, `totalLecturesViewed` — all range type). Two bidirectional joins. The `for-audience` endpoints apply OR-match across attached audiences.
 
 Page, Video, and Image tags are inline enum select fields on their
 respective collections (not separate tag collections).

--- a/src/endpoints/meditationLectures.ts
+++ b/src/endpoints/meditationLectures.ts
@@ -51,9 +51,13 @@ const querySchema = z.object({
  *   4. Find candidate lectures with audience + optional userChoice + optional
  *      excluded-id filters.
  *   5. Compute lecture weight = sum of `weights[node.slug]` over each
- *      populated `subtleSystemNodes` entry on the lecture; drop weight = 0
- *      (lectures with no nodes contribute nothing).
+ *      populated `subtleSystemNodes` entry on the lecture. By default, drop
+ *      zero-weight lectures (no relevance signal). When `userChoice` is set,
+ *      keep zero-weight lectures — the user-choice match is itself a
+ *      sufficient relevance signal (#333).
  *   6. Sort descending by weight; tie-break by id ascending → deterministic.
+ *      Zero-weight lectures (only present when `userChoice` is set) sort
+ *      after positive-weight ones and order among themselves by id ascending.
  *   7. Slice to `limit` and shape into `LecturePlayerData`.
  */
 export const meditationLectures: Endpoint = {
@@ -162,7 +166,10 @@ export const meditationLectures: Endpoint = {
           weight += weights[node.slug] ?? 0
         }
       }
-      if (weight <= 0) continue
+      // When userChoice is set, the user-choice match is itself a sufficient
+      // relevance signal — keep zero-weight matches and rank them after
+      // weighted ones via the existing comparator (#333).
+      if (weight <= 0 && typeof userChoice !== 'number') continue
       weighted.push({ lecture, weight })
     }
 

--- a/src/lib/openapi/customEndpoints.ts
+++ b/src/lib/openapi/customEndpoints.ts
@@ -266,14 +266,22 @@ export const CUSTOM_ENDPOINT_PATHS: Record<string, OpenAPIPathItem> = {
   '/api/meditations/{id}/related-lectures': {
     get: {
       tags: ['Meditations'],
-      summary: 'Suggested lectures for a meditation',
+      summary: 'Lectures relevant to a meditation, ranked by chakra overlap',
       description:
-        'Returns lectures related to a meditation, ordered most-relevant ' +
-        'first. Pass the `userChoice` query param to limit results to a ' +
-        'single mood/goal category, and `excludedLectureIds` to omit ' +
-        'lectures the user has already watched. Audience inputs filter the ' +
-        'pool to lectures eligible for this viewer. Lectures with no ' +
-        '`subtleSystemNodes` are excluded from the ranking.',
+        'Returns lectures contextually relevant to a meditation, ranked by ' +
+        'the topical overlap between the meditation\'s on-screen chakras ' +
+        '(its frames\' `subtleSystemNodes`, weighted by on-screen seconds) ' +
+        'and each lecture\'s tagged `subtleSystemNodes`. ' +
+        'By default, lectures with no chakra overlap are excluded — they ' +
+        'have no relevance signal. ' +
+        'When `userChoice` is set, the user-choice match is itself a ' +
+        'sufficient relevance signal: all lectures matching the user-choice ' +
+        'are returned regardless of chakra overlap. Positive-weight lectures ' +
+        'rank first by descending weight; zero-overlap matches follow, ' +
+        'ordered by id ascending. ' +
+        'Audience inputs filter the candidate pool to lectures eligible for ' +
+        'this viewer. Use `excludedLectureIds` to omit already-watched ' +
+        'lectures.',
       operationId: 'meditationLectures',
       parameters: [
         {
@@ -291,7 +299,9 @@ export const CUSTOM_ENDPOINT_PATHS: Record<string, OpenAPIPathItem> = {
           required: false,
           description:
             'Optional ID of a UserChoices doc. Restricts candidates to ' +
-            "lectures whose own `userChoices` hasMany contains that ID.",
+            'lectures whose own `userChoices` hasMany contains that ID, AND ' +
+            'relaxes the chakra-overlap filter so zero-overlap matches are ' +
+            'kept (ranked after positive-overlap ones).',
           schema: { type: 'integer' },
         },
         {

--- a/tests/int/meditation-lectures.int.spec.ts
+++ b/tests/int/meditation-lectures.int.spec.ts
@@ -87,6 +87,7 @@ describe('meditationLectures endpoint', () => {
   let lectureAB: Lecture // [nodeA, nodeB]    → mid weight
   let lectureNone: Lecture // []
   let lectureUC: Lecture // [nodeA] + userChoice
+  let lectureUCNone: Lecture // []         + userChoice (zero weight; only kept under userChoice query)
   let lectureNoAudience: Lecture // [nodeA] but no audience
 
   beforeAll(async () => {
@@ -166,6 +167,16 @@ describe('meditationLectures endpoint', () => {
         userChoices: [userChoice.id],
       },
     )
+    lectureUCNone = await testData.createLecture(
+      payload,
+      {},
+      {
+        title: 'Lecture UC None',
+        audiences: [audience.id],
+        subtleSystemNodes: [],
+        userChoices: [userChoice.id],
+      },
+    )
     lectureNoAudience = await testData.createLecture(
       payload,
       {},
@@ -203,12 +214,14 @@ describe('meditationLectures endpoint', () => {
     //   lectureB  → nodeC          ≈ 17s
     //   lectureA  → nodeA          ≈ 10s
     //   lectureUC → nodeA          ≈ 10s   (tie with lectureA; tie-break by id asc)
-    //   lectureNone, lectureNoAudience excluded (zero weight / no audience)
+    //   lectureNone, lectureUCNone, lectureNoAudience excluded
+    //   (zero weight without userChoice, or no audience)
     const ids = docs.map((d) => d.id)
     expect(ids[0]).toBe(lectureAB.id)
     expect(ids[1]).toBe(lectureB.id)
     expect(ids.slice(2, 4).sort()).toEqual([lectureA.id, lectureUC.id].sort())
     expect(ids).not.toContain(lectureNone.id)
+    expect(ids).not.toContain(lectureUCNone.id)
     expect(ids).not.toContain(lectureNoAudience.id)
   })
 
@@ -220,14 +233,17 @@ describe('meditationLectures endpoint', () => {
     )
   })
 
-  it('userChoice gates candidates to lectures whose own userChoices contain that ID', async () => {
+  it('userChoice returns all matching lectures, ranking weighted ones first (#333)', async () => {
+    // lectureUC has nodeA (≈10s weight); lectureUCNone has [] (zero weight).
+    // Both share the userChoice. With userChoice set, the chakra filter
+    // relaxes — lectureUCNone is kept and sorted after lectureUC.
     const { status, body } = await callEndpoint(payload, meditation.id, {
       limit: 10,
       userChoice: userChoice.id,
     })
     expect(status).toBe(200)
     const docs = (body as { docs: LecturePlayerData[] }).docs
-    expect(docs.map((d) => d.id)).toEqual([lectureUC.id])
+    expect(docs.map((d) => d.id)).toEqual([lectureUC.id, lectureUCNone.id])
   })
 
   it('excludedLectureIds removes the listed lectures', async () => {


### PR DESCRIPTION
Closes #333.

## Summary

- When `userChoice` is set on `GET /api/meditations/:id/related-lectures`, the user-choice match is treated as a sufficient relevance signal: lectures with no `subtleSystemNodes` overlap are no longer dropped from the result. Positive-weight matches still rank first; zero-overlap matches follow, ordered by id ascending via the existing comparator.
- Without `userChoice`, behavior is unchanged — zero-weight lectures still drop (no other relevance signal).
- Rewrites the Scalar API description (`src/lib/openapi/customEndpoints.ts`) and updates the endpoint JSDoc to document the new contract.
- Fixes stale post-#331 references in `.claude/docs/architecture.md` (path is `/related-lectures`, not `/related-lecture-clips`; LectureClips collection no longer exists — its bullet was removed and the relevant fields/joins were merged into the Lectures bullet).
- Supersedes #327 (which proposed dropping the chakra filter unconditionally — this narrows the relaxation to the `userChoice` branch only).

## Test plan

- [x] `pnpm exec vitest run tests/int/meditation-lectures.int.spec.ts` — 10/10 pass, including the new `lectureUCNone` fixture and updated `userChoice` assertion.
- [x] `pnpm test:int` — full integration suite passes apart from a flaky benchmark in `access-performance.int.spec.ts` (see below).
- [x] `pnpm lint` — clean.
- [x] `pnpm build` — clean.
- [ ] Manual smoke against `/api/docs` to verify the new Scalar description renders.

## Test Results

- Unit/Integration tests: 582 passed, 1 flaky benchmark
- E2E tests: not run (no UI changes)
- Build: ✓ Success
- Pre-existing failures: `tests/int/access-performance.int.spec.ts > customResourceAccess miss` — timing-only benchmark (`126ms > 100ms` threshold) that flakes when the full suite runs back-to-back. Re-running it on this branch in isolation: 10/10 pass in 44ms total (9.25ms / 100ms threshold for that case). No access-control code was touched in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)