### PR TITLE
fix(richtext): default Upload align to center (closes #318)

### DIFF
--- a/src/lib/richEditor.ts
+++ b/src/lib/richEditor.ts
@@ -52,6 +52,7 @@ export const fullRichTextEditor = (blocks?: Block[]) =>
                 name: 'align',
                 type: 'select',
                 required: true,
+                defaultValue: 'center',
                 options: [
                   {
                     label: 'Center',

--- a/tests/int/pages.int.spec.ts
+++ b/tests/int/pages.int.spec.ts
@@ -2,7 +2,10 @@ import type { Payload } from 'payload'
 
 import { describe, it, beforeAll, afterAll, expect } from 'vitest'
 
-import { createLexicalWithQuoteBlock } from '../utils/lexicalTestHelpers'
+import {
+  createLexicalWithQuoteBlock,
+  createLexicalWithUploadNode,
+} from '../utils/lexicalTestHelpers'
 import { testData } from '../utils/testData'
 import { createTestEnvironment } from '../utils/testHelpers'
 
@@ -146,6 +149,56 @@ describe('Pages Collection', () => {
       expect(fields.text).toBe('A simple quote without attribution.')
       expect(fields.credit).toBeUndefined()
       expect(fields.caption).toBeUndefined()
+    })
+  })
+
+  describe('Lexical Upload Node', () => {
+    it('saves an upload node without an explicit align value (defaults to "center")', async () => {
+      const image = await testData.createMediaImage(payload, { alt: 'Inline upload' })
+      const content = createLexicalWithUploadNode(image.id)
+
+      const page = await testData.createPage(payload, {
+        title: 'Page with Upload (no align)',
+        content,
+      })
+
+      const fetched = await payload.findByID({
+        collection: 'pages',
+        id: page.id,
+        depth: 0,
+      })
+
+      const root = fetched.content?.root as { children: Array<Record<string, unknown>> }
+      const uploadNode = root.children[0]
+      expect(uploadNode.type).toBe('upload')
+      expect(uploadNode.relationTo).toBe('images')
+
+      const fields = uploadNode.fields as Record<string, unknown>
+      expect(fields.align).toBe('center')
+    })
+
+    it('preserves an explicitly-set align value', async () => {
+      const image = await testData.createMediaImage(payload, { alt: 'Inline upload' })
+      const content = createLexicalWithUploadNode(image.id, {
+        align: 'left',
+        caption: 'A caption',
+      })
+
+      const page = await testData.createPage(payload, {
+        title: 'Page with Upload (explicit align)',
+        content,
+      })
+
+      const fetched = await payload.findByID({
+        collection: 'pages',
+        id: page.id,
+        depth: 0,
+      })
+
+      const root = fetched.content?.root as { children: Array<Record<string, unknown>> }
+      const fields = root.children[0].fields as Record<string, unknown>
+      expect(fields.align).toBe('left')
+      expect(fields.caption).toBe('A caption')
     })
   })
 

--- a/tests/utils/lexicalTestHelpers.ts
+++ b/tests/utils/lexicalTestHelpers.ts
@@ -144,6 +144,39 @@ export function createLexicalWithGalleryBlock(imageIds: number[]): Page['content
 }
 
 /**
+ * Create Lexical content with an Upload node referencing an image.
+ * Structure mirrors what `@payloadcms/richtext-lexical`'s UploadFeature emits:
+ * - `type: 'upload'`, `version: 3` for upload nodes
+ * - `relationTo`: the upload-collection slug ('images' here)
+ * - `value`: the related document ID
+ * - `fields`: bag of UploadFeature custom fields (e.g. caption, align)
+ */
+export function createLexicalWithUploadNode(
+  imageId: number,
+  fields: Record<string, unknown> = {},
+): Page['content'] {
+  return {
+    root: {
+      type: 'root',
+      children: [
+        {
+          type: 'upload',
+          version: 3,
+          format: '',
+          relationTo: 'images',
+          value: imageId,
+          fields,
+        },
+      ],
+      direction: null,
+      format: '',
+      indent: 0,
+      version: 1,
+    },
+  } as unknown as Page['content']
+}
+
+/**
  * Create Lexical content with TableOfContentsBlock
  * Structure based on createBlockNode in seeds/lib/lexicalConverter.ts
  */


### PR DESCRIPTION
## Summary

- The Upload feature's `align` field was `required: true` with no default, so inserting an Upload node into a Page (or saving an existing one) failed with `upload node failed to validate: The following fields are invalid: align` whenever the user didn't open the extra-fields drawer.
- Adds `defaultValue: 'center'` so `fieldSchemasToFormState` populates the field before the required-field check runs. Verified against the PayloadCMS source: `calculateDefaultValues` always runs (create *and* update), and the default-value promise fills any `undefined` value before validation.
- No DB migration needed — `node.fields` is stored inline in the rich-text JSON, and old rows without `align` simply get the default applied at validation/save time.

Closes #318

## Test Results
- Integration tests: 585 passed, 1 pre-existing flaky failure (`access-performance.int.spec.ts > completes 10,000 visibility checks in under 150ms` — passes in isolation at ~7ms; only fails under full-suite CPU contention; not introduced by this PR).
- E2E tests: N/A (none defined in `tests/e2e/`)
- Build: ✓ Success
- Lint: ✓ No warnings or errors

### New regression coverage
- `tests/int/pages.int.spec.ts > Lexical Upload Node > saves an upload node without an explicit align value (defaults to "center")`
- `tests/int/pages.int.spec.ts > Lexical Upload Node > preserves an explicitly-set align value`
- New `createLexicalWithUploadNode(imageId, fields?)` helper in `tests/utils/lexicalTestHelpers.ts`.

## Test plan
- [x] Add an Upload block to a Page in the admin UI without opening the extra-fields drawer → saves cleanly with `fields.align === 'center'`.
- [x] Save an existing page that contains an Upload block → no validation error.
- [x] Change `align` via the extra-fields drawer to `Left` / `Right` / `Wide` → persists as chosen.