### PR TITLE
Improve cacheability of audience-based custom endpoints

### DIFF
--- a/.claude/agents/researcher.yaml
+++ b/.claude/agents/researcher.yaml
@@ -1,0 +1,4 @@
+name: researcher
+description: Read, Grep, Glob across the repo and return a short summary. Use for "find all callers of X" or "where is Y configured" questions.
+model: haiku
+tools: [Read, Grep, Glob, WebFetch]

--- a/.claude/docs/architecture.md
+++ b/.claude/docs/architecture.md
@@ -42,9 +42,10 @@ Two places to add HTTP endpoints, chosen by scope:
 | Custom Payload endpoints | Path | Purpose |
 |---|---|---|
 | `framesByNarrator` | `/api/frames/by-narrator/:narratorId` | frames filtered by narrator gender |
-| `lecturesForAudience` | `/api/lectures/for-audience` | lectures filtered by runtime audience eligibility |
-| `appCardsForAudience` | `/api/app-cards/for-audience` | app cards filtered by runtime audience eligibility |
-| `meditationLectures` | `/api/meditations/:id/related-lectures` | lectures ranked by topical overlap between the meditation's frames and each lecture's own `subtleSystemNodes` (zero-overlap lectures dropped). Optional `userChoice` query restricts candidates to lectures with that user-choice and **relaxes** the chakra filter so zero-overlap matches are kept (ranked after weighted ones). |
+| `audiencesForUser` | `/api/audiences/for-user` | resolves the eligible audience IDs for a user from their progress data (`pathProgress`, `meditationsPerWeek`, `totalMeditationsViewed`, `totalLecturesViewed`). Mobile clients call once per state change and pass the resulting list as `audiences` to the three data endpoints below — the rule eval lives here, the data delivery is cacheable. `Cache-Control: public, max-age=300, s-maxage=300`. |
+| `lecturesForAudience` | `/api/lectures/for-audience` | uniform-random lecture feed filtered to lectures whose `audiences` overlap the supplied `audiences` ID list (OR semantics). `Cache-Control: public, max-age=600, s-maxage=600`. |
+| `appCardsForAudience` | `/api/app-cards/for-audience` | published app cards for a `targetSection`, filtered to cards whose `audiences` overlap the supplied `audiences` list (OR semantics) and weighted-random sampled. `Cache-Control: public, max-age=600, s-maxage=600`. |
+| `meditationLectures` | `/api/meditations/:id/related-lectures` | lectures ranked by topical overlap between the meditation's frames and each lecture's own `subtleSystemNodes` (zero-overlap lectures dropped). Optional `userChoice` query restricts candidates to lectures with that user-choice and **relaxes** the chakra filter so zero-overlap matches are kept (ranked after weighted ones). Audience filtering uses the same `audiences` ID list contract as the other data endpoints. `Cache-Control: public, max-age=600, s-maxage=600`. |
 
 | Next.js app-router routes | Path | Purpose |
 |---|---|---|
@@ -89,7 +90,7 @@ shim, and the known-limitations list are in `.claude/rules/openapi.md`
 - **UserChoices** (formerly MeditationTags) — upload collection with SVG icons, color picker, single-level parent/child nesting, required `type` (`mood` | `goal`), `timings`, per-timing localized meditation relationships, `isParent` auto-maintained by hooks. Mood-only fields hide via `admin.condition` on goal-type rows. Reverse joins expose attached `lectures`.
 - **SubtleSystemNodes** — closed enum of 12 chakras + nadis. Each row has a unique `slug` and a required relationship to a `pages` doc that describes it. Reverse joins expose attached `lectures` and `frames`. Referenced by Lectures (`subtleSystemNodes` hasMany — drives the meditationLectures ranking) and Frames (`subtleSystemNode` single relationship — replaces the old enum `category` field).
 - **SongTags** — upload collection with SVG icons (no color field). Admin labels say "Music Category".
-- **Audiences** — reusable visibility/targeting rules referenced by AppCards and Lectures. JSON-based rules (`pathProgress`, `meditationsPerWeek`, `totalMeditationsViewed`, `totalLecturesViewed` — all range type). Two bidirectional joins. The `for-audience` endpoints apply OR-match across attached audiences.
+- **Audiences** — reusable visibility/targeting rules referenced by AppCards and Lectures. JSON-based rules (`pathProgress`, `meditationsPerWeek`, `totalMeditationsViewed`, `totalLecturesViewed` — all range type). Two bidirectional joins. Rule eval lives on the dedicated `/api/audiences/for-user` endpoint; the data endpoints take pre-resolved IDs and apply OR-match across attached audiences. Single-source rule definitions in `src/lib/audiences/definitions.ts`.
 
 Page, Video, and Image tags are inline enum select fields on their
 respective collections (not separate tag collections).

--- a/.claude/rules/openapi.md
+++ b/.claude/rules/openapi.md
@@ -116,16 +116,23 @@ collection slug.
 | Custom path | Handler | Response schema |
 |---|---|---|
 | `GET /api/frames/by-narrator/{narratorId}` | `src/endpoints/framesByNarrator.ts` | `#/components/schemas/Frames` |
-| `GET /api/lectures/for-audience` | `src/endpoints/lecturesForAudience.ts` | `#/components/schemas/ItemPlayerData` (hand-authored) |
+| `GET /api/audiences/for-user` | `src/endpoints/audiencesForUser.ts` | `#/components/schemas/AudienceIdList` |
+| `GET /api/lectures/for-audience` | `src/endpoints/lecturesForAudience.ts` | `#/components/schemas/LecturePlayerData` (hand-authored) |
 | `GET /api/app-cards/for-audience` | `src/endpoints/appCardsForAudience.ts` | `#/components/schemas/AppCards` |
+| `GET /api/meditations/{id}/related-lectures` | `src/endpoints/meditationLectures.ts` | `#/components/schemas/LecturePlayerData` (hand-authored) |
 
-The audience query params on the two `for-audience` endpoints are
+The audience rule-data query params on `/api/audiences/for-user` are
 generated at module load from `AUDIENCE_DEFINITIONS` in
-`src/collections/tags/Audiences.ts` and mirror the Zod shape produced by
+`src/lib/audiences/definitions.ts` and mirror the Zod shape produced by
 `buildAudienceDataShape` in `src/fields/rulesField.ts` — adding a rule
-flows through to the docs automatically. The `audience params stay in
-sync` assertion in `tests/int/api-explorer.int.spec.ts` is the
-regression guard.
+flows through to the docs automatically. The three data endpoints
+(`/lectures/for-audience`, `/app-cards/for-audience`,
+`/meditations/{id}/related-lectures`) take a single pre-resolved
+`audiences` ID list (mirrors `audiencesQueryParamSchema` in
+`src/lib/audiences/audiencesQueryParam.ts`) instead of the rule-data
+params (#340). The `audience query params on /api/audiences/for-user
+stay in sync with AUDIENCE_DEFINITIONS` assertion in
+`tests/int/api-explorer.int.spec.ts` is the regression guard.
 
 When `payload-oapi` ships native custom-endpoint support, both the
 shim module and the merge block in the route handler can be deleted in
@@ -151,4 +158,5 @@ Review payload-oapi quarterly for native support of these.
 - `ALWAYS_HIDDEN_COLLECTIONS` exclusion
 - Operation filtering (DELETE, PATCH hidden)
 - Scalar UI endpoint responses
-- Audience query-param sync between Audiences config and the for-audience endpoints
+- Audience query-param sync between `AUDIENCE_DEFINITIONS` and the `/api/audiences/for-user` resolver
+- Pre-resolved `audiences` ID-list shape on the three data endpoints (#340)

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,9 @@
 {
+  "model": "sonnet",
+  "env": {
+    "MAX_THINKING_TOKENS": "10000",
+    "CLAUDE_CODE_SUBAGENT_MODEL": "haiku"
+  },
   "permissions": {
     "allow": [
       "mcp__plugin_sydevs-web_*",
@@ -70,7 +75,6 @@
       "Bash(git log:*)",
       "Bash(git check-ignore:*)",
       "Bash(git fetch:*)",
-      "Bash(git pr diff:*)",
       "Bash(find:*)",
       "Bash(ls:*)",
       "Bash(grep:*)",

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -69,6 +69,8 @@
       "Bash(git stash:*)",
       "Bash(git log:*)",
       "Bash(git check-ignore:*)",
+      "Bash(git fetch:*)",
+      "Bash(git pr diff:*)",
       "Bash(find:*)",
       "Bash(ls:*)",
       "Bash(grep:*)",
@@ -107,7 +109,6 @@
       "Bash(time pnpm build:*)",
       "mcp__payloadcms-docs__*",
       "mcp__plugin_sydevs-web_cloudflare-docs__*",
-      "Bash(git mv:*)",
       "WebFetch(domain:mapi.nirmalavidya.org)",
       "mcp__plugin_sydevs-web_puppeteer__puppeteer_navigate",
       "mcp__plugin_sydevs-web_puppeteer__puppeteer_fill",
@@ -117,8 +118,7 @@
       "Bash(npm view:*)",
       "Edit(.claude/docs/**)",
       "Write(.claude/docs/**)",
-      "Bash(pnpm test:unit *)",
-      "Bash(git fetch *)"
+      "Bash(pnpm test:unit *)"
     ]
   },
   "hooks": {

--- a/.claudeignore
+++ b/.claudeignore
@@ -1,0 +1,7 @@
+node_modules/
+dist/
+target/
+*.lock
+*.min.js
+__pycache__/
+.claude/sessions/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,6 +7,12 @@ This file provides guidance to AI coding agents when working with this repositor
 > `CLAUDE.md` is a symlink to this file for Claude Code compatibility.
 > Claude-specific features (rules, hooks, skills) remain in the `.claude/` folder.
 
+## Model routing
+- Architecture, debugging, security review: Opus
+- Implementation, content, standard coding: Sonnet
+- File search, formatting, renaming, exploration: Haiku
+- Always escalate security-sensitive changes to Opus for review
+
 ## Documentation Structure
 
 - **Root AGENTS.md** (this file) — essential commands, quick references, project overview.

--- a/src/collections/tags/Audiences.ts
+++ b/src/collections/tags/Audiences.ts
@@ -1,35 +1,13 @@
 import type { CollectionConfig } from 'payload'
 
-import type { RuleDefinition } from '@/fields'
+import { audiencesForUser } from '@/endpoints'
 import { rulesField } from '@/fields'
+import { AUDIENCE_DEFINITIONS } from '@/lib/audiences/definitions'
 
-/**
- * Single source of truth for the rule dimensions an Audience can target.
- * Consumed by Audiences itself and by the for-audience endpoints to derive
- * their query schemas — add a rule here and both sides pick it up.
- */
-export const AUDIENCE_DEFINITIONS: RuleDefinition[] = [
-  {
-    name: 'pathProgress',
-    type: 'range',
-    description: 'Index of the current Path step the user has reached (0 = not started).',
-  },
-  {
-    name: 'meditationsPerWeek',
-    type: 'range',
-    description: 'Meditation sessions the user has completed in the past seven days.',
-  },
-  {
-    name: 'totalMeditationsViewed',
-    type: 'range',
-    description: 'Lifetime count of distinct meditations the user has opened.',
-  },
-  {
-    name: 'totalLecturesViewed',
-    type: 'range',
-    description: 'Lifetime count of distinct lectures the user has played.',
-  },
-]
+// Re-exported so existing call sites can keep importing from this module
+// (the canonical home is `@/lib/audiences/definitions` — see that file
+// for the rationale).
+export { AUDIENCE_DEFINITIONS }
 
 export const Audiences: CollectionConfig = {
   slug: 'audiences',
@@ -42,6 +20,7 @@ export const Audiences: CollectionConfig = {
     useAsTitle: 'label',
     defaultColumns: ['label', 'lectures', 'appCards'],
   },
+  endpoints: [audiencesForUser],
   fields: [
     // Internal CMS label (not localized, not public-facing)
     {

--- a/src/endpoints/appCardsForAudience.ts
+++ b/src/endpoints/appCardsForAudience.ts
@@ -2,13 +2,12 @@ import type { Endpoint } from 'payload'
 
 import { z } from 'zod'
 
-import { AUDIENCE_DEFINITIONS } from '@/collections/tags/Audiences'
-import { buildAudienceDataShape, evaluateRules, type RulesValue } from '@/fields'
+import { audiencesQueryParamSchema } from '@/lib/audiences/audiencesQueryParam'
 import { weightedSample } from '@/lib/weightedSample'
-import type { AppCard, Audience } from '@/payload-types'
+import type { AppCard } from '@/payload-types'
 
 const querySchema = z.object({
-  ...buildAudienceDataShape(AUDIENCE_DEFINITIONS),
+  audiences: audiencesQueryParamSchema,
   targetSection: z.enum(['hero', 'highlights', 'lectures']),
   limit: z.coerce.number().int().min(1).max(20),
 })
@@ -16,15 +15,17 @@ const querySchema = z.object({
 /**
  * GET /api/app-cards/for-audience
  *
- * Returns a randomized, filtered list of published AppCards for the app
- * homepage (Hero or Highlights section). Audience evaluation is delegated to
- * the `audiences` docs referenced by each card's `audiences` hasMany
- * relationship. The endpoint first evaluates all audiences against the
- * supplied audience-data keys and then finds AppCards whose audience
- * relationship overlaps that eligible audience set (OR semantics). Cards with
- * empty `audiences` are always excluded. Eligible cards are then sampled with
- * weighted random selection (without replacement) based on the card's `weight`
- * field.
+ * Returns a randomized, filtered list of published AppCards targeting the
+ * requested `targetSection`, filtered down to cards whose `audiences`
+ * relationship overlaps the supplied `audiences` ID list (OR semantics).
+ * Eligible cards are then sampled with weighted random selection (without
+ * replacement) based on the card's `weight` field.
+ *
+ * Audience eligibility is **not** evaluated here — clients are expected to
+ * call `/api/audiences/for-user` once to resolve their eligible audience
+ * IDs and pass the result back as the `audiences` query param. Splitting
+ * the rule eval out keeps this endpoint cacheable behind Cloudflare's edge
+ * (see #340).
  *
  * Note: `countdown` schedule evaluation is not yet applied here — cards with
  * `countdown: true` are returned regardless of whether the schedule is
@@ -40,39 +41,13 @@ export const appCardsForAudience: Endpoint = {
       return Response.json({ errors: parsed.error.issues }, { status: 400 })
     }
 
-    const { targetSection, limit, ...audienceData } = parsed.data
-
-    const { docs: audienceDocs } = await req.payload.find({
-      collection: 'audiences',
-      // Safety cap. Assumes audience count stays well below this; if it ever
-      // approaches 200, introduce pagination and evaluate the full audience set.
-      limit: 200,
-      depth: 0,
-      pagination: false,
-      req,
-    })
-
-    const eligibleAudienceIds = new Set<number>(
-      (audienceDocs as Audience[])
-        .filter((audience) =>
-          evaluateRules(
-            audience.rules as RulesValue | null | undefined,
-            audienceData,
-            AUDIENCE_DEFINITIONS,
-          ),
-        )
-        .map((audience) => audience.id),
-    )
-
-    if (eligibleAudienceIds.size === 0) {
-      return Response.json({ docs: [] })
-    }
+    const { audiences: audienceIds, targetSection, limit } = parsed.data
 
     const { docs } = await req.payload.find({
       collection: 'app-cards',
       where: {
         _status: { equals: 'published' },
-        audiences: { in: [...eligibleAudienceIds] },
+        audiences: { in: audienceIds },
       },
       // Safety cap. Assumes published cards stay well below this; if it ever
       // approaches 200, introduce server-side filtering or pagination instead
@@ -89,6 +64,9 @@ export const appCardsForAudience: Endpoint = {
 
     const selected = weightedSample(eligible, limit, (card) => card.weight ?? 3)
 
-    return Response.json({ docs: selected })
+    return Response.json(
+      { docs: selected },
+      { headers: { 'Cache-Control': 'public, max-age=600, s-maxage=600' } },
+    )
   },
 }

--- a/src/endpoints/audiencesForUser.ts
+++ b/src/endpoints/audiencesForUser.ts
@@ -1,0 +1,42 @@
+import type { Endpoint } from 'payload'
+
+import { z } from 'zod'
+
+import { buildAudienceDataShape } from '@/fields'
+import { AUDIENCE_DEFINITIONS } from '@/lib/audiences/definitions'
+import { evaluateAudiencesForUser } from '@/lib/audiences/evaluateAudiencesForUser'
+
+const querySchema = z.object({
+  ...buildAudienceDataShape(AUDIENCE_DEFINITIONS),
+})
+
+/**
+ * GET /api/audiences/for-user
+ *
+ * Resolves the set of Audiences a user qualifies for given their current
+ * progress data (path step, meditation/lecture counts, etc.). The three
+ * `for-audience` data endpoints take this list as their `audiences` query
+ * param so they can skip rule evaluation entirely and become cacheable —
+ * see #340 for the split rationale.
+ *
+ * The response itself is only lightly cached (5 min) because rule inputs
+ * are continuous integers and cache-key permutations explode quickly.
+ */
+export const audiencesForUser: Endpoint = {
+  path: '/for-user',
+  method: 'get',
+  handler: async (req) => {
+    const parsed = querySchema.safeParse(req.query)
+
+    if (!parsed.success) {
+      return Response.json({ errors: parsed.error.issues }, { status: 400 })
+    }
+
+    const audienceIds = await evaluateAudiencesForUser(req, parsed.data)
+
+    return Response.json(
+      { audiences: audienceIds },
+      { headers: { 'Cache-Control': 'public, max-age=300, s-maxage=300' } },
+    )
+  },
+}

--- a/src/endpoints/index.ts
+++ b/src/endpoints/index.ts
@@ -1,4 +1,5 @@
 export { appCardsForAudience } from './appCardsForAudience'
+export { audiencesForUser } from './audiencesForUser'
 export { framesByNarrator } from './framesByNarrator'
 export { lecturesForAudience } from './lecturesForAudience'
 export { meditationLectures } from './meditationLectures'

--- a/src/endpoints/lecturesForAudience.ts
+++ b/src/endpoints/lecturesForAudience.ts
@@ -2,8 +2,8 @@ import type { Endpoint } from 'payload'
 
 import { z } from 'zod'
 
-import { shapeLecture, type LecturePlayerData } from '@/lib/lectureShape'
 import { audiencesQueryParamSchema } from '@/lib/audiences/audiencesQueryParam'
+import { shapeLecture, type LecturePlayerData } from '@/lib/lectureShape'
 import type { Lecture } from '@/payload-types'
 
 const querySchema = z.object({

--- a/src/endpoints/lecturesForAudience.ts
+++ b/src/endpoints/lecturesForAudience.ts
@@ -2,36 +2,31 @@ import type { Endpoint } from 'payload'
 
 import { z } from 'zod'
 
-import { AUDIENCE_DEFINITIONS } from '@/collections/tags/Audiences'
-import { buildAudienceDataShape, evaluateRules, type RulesValue } from '@/fields'
 import { shapeLecture, type LecturePlayerData } from '@/lib/lectureShape'
-import type { Audience, Lecture } from '@/payload-types'
+import { audiencesQueryParamSchema } from '@/lib/audiences/audiencesQueryParam'
+import type { Lecture } from '@/payload-types'
 
 const querySchema = z.object({
-  ...buildAudienceDataShape(AUDIENCE_DEFINITIONS),
+  audiences: audiencesQueryParamSchema,
   limit: z.coerce.number().int().min(1).max(100),
 })
 
 /**
  * GET /api/lectures/for-audience
  *
- * Returns a uniform-random, audience-filtered feed of lectures. Each lecture
- * carries an `audiences` hasMany relationship to `audiences` docs. Items are
- * eligible when ANY of their attached audiences passes evaluation against
- * `audienceData` (OR semantics). Items with empty `audiences` are always
- * excluded.
+ * Returns a uniform-random feed of lectures whose attached audiences
+ * overlap the supplied `audiences` ID list. Items with empty `audiences`
+ * are always excluded.
  *
- * Response shape (single uniform shape — no excerpt-vs-full branching):
- *   { docs: LecturePlayerData[] }
+ * Audience eligibility is **not** evaluated here — clients are expected to
+ * call `/api/audiences/for-user` once to resolve their eligible audience
+ * IDs and pass the result back as the `audiences` query param. Splitting
+ * the rule eval out keeps this endpoint cacheable behind Cloudflare's edge
+ * (see #340).
  *
- * Subtitles are returned as the full `{ [locale]: url }` map: `metadata.subtitles`
- * (NV-sourced) merged with per-locale entries on the lecture's own `subtitles`
- * array. The player picks the track it wants at playback time.
- *
- * Pipeline:
- *   1. Evaluate `audiences` with the audience data to build the eligible-audience set.
- *   2. Find ALL lectures whose `audiences` overlap the eligible set (OR-match).
- *   3. Shape each record into `LecturePlayerData`, Fisher-Yates shuffle, slice.
+ * Response shape: `{ docs: LecturePlayerData[] }`. Subtitles are returned as
+ * the full `{ [locale]: url }` map merged from NV metadata and per-locale
+ * entries on the lecture's own `subtitles` array.
  */
 export const lecturesForAudience: Endpoint = {
   path: '/for-audience',
@@ -43,35 +38,11 @@ export const lecturesForAudience: Endpoint = {
       return Response.json({ errors: parsed.error.issues }, { status: 400 })
     }
 
-    const { limit, ...audienceData } = parsed.data
-
-    const { docs: audienceDocs } = await req.payload.find({
-      collection: 'audiences',
-      limit: 200,
-      depth: 0,
-      pagination: false,
-      req,
-    })
-
-    const eligibleAudienceIds = new Set<number>(
-      (audienceDocs as Audience[])
-        .filter((audience) =>
-          evaluateRules(
-            audience.rules as RulesValue | null | undefined,
-            audienceData,
-            AUDIENCE_DEFINITIONS,
-          ),
-        )
-        .map((audience) => audience.id),
-    )
-
-    if (eligibleAudienceIds.size === 0) {
-      return Response.json({ docs: [] })
-    }
+    const { audiences: audienceIds, limit } = parsed.data
 
     const { docs: lectureDocs } = await req.payload.find({
       collection: 'lectures',
-      where: { audiences: { in: [...eligibleAudienceIds] } },
+      where: { audiences: { in: audienceIds } },
       // Fetch all eligible candidates so the Fisher-Yates shuffle below
       // samples uniformly across the entire pool, not just the first N
       // rows by DB order. Sliced down to `limit` after shuffling.
@@ -95,6 +66,9 @@ export const lecturesForAudience: Endpoint = {
       ;[shaped[i], shaped[j]] = [shaped[j], shaped[i]]
     }
 
-    return Response.json({ docs: shaped.slice(0, limit) })
+    return Response.json(
+      { docs: shaped.slice(0, limit) },
+      { headers: { 'Cache-Control': 'public, max-age=600, s-maxage=600' } },
+    )
   },
 }

--- a/src/endpoints/meditationLectures.ts
+++ b/src/endpoints/meditationLectures.ts
@@ -2,14 +2,13 @@ import type { Endpoint, Where } from 'payload'
 
 import { z } from 'zod'
 
-import { AUDIENCE_DEFINITIONS } from '@/collections/tags/Audiences'
-import { buildAudienceDataShape, evaluateRules, type RulesValue } from '@/fields'
 import { recomputeWeightsForMeditation } from '@/hooks/meditationHooks'
+import { audiencesQueryParamSchema } from '@/lib/audiences/audiencesQueryParam'
 import { shapeLecture, type LecturePlayerData } from '@/lib/lectureShape'
-import type { Audience, Lecture, Meditation, SubtleSystemNode } from '@/payload-types'
+import type { Lecture, Meditation, SubtleSystemNode } from '@/payload-types'
 
 const querySchema = z.object({
-  ...buildAudienceDataShape(AUDIENCE_DEFINITIONS),
+  audiences: audiencesQueryParamSchema,
   limit: z.coerce.number().int().min(1).max(100),
   userChoice: z.coerce.number().int().optional(),
   excludedLectureIds: z
@@ -33,8 +32,16 @@ const querySchema = z.object({
  * (cached on `meditation.subtleSystemNodeWeights`) and each candidate
  * lecture's own `subtleSystemNodes`.
  *
+ * Audience eligibility is **not** evaluated here — clients are expected to
+ * call `/api/audiences/for-user` once to resolve their eligible audience
+ * IDs and pass the result back as the `audiences` query param. Splitting
+ * the rule eval out keeps this endpoint cacheable behind Cloudflare's edge
+ * (see #340).
+ *
  * Query params:
- *   - audience inputs (required, mirrors `/for-audience` endpoints)
+ *   - `audiences` (required, comma-separated IDs) — resolved audience IDs
+ *     from `/api/audiences/for-user`. Server dedupes + sorts so equivalent
+ *     client requests share an edge-cache key.
  *   - `limit` (required, 1–100)
  *   - `userChoice` (optional int) — if set, restrict candidates to lectures
  *     whose own `userChoices` contain that ID.
@@ -45,18 +52,17 @@ const querySchema = z.object({
  *   1. Look up the meditation (404 if not found).
  *   2. Read `subtleSystemNodeWeights` from the cache; fall through to an
  *      ad-hoc compute (no persistence — keeps the GET side-effect-free).
- *   3. Evaluate audiences → eligible-audience-ID set; empty → `{ docs: [] }`.
- *   4. Find candidate lectures with audience + optional userChoice + optional
- *      excluded-id filters.
- *   5. Compute lecture weight = sum of `weights[node.slug]` over each
+ *   3. Find candidate lectures whose `audiences` overlap the requested
+ *      list, with optional userChoice + excluded-id filters.
+ *   4. Compute lecture weight = sum of `weights[node.slug]` over each
  *      populated `subtleSystemNodes` entry on the lecture. By default, drop
  *      zero-weight lectures (no relevance signal). When `userChoice` is set,
  *      keep zero-weight lectures — the user-choice match is itself a
  *      sufficient relevance signal (#333).
- *   6. Sort descending by weight; tie-break by id ascending → deterministic.
+ *   5. Sort descending by weight; tie-break by id ascending → deterministic.
  *      Zero-weight lectures (only present when `userChoice` is set) sort
  *      after positive-weight ones and order among themselves by id ascending.
- *   7. Slice to `limit` and shape into `LecturePlayerData`.
+ *   6. Slice to `limit` and shape into `LecturePlayerData`.
  */
 export const meditationLectures: Endpoint = {
   path: '/:id/related-lectures',
@@ -72,7 +78,7 @@ export const meditationLectures: Endpoint = {
       return Response.json({ errors: parsed.error.issues }, { status: 400 })
     }
 
-    const { limit, userChoice, excludedLectureIds, ...audienceData } = parsed.data
+    const { audiences: audienceIds, limit, userChoice, excludedLectureIds } = parsed.data
 
     let meditation: Meditation | null = null
     try {
@@ -104,32 +110,8 @@ export const meditationLectures: Endpoint = {
     const weights =
       cachedWeights ?? (await recomputeWeightsForMeditation(req.payload, meditation, req))
 
-    const { docs: audienceDocs } = await req.payload.find({
-      collection: 'audiences',
-      limit: 200,
-      depth: 0,
-      pagination: false,
-      req,
-    })
-
-    const eligibleAudienceIds = new Set<number>(
-      (audienceDocs as Audience[])
-        .filter((audience) =>
-          evaluateRules(
-            audience.rules as RulesValue | null | undefined,
-            audienceData,
-            AUDIENCE_DEFINITIONS,
-          ),
-        )
-        .map((audience) => audience.id),
-    )
-
-    if (eligibleAudienceIds.size === 0) {
-      return Response.json({ docs: [] })
-    }
-
     const lectureWhere: Where = {
-      audiences: { in: [...eligibleAudienceIds] },
+      audiences: { in: audienceIds },
     }
     if (excludedLectureIds.length > 0) {
       lectureWhere.id = { not_in: excludedLectureIds }
@@ -152,7 +134,10 @@ export const meditationLectures: Endpoint = {
 
     const eligibleLectures = lectureDocs as Lecture[]
     if (eligibleLectures.length === 0) {
-      return Response.json({ docs: [] })
+      return Response.json(
+        { docs: [] },
+        { headers: { 'Cache-Control': 'public, max-age=600, s-maxage=600' } },
+      )
     }
 
     type WeightedLecture = { lecture: Lecture; weight: number }
@@ -182,6 +167,9 @@ export const meditationLectures: Endpoint = {
       .map(({ lecture }): LecturePlayerData | null => shapeLecture(lecture, req.payload.logger))
       .filter((item): item is LecturePlayerData => item !== null)
 
-    return Response.json({ docs: shaped })
+    return Response.json(
+      { docs: shaped },
+      { headers: { 'Cache-Control': 'public, max-age=600, s-maxage=600' } },
+    )
   },
 }

--- a/src/lib/audiences/audiencesQueryParam.ts
+++ b/src/lib/audiences/audiencesQueryParam.ts
@@ -1,0 +1,54 @@
+import { z } from 'zod'
+
+/**
+ * Zod schema for the `audiences` query param accepted by the three
+ * `/for-audience` data endpoints.
+ *
+ * Wire format: comma-separated positive integers (e.g. `audiences=3,1,2`).
+ * Repeated query params (`audiences=3&audiences=1`) are intentionally not
+ * supported — the single canonical form keeps the OpenAPI shape simple
+ * and the cache-key permutation predictable.
+ *
+ * Server-side normalization: the parsed list is **deduplicated and sorted
+ * ascending**, so `audiences=3,1,2` and `audiences=2,3,1,2` collapse to the
+ * same `[1, 2, 3]`. Together with `Cache-Control` on the data endpoints,
+ * this means equivalent client requests share an edge-cache entry.
+ *
+ * Empty input rejects with a 400. Mobile clients are expected to call
+ * `/api/audiences/for-user` first and pass that response through; an empty
+ * `audiences` value usually means "no audiences match this user", and the
+ * caller can decide to short-circuit on its side rather than firing a
+ * round-trip we know will return `{ docs: [] }`.
+ */
+export const audiencesQueryParamSchema = z
+  .string()
+  .transform((raw, ctx) => {
+    const parts = raw
+      .split(',')
+      .map((p) => p.trim())
+      .filter((p) => p.length > 0)
+
+    const ids: number[] = []
+    for (const part of parts) {
+      if (!/^\d+$/.test(part)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: `Invalid audience ID: "${part}"`,
+          path: ['audiences'],
+        })
+        return z.NEVER
+      }
+      ids.push(parseInt(part, 10))
+    }
+
+    if (ids.length === 0) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'audiences must be a non-empty list of comma-separated IDs',
+        path: ['audiences'],
+      })
+      return z.NEVER
+    }
+
+    return [...new Set(ids)].sort((a, b) => a - b)
+  })

--- a/src/lib/audiences/audiencesQueryParam.ts
+++ b/src/lib/audiences/audiencesQueryParam.ts
@@ -4,10 +4,13 @@ import { z } from 'zod'
  * Zod schema for the `audiences` query param accepted by the three
  * `/for-audience` data endpoints.
  *
- * Wire format: comma-separated positive integers (e.g. `audiences=3,1,2`).
- * Repeated query params (`audiences=3&audiences=1`) are intentionally not
- * supported — the single canonical form keeps the OpenAPI shape simple
- * and the cache-key permutation predictable.
+ * Canonical wire format: comma-separated positive integers
+ * (e.g. `audiences=3,1,2`). The single canonical form keeps the OpenAPI
+ * shape simple and the cache-key permutation predictable. As a
+ * compatibility nicety, repeated query params (`audiences=3&audiences=1`),
+ * which `qs-esm` parses into an array, are also accepted: array values get
+ * joined with commas and run through the same parser, so the canonical
+ * comma-separated form remains the contract.
  *
  * Server-side normalization: the parsed list is **deduplicated and sorted
  * ascending**, so `audiences=3,1,2` and `audiences=2,3,1,2` collapse to the
@@ -21,7 +24,10 @@ import { z } from 'zod'
  * round-trip we know will return `{ docs: [] }`.
  */
 export const audiencesQueryParamSchema = z
-  .string()
+  .preprocess((value) => {
+    if (Array.isArray(value)) return value.join(',')
+    return value
+  }, z.string({ error: 'audiences must be a comma-separated string of IDs' }))
   .transform((raw, ctx) => {
     const parts = raw
       .split(',')

--- a/src/lib/audiences/definitions.ts
+++ b/src/lib/audiences/definitions.ts
@@ -1,0 +1,34 @@
+import type { RuleDefinition } from '@/fields'
+
+/**
+ * Single source of truth for the rule dimensions an Audience can target.
+ * Consumed by the Audiences collection schema, the audience-eval endpoints,
+ * and the OpenAPI shim — add a rule here and all sides pick it up.
+ *
+ * Lives under `src/lib/audiences/` (rather than the Audiences collection
+ * file itself) so the audiencesForUser endpoint can reference it without
+ * creating a circular import: the Audiences collection registers the
+ * endpoint, and the endpoint reads the definitions.
+ */
+export const AUDIENCE_DEFINITIONS: RuleDefinition[] = [
+  {
+    name: 'pathProgress',
+    type: 'range',
+    description: 'Index of the current Path step the user has reached (0 = not started).',
+  },
+  {
+    name: 'meditationsPerWeek',
+    type: 'range',
+    description: 'Meditation sessions the user has completed in the past seven days.',
+  },
+  {
+    name: 'totalMeditationsViewed',
+    type: 'range',
+    description: 'Lifetime count of distinct meditations the user has opened.',
+  },
+  {
+    name: 'totalLecturesViewed',
+    type: 'range',
+    description: 'Lifetime count of distinct lectures the user has played.',
+  },
+]

--- a/src/lib/audiences/evaluateAudiencesForUser.ts
+++ b/src/lib/audiences/evaluateAudiencesForUser.ts
@@ -1,0 +1,42 @@
+import type { PayloadRequest } from 'payload'
+
+import { evaluateRules, type AudienceData, type RulesValue } from '@/fields'
+import { AUDIENCE_DEFINITIONS } from '@/lib/audiences/definitions'
+import type { Audience } from '@/payload-types'
+
+/**
+ * Returns the IDs of every Audience whose stored `rules` evaluate to true
+ * against the supplied `audienceData` (mirrors the `pathProgress`/
+ * `meditationsPerWeek`/etc. shape produced by `buildAudienceDataShape`).
+ *
+ * Returned IDs are sorted ascending so the wire response from
+ * `/api/audiences/for-user` is byte-stable across calls — useful for client
+ * caching even though the endpoint itself isn't a strong cache candidate.
+ *
+ * Hardcoded `limit: 200` matches the legacy data-endpoint code paths this
+ * helper replaced. If audience count ever approaches that, paginate here
+ * instead of bumping the limit.
+ */
+export async function evaluateAudiencesForUser(
+  req: PayloadRequest,
+  audienceData: AudienceData,
+): Promise<number[]> {
+  const { docs } = await req.payload.find({
+    collection: 'audiences',
+    limit: 200,
+    depth: 0,
+    pagination: false,
+    req,
+  })
+
+  return (docs as Audience[])
+    .filter((audience) =>
+      evaluateRules(
+        audience.rules as RulesValue | null | undefined,
+        audienceData,
+        AUDIENCE_DEFINITIONS,
+      ),
+    )
+    .map((audience) => audience.id)
+    .sort((a, b) => a - b)
+}

--- a/src/lib/openapi/customEndpoints.ts
+++ b/src/lib/openapi/customEndpoints.ts
@@ -90,13 +90,18 @@ function ruleToSchema(rule: RuleDefinition): OpenAPISchemaObject {
 
 /**
  * Produces one required query parameter per entry in `AUDIENCE_DEFINITIONS`.
+ * Consumed only by `/api/audiences/for-user` — the three data endpoints
+ * (`/lectures/for-audience`, `/app-cards/for-audience`,
+ * `/meditations/{id}/related-lectures`) take the pre-resolved
+ * `audiencesIdsParam` instead, so they can be edge-cached (#340).
+ *
  * Required matches the runtime contract (`buildAudienceDataShape` emits
  * non-optional Zod schemas), and the per-rule `description` is sourced from
  * `RuleDefinition.description` so the Scalar docs explain each input in the
  * same words as the admin UI. Generated at module load so adding a new rule
- * flows through automatically — the test `audience params stay in sync with
- * AUDIENCE_DEFINITIONS` in `api-explorer.int.spec.ts` fails loudly if this
- * drifts.
+ * flows through automatically — the test `audience query params on
+ * /api/audiences/for-user stay in sync with AUDIENCE_DEFINITIONS` in
+ * `api-explorer.int.spec.ts` fails loudly if this drifts.
  */
 const audienceQueryParameters: OpenAPIParameter[] = AUDIENCE_DEFINITIONS.map((rule) => ({
   name: rule.name,

--- a/src/lib/openapi/customEndpoints.ts
+++ b/src/lib/openapi/customEndpoints.ts
@@ -118,6 +118,27 @@ const forAudienceLimitParam = (max: number): OpenAPIParameter => ({
   schema: { type: 'integer', minimum: 1, maximum: max },
 })
 
+/**
+ * The `audiences` query parameter accepted by the three `/for-audience` data
+ * endpoints. Comma-separated positive integers; server dedupes + sorts so
+ * equivalent client requests collapse to the same edge-cache key. Mobile
+ * clients are expected to call `/api/audiences/for-user` first and pass the
+ * resulting ID list back.
+ *
+ * Mirrors the Zod schema in `src/lib/audiences/audiencesQueryParam.ts`.
+ */
+const audiencesIdsParam: OpenAPIParameter = {
+  name: 'audiences',
+  in: 'query',
+  required: true,
+  description:
+    'Comma-separated audience IDs the caller qualifies for, e.g. `1,2,3`. ' +
+    'Resolve via `GET /api/audiences/for-user`. Server-side the list is ' +
+    'deduplicated and sorted ascending, so `3,1,2` and `2,3,1,2` are ' +
+    'treated identically and share the same edge-cache key.',
+  schema: { type: 'string', pattern: '^\\d+(,\\d+)*$' },
+}
+
 const jsonDocsResponse = (itemSchemaRef: string): OpenAPIResponse => ({
   description: 'Audience-filtered docs.',
   content: {
@@ -219,19 +240,53 @@ export const CUSTOM_ENDPOINT_PATHS: Record<string, OpenAPIPathItem> = {
     },
   },
 
+  '/api/audiences/for-user': {
+    get: {
+      tags: ['Audiences'],
+      summary: 'Resolve eligible audience IDs for a user',
+      description:
+        'Evaluates every Audience\'s rules against the supplied user ' +
+        'progress data (path step, meditation/lecture counts) and returns ' +
+        'the IDs of those that pass. Mobile clients call this once per ' +
+        'state change and pass the resulting list as `audiences` to the ' +
+        '`/for-audience` data endpoints, which lets those endpoints become ' +
+        'edge-cacheable. ' +
+        'IDs are returned sorted ascending so the response body is stable ' +
+        'across calls. Sets `Cache-Control: public, max-age=300, ' +
+        's-maxage=300` to absorb repeat calls within a foreground/background ' +
+        'cycle while keeping the TTL short enough for rule changes to ' +
+        'propagate.',
+      operationId: 'audiencesForUser',
+      parameters: [...audienceQueryParameters],
+      responses: {
+        '200': {
+          description: 'List of eligible audience IDs.',
+          content: {
+            'application/json': {
+              schema: { $ref: '#/components/schemas/AudienceIdList' },
+            },
+          },
+        },
+        '400': errorResponse('Query param validation failed.'),
+      },
+    },
+  },
+
   '/api/lectures/for-audience': {
     get: {
       tags: ['Lectures'],
       summary: 'Audience-targeted lecture feed',
       description:
         'Returns a uniform-random feed of lectures whose attached audiences ' +
-        'match the supplied audience data (OR semantics across audiences). ' +
-        'Each lecture is shaped into a flat, player-ready record matching ' +
+        'overlap the supplied `audiences` ID list (OR semantics). Each ' +
+        'lecture is shaped into a flat, player-ready record matching ' +
         '`LecturePlayerData`. Records carrying `startTime`/`stopTime` denote ' +
         'a playback window within the lecture; `fullLectureId` (when set) ' +
-        'points at a related lecture for editorial grouping.',
+        'points at a related lecture for editorial grouping. ' +
+        'Resolve `audiences` first via `GET /api/audiences/for-user`; this ' +
+        'endpoint sets `Cache-Control: public, max-age=600, s-maxage=600`.',
       operationId: 'lecturesForAudience',
-      parameters: [...audienceQueryParameters, forAudienceLimitParam(100)],
+      parameters: [audiencesIdsParam, forAudienceLimitParam(100)],
       responses: {
         '200': jsonDocsResponse('#/components/schemas/LecturePlayerData'),
         '400': errorResponse('Query param validation failed.'),
@@ -245,11 +300,13 @@ export const CUSTOM_ENDPOINT_PATHS: Record<string, OpenAPIPathItem> = {
       summary: 'Audience-targeted app cards',
       description:
         'Returns published app cards targeting the requested `targetSection`, ' +
-        'filtered by audience eligibility (OR semantics across audiences) and ' +
-        'weighted-random sampled by `weight`.',
+        'filtered to those whose `audiences` overlap the supplied list (OR ' +
+        'semantics) and weighted-random sampled by `weight`. ' +
+        'Resolve `audiences` first via `GET /api/audiences/for-user`; this ' +
+        'endpoint sets `Cache-Control: public, max-age=600, s-maxage=600`.',
       operationId: 'appCardsForAudience',
       parameters: [
-        ...audienceQueryParameters,
+        audiencesIdsParam,
         {
           name: 'targetSection',
           in: 'query',
@@ -282,9 +339,10 @@ export const CUSTOM_ENDPOINT_PATHS: Record<string, OpenAPIPathItem> = {
         'are returned regardless of chakra overlap. Positive-weight lectures ' +
         'rank first by descending weight; zero-overlap matches follow, ' +
         'ordered by id ascending. ' +
-        'Audience inputs filter the candidate pool to lectures eligible for ' +
-        'this viewer. Use `excludedLectureIds` to omit already-watched ' +
-        'lectures.',
+        'Pass `audiences` (resolved via `GET /api/audiences/for-user`) to ' +
+        'restrict the candidate pool to lectures eligible for this viewer. ' +
+        'Use `excludedLectureIds` to omit already-watched lectures. ' +
+        'This endpoint sets `Cache-Control: public, max-age=600, s-maxage=600`.',
       operationId: 'meditationLectures',
       parameters: [
         {
@@ -294,7 +352,7 @@ export const CUSTOM_ENDPOINT_PATHS: Record<string, OpenAPIPathItem> = {
           description: 'ID of the meditation whose context drives the ranking.',
           schema: { type: 'string' },
         },
-        ...audienceQueryParameters,
+        audiencesIdsParam,
         forAudienceLimitParam(100),
         {
           name: 'userChoice',
@@ -341,6 +399,21 @@ export const CUSTOM_ENDPOINT_PATHS: Record<string, OpenAPIPathItem> = {
  * shape tight so accidental fields are rejected.
  */
 export const CUSTOM_ENDPOINT_SCHEMAS: Record<string, OpenAPISchemaObject> = {
+  /**
+   * Response shape for `GET /api/audiences/for-user`. Sorted ascending so
+   * the body is byte-stable across calls.
+   */
+  AudienceIdList: {
+    type: 'object',
+    additionalProperties: false,
+    required: ['audiences'],
+    properties: {
+      audiences: {
+        type: 'array',
+        items: { type: 'integer' },
+      },
+    },
+  },
   LecturePlayerData: {
     type: 'object',
     additionalProperties: false,

--- a/tests/int/api-explorer.int.spec.ts
+++ b/tests/int/api-explorer.int.spec.ts
@@ -529,10 +529,12 @@ describe('OpenAPI Spec Marker Utility', () => {
 
 describe('Custom Endpoint Shims', () => {
   describe('CUSTOM_ENDPOINT_PATHS', () => {
-    it('defines all three custom endpoints with GET operations', () => {
+    it('defines all custom endpoints with GET operations', () => {
       expect(CUSTOM_ENDPOINT_PATHS['/api/frames/by-narrator/{narratorId}']?.get).toBeDefined()
       expect(CUSTOM_ENDPOINT_PATHS['/api/lectures/for-audience']?.get).toBeDefined()
       expect(CUSTOM_ENDPOINT_PATHS['/api/app-cards/for-audience']?.get).toBeDefined()
+      expect(CUSTOM_ENDPOINT_PATHS['/api/meditations/{id}/related-lectures']?.get).toBeDefined()
+      expect(CUSTOM_ENDPOINT_PATHS['/api/audiences/for-user']?.get).toBeDefined()
     })
 
     it('frames/by-narrator declares a required narratorId path param and refs the Frames schema', () => {
@@ -586,30 +588,25 @@ describe('Custom Endpoint Shims', () => {
       expect(successSchema?.properties?.docs?.items?.$ref).toBe('#/components/schemas/AppCards')
     })
 
-    it('audience query params stay in sync with AUDIENCE_DEFINITIONS on every audience-aware endpoint', () => {
+    it('audience query params on /api/audiences/for-user stay in sync with AUDIENCE_DEFINITIONS', () => {
       // Regression guard: if a new rule is added to AUDIENCE_DEFINITIONS but
       // not plumbed through `audienceQueryParameters` in customEndpoints.ts,
-      // the generated docs silently under-advertise the endpoint.
+      // the generated docs silently under-advertise the resolver endpoint.
+      // After #340 the data endpoints no longer carry rule-data params —
+      // they take a pre-resolved `audiences` ID list instead — so the sync
+      // contract only applies to /for-user.
       const ruleNames = AUDIENCE_DEFINITIONS.map((rule) => rule.name)
+      const op = CUSTOM_ENDPOINT_PATHS['/api/audiences/for-user']!.get!
+      const paramNames = (op.parameters ?? []).map((p) => p.name)
 
-      for (const path of [
-        '/api/lectures/for-audience',
-        '/api/app-cards/for-audience',
-        '/api/meditations/{id}/related-lectures',
-      ] as const) {
-        const op = CUSTOM_ENDPOINT_PATHS[path]!.get!
-        const paramNames = (op.parameters ?? []).map((p) => p.name)
-        for (const ruleName of ruleNames) {
-          expect(paramNames, `${path} should expose '${ruleName}' as a query param`).toContain(
-            ruleName,
-          )
-        }
+      for (const ruleName of ruleNames) {
+        expect(paramNames, `/audiences/for-user should expose '${ruleName}'`).toContain(ruleName)
       }
     })
 
-    it('audience params are all required query params', () => {
+    it('audience params on /api/audiences/for-user are all required query params', () => {
       const ruleNames = new Set(AUDIENCE_DEFINITIONS.map((rule) => rule.name))
-      const op = CUSTOM_ENDPOINT_PATHS['/api/lectures/for-audience']!.get!
+      const op = CUSTOM_ENDPOINT_PATHS['/api/audiences/for-user']!.get!
 
       for (const param of op.parameters ?? []) {
         if (ruleNames.has(param.name)) {
@@ -617,6 +614,48 @@ describe('Custom Endpoint Shims', () => {
           expect(param.required).toBe(true)
         }
       }
+    })
+
+    it('the three data endpoints expose a required `audiences` query param instead', () => {
+      // After #340 callers pass a pre-resolved comma-separated list of
+      // audience IDs. The schema documents the canonical wire format via a
+      // pattern, so OpenAPI codegen / validation tools see the same shape
+      // the Zod schema enforces at runtime.
+      for (const path of [
+        '/api/lectures/for-audience',
+        '/api/app-cards/for-audience',
+        '/api/meditations/{id}/related-lectures',
+      ] as const) {
+        const op = CUSTOM_ENDPOINT_PATHS[path]!.get!
+        const audiencesParam = (op.parameters ?? []).find((p) => p.name === 'audiences')
+        expect(audiencesParam, `${path} should expose 'audiences'`).toBeDefined()
+        expect(audiencesParam?.in).toBe('query')
+        expect(audiencesParam?.required).toBe(true)
+        expect(audiencesParam?.schema?.type).toBe('string')
+        expect(audiencesParam?.schema?.pattern).toBe('^\\d+(,\\d+)*$')
+
+        // Old rule-data params must not be present anymore.
+        const paramNames = (op.parameters ?? []).map((p) => p.name)
+        for (const rule of AUDIENCE_DEFINITIONS) {
+          expect(
+            paramNames,
+            `${path} should NOT expose old rule param '${rule.name}'`,
+          ).not.toContain(rule.name)
+        }
+      }
+    })
+
+    it('/api/audiences/for-user returns the AudienceIdList shape', () => {
+      const op = CUSTOM_ENDPOINT_PATHS['/api/audiences/for-user']!.get!
+      const successRef = op.responses?.['200']?.content?.['application/json']?.schema?.$ref
+      expect(successRef).toBe('#/components/schemas/AudienceIdList')
+
+      const listSchema = CUSTOM_ENDPOINT_SCHEMAS.AudienceIdList as
+        | { type?: string; required?: string[]; properties?: { audiences?: { items?: { type?: string } } } }
+        | undefined
+      expect(listSchema?.type).toBe('object')
+      expect(listSchema?.required).toContain('audiences')
+      expect(listSchema?.properties?.audiences?.items?.type).toBe('integer')
     })
 
     it('meditations/:id/related-lectures returns LecturePlayerData via single $ref', () => {
@@ -652,27 +691,23 @@ describe('Custom Endpoint Shims', () => {
       expect((limitParam?.schema as { maximum?: number; minimum?: number })?.minimum).toBe(1)
     })
 
-    it('audience query-param descriptions mirror RuleDefinition.description', () => {
+    it('audience query-param descriptions on /api/audiences/for-user mirror RuleDefinition.description', () => {
       // Each rule with an authored description in AUDIENCE_DEFINITIONS should
-      // surface that exact text on both for-audience endpoints — keeps admin
-      // UI hint + OpenAPI docs copy in lockstep.
+      // surface that exact text on the resolver endpoint — keeps admin UI
+      // hint + OpenAPI docs copy in lockstep.
       const definedDescriptions = new Map<string, string>()
       for (const rule of AUDIENCE_DEFINITIONS) {
         if (rule.description) definedDescriptions.set(rule.name, rule.description)
       }
       expect(definedDescriptions.size).toBeGreaterThan(0)
 
-      for (const path of [
-        '/api/lectures/for-audience',
-        '/api/app-cards/for-audience',
-        '/api/meditations/{id}/related-lectures',
-      ] as const) {
-        const op = CUSTOM_ENDPOINT_PATHS[path]!.get!
-        for (const param of op.parameters ?? []) {
-          const expected = definedDescriptions.get(param.name)
-          if (expected) {
-            expect(param.description, `${path} ${param.name} description`).toBe(expected)
-          }
+      const op = CUSTOM_ENDPOINT_PATHS['/api/audiences/for-user']!.get!
+      for (const param of op.parameters ?? []) {
+        const expected = definedDescriptions.get(param.name)
+        if (expected) {
+          expect(param.description, `/audiences/for-user ${param.name} description`).toBe(
+            expected,
+          )
         }
       }
     })
@@ -729,11 +764,12 @@ describe('Custom Endpoint Shims', () => {
       expect(schema?.properties?.errors?.items?.required).toContain('message')
     })
 
-    it('wires ErrorResponse into 4xx responses on all three endpoints', () => {
+    it('wires ErrorResponse into 4xx responses on all custom endpoints', () => {
       const pathsWithErrorResponses: Array<[string, string[]]> = [
         ['/api/frames/by-narrator/{narratorId}', ['400', '404']],
         ['/api/lectures/for-audience', ['400']],
         ['/api/app-cards/for-audience', ['400']],
+        ['/api/audiences/for-user', ['400']],
       ]
 
       for (const [path, statusCodes] of pathsWithErrorResponses) {

--- a/tests/int/app-cards-for-audience.int.spec.ts
+++ b/tests/int/app-cards-for-audience.int.spec.ts
@@ -9,26 +9,19 @@ import { appCardsForAudience } from '@/endpoints'
 import { testData } from '../utils/testData'
 import { createTestEnvironment } from '../utils/testHelpers'
 
-// All audience params are required by the endpoint's Zod schema. Tests that
-// don't exercise a specific param still need to pass neutral defaults; pass
-// `{ skipAudienceDefaults: true }` on the 400-validation cases that want to
-// exercise the missing-audience-param path.
-const AUDIENCE_DEFAULTS = {
-  pathProgress: 0,
-  meditationsPerWeek: 0,
-  totalMeditationsViewed: 0,
-  totalLecturesViewed: 0,
-}
-
+// `audiences` is a required, non-empty comma-separated list of IDs.
+// Tests that don't exercise a specific eligibility scenario still need to
+// pass a valid value; pass `{ skipDefaultAudiences: true }` on the
+// 400-validation cases that want to omit it.
 async function callEndpoint(
   payload: Payload,
   query: Record<string, string | number | boolean>,
   user?: { id: number | string; collection: string },
-  options: { skipAudienceDefaults?: boolean } = {},
-): Promise<{ status: number; body: unknown }> {
-  const finalQuery = options.skipAudienceDefaults
+  options: { skipDefaultAudiences?: boolean; defaultAudiences?: string } = {},
+): Promise<{ status: number; headers: Headers; body: unknown }> {
+  const finalQuery = options.skipDefaultAudiences
     ? query
-    : { ...AUDIENCE_DEFAULTS, ...query }
+    : { audiences: options.defaultAudiences ?? '', ...query }
   const req = {
     payload,
     query: finalQuery,
@@ -39,7 +32,7 @@ async function callEndpoint(
 
   const response = (await appCardsForAudience.handler(req)) as Response
   const body = await response.json()
-  return { status: response.status, body }
+  return { status: response.status, headers: response.headers, body }
 }
 
 describe('appCardsForAudience endpoint', () => {
@@ -49,6 +42,17 @@ describe('appCardsForAudience endpoint', () => {
 
   let openAudience: Audience
   let pathStartedAudience: Audience
+  let nullRulesAudience: Audience
+
+  // Audience-ID combinations representative of the previous rule scenarios:
+  // - allEligible:  resolved audiences for a "path-started" caller
+  //   (Open + PathStarted + NullRules — the union of every always-match
+  //   plus a positive pathProgress audience).
+  // - openOnly:     resolved audiences for a beginner who hasn't started
+  //   the path (Open + NullRules — PathStarted requires min:1).
+  let allEligible: string
+  let openOnly: string
+
   let heroCardOpen: AppCard
   let heroCardPathStarted: AppCard
   let highlightsCard: AppCard
@@ -70,13 +74,17 @@ describe('appCardsForAudience endpoint', () => {
     const img = await testData.createMediaImage(payload, { alt: 'Shared card image' })
     const imageId = img.id
 
-    // Always-match audience — no configured rules
+    // Always-match audience — no configured rules. (Rule semantics are now
+    // tested in audiences-for-user.int.spec.ts; here we only care about
+    // which audiences end up in the caller's `audiences` list.)
     openAudience = await testData.createAudience(payload, {
       label: 'Open Audience',
       rules: {},
     })
 
-    // Audience requiring pathProgress >= 1 (replaces the old hasRealization boolean)
+    // A "path-started" audience the new resolver would only return for callers
+    // with pathProgress >= 1. We emulate the difference by varying the
+    // `audiences` list passed to the endpoint per test.
     pathStartedAudience = await testData.createAudience(payload, {
       label: 'Path Started',
       rules: {
@@ -85,7 +93,15 @@ describe('appCardsForAudience endpoint', () => {
       },
     })
 
-    // Hero card with open audience — matches any caller with pathProgress in any range
+    nullRulesAudience = await testData.createAudience(payload, {
+      label: 'Null Rules Audience',
+      rules: null,
+    })
+
+    allEligible = [openAudience.id, pathStartedAudience.id, nullRulesAudience.id].join(',')
+    openOnly = [openAudience.id, nullRulesAudience.id].join(',')
+
+    // Hero card with open audience — present whenever Open is in the caller's list.
     heroCardOpen = await testData.createAppCard(payload, {
       title: 'Hero Open',
       image: imageId,
@@ -95,7 +111,7 @@ describe('appCardsForAudience endpoint', () => {
       _status: 'published',
     })
 
-    // Hero card requiring pathProgress in [1, 5]
+    // Hero card requiring the path-started audience.
     heroCardPathStarted = await testData.createAppCard(payload, {
       title: 'Hero Path Started',
       image: imageId,
@@ -135,11 +151,6 @@ describe('appCardsForAudience endpoint', () => {
       _status: 'published',
     })
 
-    const nullRulesAudience = await testData.createAudience(payload, {
-      label: 'Null Rules Audience',
-      rules: null,
-    })
-
     nullRulesAudienceCard = await testData.createAppCard(payload, {
       title: 'Null Rules Audience Card',
       image: imageId,
@@ -159,9 +170,8 @@ describe('appCardsForAudience endpoint', () => {
       _status: 'published',
     })
 
-    // OR-match coverage: card with one passing + one failing audience.
-    // For pathProgress=0 → openAudience passes (rules:{}, always matches),
-    // pathStartedAudience fails. Card should be included.
+    // OR-match coverage: card with one matching + one non-matching audience
+    // for a beginner caller (audiences=openOnly).
     multiAudienceCard = await testData.createAppCard(payload, {
       title: 'Multi Audience Card',
       image: imageId,
@@ -171,8 +181,8 @@ describe('appCardsForAudience endpoint', () => {
       _status: 'published',
     })
 
-    // OR-match coverage: card with only failing audience.
-    // For pathProgress=0 → pathStartedAudience fails (min:1). Card should be excluded.
+    // OR-match coverage: card whose only audience is missing from the
+    // caller's resolved list (audiences=openOnly excludes PathStarted).
     allFailingAudiencesCard = await testData.createAppCard(payload, {
       title: 'All Failing Audiences Card',
       image: imageId,
@@ -201,34 +211,118 @@ describe('appCardsForAudience endpoint', () => {
     await cleanup()
   })
 
-  it('returns 400 when targetSection is missing', async () => {
-    const { status } = await callEndpoint(payload, { limit: 5 })
-    expect(status).toBe(400)
+  describe('Validation', () => {
+    it('returns 400 when targetSection is missing', async () => {
+      const { status } = await callEndpoint(payload, { limit: 5 }, undefined, {
+        defaultAudiences: allEligible,
+      })
+      expect(status).toBe(400)
+    })
+
+    it('returns 400 when targetSection is invalid', async () => {
+      const { status } = await callEndpoint(
+        payload,
+        { targetSection: 'footer', limit: 5 },
+        undefined,
+        { defaultAudiences: allEligible },
+      )
+      expect(status).toBe(400)
+    })
+
+    it('returns 400 when limit is missing', async () => {
+      const { status } = await callEndpoint(
+        payload,
+        { targetSection: 'hero' },
+        undefined,
+        { defaultAudiences: allEligible },
+      )
+      expect(status).toBe(400)
+    })
+
+    it('returns 400 when limit is out of range', async () => {
+      const low = await callEndpoint(payload, { targetSection: 'hero', limit: 0 }, undefined, {
+        defaultAudiences: allEligible,
+      })
+      expect(low.status).toBe(400)
+      const high = await callEndpoint(payload, { targetSection: 'hero', limit: 21 }, undefined, {
+        defaultAudiences: allEligible,
+      })
+      expect(high.status).toBe(400)
+    })
+
+    it('returns 400 when audiences is missing', async () => {
+      const { status } = await callEndpoint(
+        payload,
+        { targetSection: 'hero', limit: 5 },
+        undefined,
+        { skipDefaultAudiences: true },
+      )
+      expect(status).toBe(400)
+    })
+
+    it('returns 400 when audiences is empty', async () => {
+      const { status } = await callEndpoint(payload, {
+        audiences: '',
+        targetSection: 'hero',
+        limit: 5,
+      })
+      expect(status).toBe(400)
+    })
+
+    it('returns 400 when audiences contains non-numeric values', async () => {
+      const { status } = await callEndpoint(payload, {
+        audiences: '1,abc',
+        targetSection: 'hero',
+        limit: 5,
+      })
+      expect(status).toBe(400)
+    })
   })
 
-  it('returns 400 when targetSection is invalid', async () => {
-    const { status } = await callEndpoint(payload, { targetSection: 'footer', limit: 5 })
-    expect(status).toBe(400)
+  describe('Cache headers', () => {
+    it('sets Cache-Control: public, max-age=600, s-maxage=600', async () => {
+      const { headers, status } = await callEndpoint(
+        payload,
+        { targetSection: 'hero', limit: 5 },
+        undefined,
+        { defaultAudiences: allEligible },
+      )
+      expect(status).toBe(200)
+      expect(headers.get('Cache-Control')).toBe('public, max-age=600, s-maxage=600')
+    })
   })
 
-  it('returns 400 when limit is missing', async () => {
-    const { status } = await callEndpoint(payload, { targetSection: 'hero' })
-    expect(status).toBe(400)
-  })
+  describe('audiences param normalization', () => {
+    it('treats unsorted/duplicated audiences as equivalent to the canonical sorted form', async () => {
+      const canonical = [openAudience.id, pathStartedAudience.id].join(',')
+      const messy = [pathStartedAudience.id, openAudience.id, openAudience.id].join(',')
 
-  it('returns 400 when limit is out of range', async () => {
-    const low = await callEndpoint(payload, { targetSection: 'hero', limit: 0 })
-    expect(low.status).toBe(400)
-    const high = await callEndpoint(payload, { targetSection: 'hero', limit: 21 })
-    expect(high.status).toBe(400)
+      const a = await callEndpoint(payload, {
+        audiences: canonical,
+        targetSection: 'hero',
+        limit: 20,
+      })
+      const b = await callEndpoint(payload, {
+        audiences: messy,
+        targetSection: 'hero',
+        limit: 20,
+      })
+      expect(a.status).toBe(200)
+      expect(b.status).toBe(200)
+
+      const idsA = (a.body as { docs: AppCard[] }).docs.map((c) => c.id).sort((x, y) => x - y)
+      const idsB = (b.body as { docs: AppCard[] }).docs.map((c) => c.id).sort((x, y) => x - y)
+      expect(idsA).toEqual(idsB)
+    })
   })
 
   it('excludes draft cards', async () => {
-    const { status, body } = await callEndpoint(payload, {
-      targetSection: 'hero',
-      limit: 20,
-      pathProgress: 3,
-    })
+    const { status, body } = await callEndpoint(
+      payload,
+      { targetSection: 'hero', limit: 20 },
+      undefined,
+      { defaultAudiences: allEligible },
+    )
     expect(status).toBe(200)
     const docs = (body as { docs: AppCard[] }).docs
     const ids = docs.map((c) => c.id)
@@ -236,11 +330,12 @@ describe('appCardsForAudience endpoint', () => {
   })
 
   it('filters by targetSection = hero', async () => {
-    const { status, body } = await callEndpoint(payload, {
-      targetSection: 'hero',
-      limit: 20,
-      pathProgress: 3,
-    })
+    const { status, body } = await callEndpoint(
+      payload,
+      { targetSection: 'hero', limit: 20 },
+      undefined,
+      { defaultAudiences: allEligible },
+    )
     expect(status).toBe(200)
     const docs = (body as { docs: AppCard[] }).docs
     const ids = docs.map((c) => c.id)
@@ -250,11 +345,12 @@ describe('appCardsForAudience endpoint', () => {
   })
 
   it('filters by targetSection = highlights', async () => {
-    const { status, body } = await callEndpoint(payload, {
-      targetSection: 'highlights',
-      limit: 20,
-      pathProgress: 3,
-    })
+    const { status, body } = await callEndpoint(
+      payload,
+      { targetSection: 'highlights', limit: 20 },
+      undefined,
+      { defaultAudiences: allEligible },
+    )
     expect(status).toBe(200)
     const docs = (body as { docs: AppCard[] }).docs
     const ids = docs.map((c) => c.id)
@@ -264,77 +360,85 @@ describe('appCardsForAudience endpoint', () => {
   })
 
   it('excludes cards with empty audiences', async () => {
-    const { body } = await callEndpoint(payload, {
-      targetSection: 'hero',
-      limit: 20,
-      pathProgress: 3,
-    })
+    const { body } = await callEndpoint(
+      payload,
+      { targetSection: 'hero', limit: 20 },
+      undefined,
+      { defaultAudiences: allEligible },
+    )
     const ids = (body as { docs: AppCard[] }).docs.map((c) => c.id)
     expect(ids).not.toContain(emptyAudiencesCard.id)
   })
 
-  it('excludes cards whose audiences do not match caller inputs', async () => {
-    // Caller with pathProgress=0 → pathStartedAudience requires min:1, so fails
-    const { body } = await callEndpoint(payload, {
-      targetSection: 'hero',
-      limit: 20,
-      pathProgress: 0,
-    })
+  it('excludes cards whose audiences are not in the requested list', async () => {
+    // Caller's resolved audiences don't include pathStartedAudience.
+    const { body } = await callEndpoint(
+      payload,
+      { targetSection: 'hero', limit: 20 },
+      undefined,
+      { defaultAudiences: openOnly },
+    )
     const ids = (body as { docs: AppCard[] }).docs.map((c) => c.id)
     expect(ids).not.toContain(heroCardPathStarted.id)
   })
 
-  it('includes cards whose audiences match caller inputs', async () => {
-    const { body } = await callEndpoint(payload, {
-      targetSection: 'hero',
-      limit: 20,
-      pathProgress: 3,
-    })
+  it('includes cards whose audiences are in the requested list', async () => {
+    const { body } = await callEndpoint(
+      payload,
+      { targetSection: 'hero', limit: 20 },
+      undefined,
+      { defaultAudiences: allEligible },
+    )
     const ids = (body as { docs: AppCard[] }).docs.map((c) => c.id)
     expect(ids).toContain(heroCardPathStarted.id)
   })
 
-  it('includes cards attached to an audience with null rules', async () => {
-    const { body } = await callEndpoint(payload, {
-      targetSection: 'hero',
-      limit: 20,
-      pathProgress: 0,
-    })
+  it('includes cards attached to a null-rules audience when that ID is in the request', async () => {
+    const { body } = await callEndpoint(
+      payload,
+      { targetSection: 'hero', limit: 20 },
+      undefined,
+      { defaultAudiences: openOnly },
+    )
     const ids = (body as { docs: AppCard[] }).docs.map((c) => c.id)
     expect(ids).toContain(nullRulesAudienceCard.id)
   })
 
   describe('OR-match audiences', () => {
-    it('includes a card when ANY of its audiences passes', async () => {
-      // pathProgress=0 → openAudience (rules:{}) passes, pathStartedAudience (min:1) fails.
-      // Card has both → should be included.
-      const { body } = await callEndpoint(payload, {
-        targetSection: 'hero',
-        limit: 20,
-        pathProgress: 0,
-      })
+    it('includes a card when ANY of its audiences overlaps the requested list', async () => {
+      // Beginner caller (openOnly = Open + NullRules). multiAudienceCard has
+      // [Open, PathStarted] — Open matches, so the card is included.
+      const { body } = await callEndpoint(
+        payload,
+        { targetSection: 'hero', limit: 20 },
+        undefined,
+        { defaultAudiences: openOnly },
+      )
       const ids = (body as { docs: AppCard[] }).docs.map((c) => c.id)
       expect(ids).toContain(multiAudienceCard.id)
     })
 
-    it('excludes a card when ALL of its audiences fail', async () => {
-      // pathProgress=0 → pathStartedAudience (min:1) fails. Card has only that one.
-      const { body } = await callEndpoint(payload, {
-        targetSection: 'hero',
-        limit: 20,
-        pathProgress: 0,
-      })
+    it('excludes a card when NONE of its audiences are in the requested list', async () => {
+      // Beginner caller — allFailingAudiencesCard has only [PathStarted],
+      // which is not in `openOnly`.
+      const { body } = await callEndpoint(
+        payload,
+        { targetSection: 'hero', limit: 20 },
+        undefined,
+        { defaultAudiences: openOnly },
+      )
       const ids = (body as { docs: AppCard[] }).docs.map((c) => c.id)
       expect(ids).not.toContain(allFailingAudiencesCard.id)
     })
   })
 
   it('respects the limit parameter', async () => {
-    const { body } = await callEndpoint(payload, {
-      targetSection: 'hero',
-      limit: 1,
-      pathProgress: 3,
-    })
+    const { body } = await callEndpoint(
+      payload,
+      { targetSection: 'hero', limit: 1 },
+      undefined,
+      { defaultAudiences: allEligible },
+    )
     const docs = (body as { docs: AppCard[] }).docs
     expect(docs).toHaveLength(1)
   })
@@ -351,8 +455,9 @@ describe('appCardsForAudience endpoint', () => {
     try {
       const { status } = await callEndpoint(
         payload,
-        { targetSection: 'hero', limit: 5, pathProgress: 3 },
+        { targetSection: 'hero', limit: 5 },
         { id: client.id, collection: 'clients' },
+        { defaultAudiences: allEligible },
       )
       expect(status).toBe(200)
 
@@ -369,11 +474,12 @@ describe('appCardsForAudience endpoint', () => {
   })
 
   it('populates relationships at depth 1', async () => {
-    const { body } = await callEndpoint(payload, {
-      targetSection: 'hero',
-      limit: 20,
-      pathProgress: 3,
-    })
+    const { body } = await callEndpoint(
+      payload,
+      { targetSection: 'hero', limit: 20 },
+      undefined,
+      { defaultAudiences: allEligible },
+    )
     const docs = (body as { docs: AppCard[] }).docs
     const card = docs.find((c) => c.id === contentCard.id)
     expect(card).toBeDefined()

--- a/tests/int/audiences-for-user.int.spec.ts
+++ b/tests/int/audiences-for-user.int.spec.ts
@@ -1,0 +1,109 @@
+import type { Payload, PayloadRequest } from 'payload'
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+
+import type { Audience } from '@/payload-types'
+
+import { audiencesForUser } from '@/endpoints'
+
+import { testData } from '../utils/testData'
+import { createTestEnvironment } from '../utils/testHelpers'
+
+const AUDIENCE_DEFAULTS = {
+  pathProgress: 0,
+  meditationsPerWeek: 0,
+  totalMeditationsViewed: 0,
+  totalLecturesViewed: 0,
+}
+
+async function callEndpoint(
+  payload: Payload,
+  query: Record<string, string | number | boolean>,
+  options: { skipAudienceDefaults?: boolean } = {},
+): Promise<{ status: number; headers: Headers; body: { audiences?: number[]; errors?: unknown } }> {
+  const finalQuery = options.skipAudienceDefaults ? query : { ...AUDIENCE_DEFAULTS, ...query }
+  const req = {
+    payload,
+    query: finalQuery,
+    headers: new Headers(),
+    routeParams: {},
+  } as unknown as PayloadRequest
+
+  const response = (await audiencesForUser.handler(req)) as Response
+  const body = await response.json()
+  return { status: response.status, headers: response.headers, body }
+}
+
+describe('audiencesForUser endpoint', () => {
+  let payload: Payload
+  let cleanup: () => Promise<void>
+
+  let audienceBeginner: Audience
+  let audienceIntermediate: Audience
+  let audienceFrequent: Audience
+
+  beforeAll(async () => {
+    const env = await createTestEnvironment()
+    payload = env.payload
+    cleanup = env.cleanup
+
+    // Three audiences whose rule sets target distinct slices of the user-state space.
+    // Beginner — pathProgress 0..5
+    audienceBeginner = await testData.createAudience(payload, {
+      label: 'Beginner',
+      rules: { logic: 'AND', pathProgress: { min: 0, max: 5 } },
+    })
+    // Intermediate — pathProgress 5..10
+    audienceIntermediate = await testData.createAudience(payload, {
+      label: 'Intermediate',
+      rules: { logic: 'AND', pathProgress: { min: 5, max: 10 } },
+    })
+    // Frequent meditator — meditationsPerWeek >= 3
+    audienceFrequent = await testData.createAudience(payload, {
+      label: 'Frequent',
+      rules: { logic: 'AND', meditationsPerWeek: { min: 3 } },
+    })
+  })
+
+  afterAll(async () => {
+    await cleanup()
+  })
+
+  it('returns 400 when audience rule-data params are missing', async () => {
+    const { status, body } = await callEndpoint(payload, {}, { skipAudienceDefaults: true })
+    expect(status).toBe(400)
+    expect(body).toHaveProperty('errors')
+  })
+
+  it('returns IDs of audiences whose rules pass for the supplied data', async () => {
+    const { status, body } = await callEndpoint(payload, { pathProgress: 3 })
+    expect(status).toBe(200)
+    expect(body.audiences).toContain(audienceBeginner.id)
+    expect(body.audiences).not.toContain(audienceIntermediate.id)
+  })
+
+  it('returns IDs sorted ascending', async () => {
+    // pathProgress=5 sits in the overlap and matches both Beginner (max 5)
+    // and Intermediate (min 5). The combined list must come back sorted.
+    const { body } = await callEndpoint(payload, { pathProgress: 5 })
+    const ids = body.audiences ?? []
+    expect(ids.length).toBeGreaterThanOrEqual(2)
+    const sorted = [...ids].sort((a, b) => a - b)
+    expect(ids).toEqual(sorted)
+  })
+
+  it('combines matches across rule dimensions (e.g. path + frequency)', async () => {
+    const { body } = await callEndpoint(payload, {
+      pathProgress: 7,
+      meditationsPerWeek: 5,
+    })
+    expect(body.audiences).toContain(audienceIntermediate.id)
+    expect(body.audiences).toContain(audienceFrequent.id)
+    expect(body.audiences).not.toContain(audienceBeginner.id)
+  })
+
+  it('sets Cache-Control: public, max-age=300, s-maxage=300', async () => {
+    const { headers } = await callEndpoint(payload, { pathProgress: 0 })
+    expect(headers.get('Cache-Control')).toBe('public, max-age=300, s-maxage=300')
+  })
+})

--- a/tests/int/lectures-for-audience.int.spec.ts
+++ b/tests/int/lectures-for-audience.int.spec.ts
@@ -29,26 +29,19 @@ vi.mock('@/lib/nirmalaVidyaApi', async (importOriginal) => {
   }
 })
 
-// All audience params are required by the endpoint's Zod schema. Tests that
-// don't exercise a specific param still need to pass neutral defaults; only
-// the 400-validation cases should call with `{ skipAudienceDefaults: true }`
-// to omit them and exercise the "missing required param" path.
-const AUDIENCE_DEFAULTS = {
-  pathProgress: 0,
-  meditationsPerWeek: 0,
-  totalMeditationsViewed: 0,
-  totalLecturesViewed: 0,
-}
-
+// `audiences` is required by the endpoint's Zod schema. Tests that don't
+// exercise a specific eligibility scenario still need to pass a non-empty
+// list; pass `{ skipDefaultAudiences: true }` on the 400-validation cases
+// that want to omit it entirely.
 async function callEndpoint(
   payload: Payload,
   query: Record<string, string | number | boolean>,
   user?: { id: number | string; collection: string },
-  options: { skipAudienceDefaults?: boolean } = {},
-): Promise<{ status: number; body: { docs: LecturePlayerData[] } | unknown }> {
-  const finalQuery = options.skipAudienceDefaults
+  options: { skipDefaultAudiences?: boolean; defaultAudiences?: string } = {},
+): Promise<{ status: number; headers: Headers; body: { docs: LecturePlayerData[] } | unknown }> {
+  const finalQuery = options.skipDefaultAudiences
     ? query
-    : { ...AUDIENCE_DEFAULTS, ...query }
+    : { audiences: options.defaultAudiences ?? '', ...query }
   const req = {
     payload,
     query: finalQuery,
@@ -59,7 +52,7 @@ async function callEndpoint(
 
   const response = (await lecturesForAudience.handler(req)) as Response
   const body = await response.json()
-  return { status: response.status, body }
+  return { status: response.status, headers: response.headers, body }
 }
 
 describe('lecturesForAudience endpoint', () => {
@@ -69,6 +62,10 @@ describe('lecturesForAudience endpoint', () => {
 
   let audienceBeginner: Audience
   let audienceIntermediate: Audience
+  let audienceUnused: Audience
+
+  let beginnerOnly: string // audiences param for "Beginner only is eligible"
+  let intermediateOnly: string
 
   let lectureBeginnerOnly: Lecture
   let lectureIntermediateOnly: Lecture
@@ -95,6 +92,14 @@ describe('lecturesForAudience endpoint', () => {
       label: 'Intermediate',
       rules: { logic: 'AND', pathProgress: { min: 5, max: 10 } },
     })
+    // No lectures attached — used to exercise the empty-result path.
+    audienceUnused = await testData.createAudience(payload, {
+      label: 'Unused',
+      rules: { logic: 'AND', pathProgress: { min: 50, max: 100 } },
+    })
+
+    beginnerOnly = String(audienceBeginner.id)
+    intermediateOnly = String(audienceIntermediate.id)
 
     editorThumbnailImage = (await testData.createMediaImage(payload, {
       alt: 'Editor override',
@@ -118,7 +123,7 @@ describe('lecturesForAudience endpoint', () => {
       { title: 'No Audience Lecture', audiences: [] },
     )
 
-    // OR-match: passes when ANY attached audience matches.
+    // OR-match: passes when ANY attached audience is in the requested list.
     lectureMultiAudience = await testData.createLecture(
       payload,
       {},
@@ -128,7 +133,7 @@ describe('lecturesForAudience endpoint', () => {
       },
     )
 
-    // OR-match: should be excluded for pathProgress=3 (Intermediate fails).
+    // Should be excluded when only Beginner is requested.
     lectureAllFailingAudiences = await testData.createLecture(
       payload,
       {},
@@ -189,37 +194,77 @@ describe('lecturesForAudience endpoint', () => {
 
   describe('Validation', () => {
     it('returns 400 when limit is missing', async () => {
-      const { status } = await callEndpoint(payload, {})
-      expect(status).toBe(400)
-    })
-
-    it('returns 400 when limit is out of range', async () => {
-      expect((await callEndpoint(payload, { limit: 0 })).status).toBe(400)
-      expect((await callEndpoint(payload, { limit: 101 })).status).toBe(400)
-    })
-
-    it('returns 400 when a numeric param is non-numeric', async () => {
-      const { status } = await callEndpoint(payload, {
-        limit: 10,
-        pathProgress: 'not-a-number',
+      const { status } = await callEndpoint(payload, {}, undefined, {
+        defaultAudiences: beginnerOnly,
       })
       expect(status).toBe(400)
     })
 
-    it('returns 400 when any audience-data param is missing', async () => {
+    it('returns 400 when limit is out of range', async () => {
+      expect(
+        (await callEndpoint(payload, { limit: 0 }, undefined, { defaultAudiences: beginnerOnly })).status,
+      ).toBe(400)
+      expect(
+        (await callEndpoint(payload, { limit: 101 }, undefined, { defaultAudiences: beginnerOnly })).status,
+      ).toBe(400)
+    })
+
+    it('returns 400 when audiences is missing', async () => {
       const { status } = await callEndpoint(
         payload,
-        { limit: 10, pathProgress: 3 },
+        { limit: 10 },
         undefined,
-        { skipAudienceDefaults: true },
+        { skipDefaultAudiences: true },
       )
       expect(status).toBe(400)
+    })
+
+    it('returns 400 when audiences is empty', async () => {
+      const { status } = await callEndpoint(payload, { audiences: '', limit: 10 })
+      expect(status).toBe(400)
+    })
+
+    it('returns 400 when audiences contains non-numeric values', async () => {
+      const { status } = await callEndpoint(payload, { audiences: '1,abc,3', limit: 10 })
+      expect(status).toBe(400)
+    })
+  })
+
+  describe('Cache headers', () => {
+    it('sets Cache-Control: public, max-age=600, s-maxage=600', async () => {
+      const { headers, status } = await callEndpoint(
+        payload,
+        { limit: 10 },
+        undefined,
+        { defaultAudiences: beginnerOnly },
+      )
+      expect(status).toBe(200)
+      expect(headers.get('Cache-Control')).toBe('public, max-age=600, s-maxage=600')
+    })
+  })
+
+  describe('audiences param normalization', () => {
+    it('treats unsorted/duplicated audiences as equivalent to the canonical sorted form', async () => {
+      const canonical = `${audienceBeginner.id},${audienceIntermediate.id}`
+      const messy = `${audienceIntermediate.id},${audienceBeginner.id},${audienceBeginner.id}`
+
+      const a = await callEndpoint(payload, { audiences: canonical, limit: 100 })
+      const b = await callEndpoint(payload, { audiences: messy, limit: 100 })
+      expect(a.status).toBe(200)
+      expect(b.status).toBe(200)
+
+      const idsA = (a.body as { docs: LecturePlayerData[] }).docs.map((d) => d.id).sort((x, y) => x - y)
+      const idsB = (b.body as { docs: LecturePlayerData[] }).docs.map((d) => d.id).sort((x, y) => x - y)
+      // Same eligible pool — random order but identical set.
+      expect(idsA).toEqual(idsB)
     })
   })
 
   describe('Uniform response shape', () => {
     it('emits the same flat key set for every record (no excerpt-vs-full branching)', async () => {
-      const { body } = await callEndpoint(payload, { limit: 100, pathProgress: 3 })
+      const { body } = await callEndpoint(payload, { limit: 100 }, undefined, {
+        defaultAudiences: beginnerOnly,
+      })
       const docs = (body as { docs: LecturePlayerData[] }).docs
 
       expect(docs.length).toBeGreaterThan(0)
@@ -245,7 +290,9 @@ describe('lecturesForAudience endpoint', () => {
     })
 
     it('respects `limit` across the full pool', async () => {
-      const { body } = await callEndpoint(payload, { limit: 1, pathProgress: 3 })
+      const { body } = await callEndpoint(payload, { limit: 1 }, undefined, {
+        defaultAudiences: beginnerOnly,
+      })
       const docs = (body as { docs: LecturePlayerData[] }).docs
       expect(docs).toHaveLength(1)
     })
@@ -253,7 +300,9 @@ describe('lecturesForAudience endpoint', () => {
     it('fetches the full eligible pool, not just `limit` rows, before sampling', async () => {
       const findSpy = vi.spyOn(payload, 'find')
       try {
-        await callEndpoint(payload, { limit: 1, pathProgress: 3 })
+        await callEndpoint(payload, { limit: 1 }, undefined, {
+          defaultAudiences: beginnerOnly,
+        })
         const lectureFindCall = findSpy.mock.calls.find(
           ([args]) => (args as { collection?: string }).collection === 'lectures',
         )
@@ -272,7 +321,9 @@ describe('lecturesForAudience endpoint', () => {
 
   describe('Default time fields', () => {
     it('lectures with no startTime/stopTime resolve to startTime=0, stopTime=null when metadata.duration is missing', async () => {
-      const { body } = await callEndpoint(payload, { limit: 100, pathProgress: 3 })
+      const { body } = await callEndpoint(payload, { limit: 100 }, undefined, {
+        defaultAudiences: beginnerOnly,
+      })
       const lecture = (body as { docs: LecturePlayerData[] }).docs.find(
         (d) => d.id === lectureBeginnerOnly.id,
       )
@@ -298,7 +349,9 @@ describe('lecturesForAudience endpoint', () => {
         { title: 'Lecture With Duration', audiences: [audienceBeginner.id] },
       )
 
-      const { body } = await callEndpoint(payload, { limit: 100, pathProgress: 3 })
+      const { body } = await callEndpoint(payload, { limit: 100 }, undefined, {
+        defaultAudiences: beginnerOnly,
+      })
       const item = (body as { docs: LecturePlayerData[] }).docs.find(
         (d) => d.id === lectureWithDuration.id,
       )
@@ -309,7 +362,9 @@ describe('lecturesForAudience endpoint', () => {
     })
 
     it('excerpts with explicit startTime/stopTime pass them through and expose fullLectureId', async () => {
-      const { body } = await callEndpoint(payload, { limit: 100, pathProgress: 3 })
+      const { body } = await callEndpoint(payload, { limit: 100 }, undefined, {
+        defaultAudiences: beginnerOnly,
+      })
       const item = (body as { docs: LecturePlayerData[] }).docs.find(
         (d) => d.id === excerptOfBeginner.id,
       )
@@ -322,14 +377,18 @@ describe('lecturesForAudience endpoint', () => {
   })
 
   describe('Eligibility', () => {
-    it('returns lectures whose audiences pass', async () => {
-      const { body } = await callEndpoint(payload, { limit: 100, pathProgress: 3 })
+    it('returns lectures whose audiences overlap the requested list', async () => {
+      const { body } = await callEndpoint(payload, { limit: 100 }, undefined, {
+        defaultAudiences: beginnerOnly,
+      })
       const ids = (body as { docs: LecturePlayerData[] }).docs.map((d) => d.id)
       expect(ids).toContain(lectureBeginnerOnly.id)
     })
 
     it('excludes records with no audiences', async () => {
-      const { body } = await callEndpoint(payload, { limit: 100, pathProgress: 3 })
+      const { body } = await callEndpoint(payload, { limit: 100 }, undefined, {
+        defaultAudiences: beginnerOnly,
+      })
       const ids = (body as { docs: LecturePlayerData[] }).docs.map((d) => d.id)
       expect(ids).not.toContain(lectureNoAudience.id)
       const titles = (body as { docs: LecturePlayerData[] }).docs.map((d) => d.title)
@@ -337,7 +396,9 @@ describe('lecturesForAudience endpoint', () => {
     })
 
     it('returns excerpts independently of their fullLecture parent eligibility', async () => {
-      const { body } = await callEndpoint(payload, { limit: 100, pathProgress: 3 })
+      const { body } = await callEndpoint(payload, { limit: 100 }, undefined, {
+        defaultAudiences: beginnerOnly,
+      })
       const ids = (body as { docs: LecturePlayerData[] }).docs.map((d) => d.id)
       expect(ids).toContain(excerptOfBeginner.id)
       expect(ids).toContain(excerptOfIntermediate.id)
@@ -347,11 +408,10 @@ describe('lecturesForAudience endpoint', () => {
       expect(ineligibleParentExcerpt.fullLectureId).toBe(lectureIntermediateOnly.id)
     })
 
-    it('returns empty docs when no audiences pass', async () => {
+    it('returns empty docs when the requested audiences match no lectures', async () => {
       const { status, body } = await callEndpoint(payload, {
+        audiences: String(audienceUnused.id),
         limit: 100,
-        pathProgress: 99,
-        totalLecturesViewed: 0,
       })
       expect(status).toBe(200)
       expect((body as { docs: LecturePlayerData[] }).docs).toEqual([])
@@ -359,15 +419,20 @@ describe('lecturesForAudience endpoint', () => {
   })
 
   describe('OR-match audiences', () => {
-    it('includes a lecture when ANY of its multiple audiences passes', async () => {
-      // pathProgress=3 → Beginner passes, Intermediate fails. Lecture has both.
-      const { body } = await callEndpoint(payload, { limit: 100, pathProgress: 3 })
+    it('includes a lecture when ANY of its multiple audiences overlaps the requested list', async () => {
+      // Requested only Beginner. lectureMultiAudience has [Beginner, Intermediate].
+      const { body } = await callEndpoint(payload, { limit: 100 }, undefined, {
+        defaultAudiences: beginnerOnly,
+      })
       const ids = (body as { docs: LecturePlayerData[] }).docs.map((d) => d.id)
       expect(ids).toContain(lectureMultiAudience.id)
     })
 
-    it('excludes a lecture when ALL of its audiences fail', async () => {
-      const { body } = await callEndpoint(payload, { limit: 100, pathProgress: 3 })
+    it('excludes a lecture when NONE of its audiences are in the requested list', async () => {
+      // Requested only Beginner. lectureAllFailingAudiences has [Intermediate].
+      const { body } = await callEndpoint(payload, { limit: 100 }, undefined, {
+        defaultAudiences: beginnerOnly,
+      })
       const ids = (body as { docs: LecturePlayerData[] }).docs.map((d) => d.id)
       expect(ids).not.toContain(lectureAllFailingAudiences.id)
     })
@@ -375,7 +440,9 @@ describe('lecturesForAudience endpoint', () => {
 
   describe('Subtitle merge', () => {
     it('exposes the full metadata.subtitles map when no overrides are set', async () => {
-      const { body } = await callEndpoint(payload, { limit: 100, pathProgress: 3 })
+      const { body } = await callEndpoint(payload, { limit: 100 }, undefined, {
+        defaultAudiences: beginnerOnly,
+      })
       const lecture = (body as { docs: LecturePlayerData[] }).docs.find(
         (d) => d.id === lectureBeginnerOnly.id,
       )
@@ -387,7 +454,9 @@ describe('lecturesForAudience endpoint', () => {
     })
 
     it('layers a per-locale override on top of metadata.subtitles', async () => {
-      const { body } = await callEndpoint(payload, { limit: 100, pathProgress: 3 })
+      const { body } = await callEndpoint(payload, { limit: 100 }, undefined, {
+        defaultAudiences: beginnerOnly,
+      })
       const lecture = (body as { docs: LecturePlayerData[] }).docs.find(
         (d) => d.id === lectureWithSubtitleOverride.id,
       )
@@ -402,7 +471,9 @@ describe('lecturesForAudience endpoint', () => {
 
   describe('Thumbnail fallback', () => {
     it('uses the editor override when present', async () => {
-      const { body } = await callEndpoint(payload, { limit: 100, pathProgress: 3 })
+      const { body } = await callEndpoint(payload, { limit: 100 }, undefined, {
+        defaultAudiences: beginnerOnly,
+      })
       const lecture = (body as { docs: LecturePlayerData[] }).docs.find(
         (d) => d.id === lectureBeginnerOnly.id,
       )
@@ -411,7 +482,9 @@ describe('lecturesForAudience endpoint', () => {
     })
 
     it('falls back to metadata.thumbnailUrl when no editor override is set', async () => {
-      const { body } = await callEndpoint(payload, { limit: 100, pathProgress: 7 })
+      const { body } = await callEndpoint(payload, { limit: 100 }, undefined, {
+        defaultAudiences: intermediateOnly,
+      })
       const lecture = (body as { docs: LecturePlayerData[] }).docs.find(
         (d) => d.id === lectureIntermediateOnly.id,
       )
@@ -422,7 +495,9 @@ describe('lecturesForAudience endpoint', () => {
 
   describe('Clip sources metadata from parent (#338)', () => {
     it('uses parent.metadata.hlsUrl for clip records (clips have metadata: null)', async () => {
-      const { body } = await callEndpoint(payload, { limit: 100, pathProgress: 3 })
+      const { body } = await callEndpoint(payload, { limit: 100 }, undefined, {
+        defaultAudiences: beginnerOnly,
+      })
       const clip = (body as { docs: LecturePlayerData[] }).docs.find(
         (d) => d.id === excerptOfBeginner.id,
       )
@@ -449,7 +524,9 @@ describe('lecturesForAudience endpoint', () => {
         { audiences: [audienceBeginner.id] },
       )
 
-      const { body } = await callEndpoint(payload, { limit: 100, pathProgress: 3 })
+      const { body } = await callEndpoint(payload, { limit: 100 }, undefined, {
+        defaultAudiences: beginnerOnly,
+      })
       const item = (body as { docs: LecturePlayerData[] }).docs.find((d) => d.id === clip.id)
       expect(item).toBeDefined()
       expect(item!.thumbnailUrl).toBe('https://example.com/parent-thumb.jpg')
@@ -472,7 +549,9 @@ describe('lecturesForAudience endpoint', () => {
         { audiences: [audienceBeginner.id], thumbnail: overrideThumb.id },
       )
 
-      const { body } = await callEndpoint(payload, { limit: 100, pathProgress: 3 })
+      const { body } = await callEndpoint(payload, { limit: 100 }, undefined, {
+        defaultAudiences: beginnerOnly,
+      })
       const item = (body as { docs: LecturePlayerData[] }).docs.find((d) => d.id === clip.id)
       expect(item).toBeDefined()
       // Override thumbnail came back through the editor relationship, not the
@@ -503,7 +582,9 @@ describe('lecturesForAudience endpoint', () => {
         },
       )
 
-      const { body } = await callEndpoint(payload, { limit: 100, pathProgress: 3 })
+      const { body } = await callEndpoint(payload, { limit: 100 }, undefined, {
+        defaultAudiences: beginnerOnly,
+      })
       const item = (body as { docs: LecturePlayerData[] }).docs.find((d) => d.id === clip.id)
       expect(item).toBeDefined()
       expect(item!.subtitles).toEqual({
@@ -528,7 +609,9 @@ describe('lecturesForAudience endpoint', () => {
         { audiences: [audienceBeginner.id], startTime: null, stopTime: null },
       )
 
-      const { body } = await callEndpoint(payload, { limit: 100, pathProgress: 3 })
+      const { body } = await callEndpoint(payload, { limit: 100 }, undefined, {
+        defaultAudiences: beginnerOnly,
+      })
       const item = (body as { docs: LecturePlayerData[] }).docs.find((d) => d.id === clip.id)
       expect(item).toBeDefined()
       expect(item!.startTime).toBe(0)
@@ -538,7 +621,7 @@ describe('lecturesForAudience endpoint', () => {
   })
 
   describe('req forwarding', () => {
-    it('threads req through all payload.find calls for usage-tracking / rate-limit hooks', async () => {
+    it('threads req through the lectures payload.find call for usage-tracking / rate-limit hooks', async () => {
       void audienceIntermediate
       void lectureIntermediateOnly
 
@@ -550,8 +633,9 @@ describe('lecturesForAudience endpoint', () => {
       try {
         const { status } = await callEndpoint(
           payload,
-          { limit: 5, pathProgress: 3 },
+          { limit: 5 },
           { id: client.id, collection: 'clients' },
+          { defaultAudiences: beginnerOnly },
         )
         expect(status).toBe(200)
 
@@ -560,7 +644,6 @@ describe('lecturesForAudience endpoint', () => {
             .map(([args]) => (args as { collection?: string }).collection)
             .filter(Boolean) as string[],
         )
-        expect(collectionsHit.has('audiences')).toBe(true)
         expect(collectionsHit.has('lectures')).toBe(true)
 
         for (const args of findSpy.mock.calls.map((c) => c[0])) {

--- a/tests/int/meditation-lectures.int.spec.ts
+++ b/tests/int/meditation-lectures.int.spec.ts
@@ -32,22 +32,19 @@ vi.mock('@/lib/nirmalaVidyaApi', async (importOriginal) => {
   }
 })
 
-const AUDIENCE_DEFAULTS = {
-  pathProgress: 3,
-  meditationsPerWeek: 1,
-  totalMeditationsViewed: 5,
-  totalLecturesViewed: 0,
-}
-
+// `audiences` is a required, non-empty comma-separated list of IDs. Tests
+// that don't exercise validation pass the resolved-audience ID through
+// `defaultAudiences`. Cases that want to omit it entirely set
+// `skipDefaultAudiences: true`.
 async function callEndpoint(
   payload: Payload,
   meditationId: number | string,
   query: Record<string, string | number | boolean> = {},
-  options: { skipAudienceDefaults?: boolean } = {},
-): Promise<{ status: number; body: { docs: LecturePlayerData[] } | unknown }> {
-  const finalQuery = options.skipAudienceDefaults
+  options: { skipDefaultAudiences?: boolean; defaultAudiences?: string } = {},
+): Promise<{ status: number; headers: Headers; body: { docs: LecturePlayerData[] } | unknown }> {
+  const finalQuery = options.skipDefaultAudiences
     ? query
-    : { ...AUDIENCE_DEFAULTS, ...query }
+    : { audiences: options.defaultAudiences ?? '', ...query }
   const req = {
     payload,
     query: finalQuery,
@@ -62,7 +59,7 @@ async function callEndpoint(
 
   const response = (await meditationLectures.handler(req)) as Response
   const body = await response.json()
-  return { status: response.status, body }
+  return { status: response.status, headers: response.headers, body }
 }
 
 describe('meditationLectures endpoint', () => {
@@ -80,6 +77,8 @@ describe('meditationLectures endpoint', () => {
   let frameC: Frame
 
   let audience: Audience
+  let audienceFilter: string // comma-separated audiences param including `audience`
+  let unusedAudience: Audience // matches no lectures — used for the empty-result test
   let userChoice: UserChoice
 
   let lectureA: Lecture // [nodeA]            ≈ 10s
@@ -129,6 +128,12 @@ describe('meditationLectures endpoint', () => {
     audience = await testData.createAudience(payload, {
       label: 'Everyone',
       rules: { logic: 'AND', pathProgress: { min: 0, max: 100 } },
+    })
+    audienceFilter = String(audience.id)
+
+    unusedAudience = await testData.createAudience(payload, {
+      label: 'Unused',
+      rules: {},
     })
 
     userChoice = await testData.createUserChoice(payload, { title: 'Stress relief' })
@@ -205,7 +210,9 @@ describe('meditationLectures endpoint', () => {
   })
 
   it('returns lectures sorted by descending overlap weight', async () => {
-    const { status, body } = await callEndpoint(payload, meditation.id, { limit: 10 })
+    const { status, body } = await callEndpoint(payload, meditation.id, { limit: 10 }, {
+      defaultAudiences: audienceFilter,
+    })
     expect(status).toBe(200)
     const docs = (body as { docs: LecturePlayerData[] }).docs
 
@@ -226,8 +233,12 @@ describe('meditationLectures endpoint', () => {
   })
 
   it('is deterministic across repeated calls', async () => {
-    const a = await callEndpoint(payload, meditation.id, { limit: 10 })
-    const b = await callEndpoint(payload, meditation.id, { limit: 10 })
+    const a = await callEndpoint(payload, meditation.id, { limit: 10 }, {
+      defaultAudiences: audienceFilter,
+    })
+    const b = await callEndpoint(payload, meditation.id, { limit: 10 }, {
+      defaultAudiences: audienceFilter,
+    })
     expect((a.body as { docs: LecturePlayerData[] }).docs.map((d) => d.id)).toEqual(
       (b.body as { docs: LecturePlayerData[] }).docs.map((d) => d.id),
     )
@@ -237,20 +248,24 @@ describe('meditationLectures endpoint', () => {
     // lectureUC has nodeA (≈10s weight); lectureUCNone has [] (zero weight).
     // Both share the userChoice. With userChoice set, the chakra filter
     // relaxes — lectureUCNone is kept and sorted after lectureUC.
-    const { status, body } = await callEndpoint(payload, meditation.id, {
-      limit: 10,
-      userChoice: userChoice.id,
-    })
+    const { status, body } = await callEndpoint(
+      payload,
+      meditation.id,
+      { limit: 10, userChoice: userChoice.id },
+      { defaultAudiences: audienceFilter },
+    )
     expect(status).toBe(200)
     const docs = (body as { docs: LecturePlayerData[] }).docs
     expect(docs.map((d) => d.id)).toEqual([lectureUC.id, lectureUCNone.id])
   })
 
   it('excludedLectureIds removes the listed lectures', async () => {
-    const { body } = await callEndpoint(payload, meditation.id, {
-      limit: 10,
-      excludedLectureIds: `${lectureAB.id},${lectureB.id}`,
-    })
+    const { body } = await callEndpoint(
+      payload,
+      meditation.id,
+      { limit: 10, excludedLectureIds: `${lectureAB.id},${lectureB.id}` },
+      { defaultAudiences: audienceFilter },
+    )
     const ids = (body as { docs: LecturePlayerData[] }).docs.map((d) => d.id)
     expect(ids).not.toContain(lectureAB.id)
     expect(ids).not.toContain(lectureB.id)
@@ -259,44 +274,102 @@ describe('meditationLectures endpoint', () => {
 
   it('userChoice + excludedLectureIds removes weighted and zero-weight matches', async () => {
     // Exclude the weighted match — zero-weight match still returns under userChoice.
-    const a = await callEndpoint(payload, meditation.id, {
-      limit: 10,
-      userChoice: userChoice.id,
-      excludedLectureIds: `${lectureUC.id}`,
-    })
+    const a = await callEndpoint(
+      payload,
+      meditation.id,
+      { limit: 10, userChoice: userChoice.id, excludedLectureIds: `${lectureUC.id}` },
+      { defaultAudiences: audienceFilter },
+    )
     expect((a.body as { docs: LecturePlayerData[] }).docs.map((d) => d.id)).toEqual([
       lectureUCNone.id,
     ])
     // Exclude both — empty.
-    const b = await callEndpoint(payload, meditation.id, {
-      limit: 10,
-      userChoice: userChoice.id,
-      excludedLectureIds: `${lectureUC.id},${lectureUCNone.id}`,
-    })
+    const b = await callEndpoint(
+      payload,
+      meditation.id,
+      {
+        limit: 10,
+        userChoice: userChoice.id,
+        excludedLectureIds: `${lectureUC.id},${lectureUCNone.id}`,
+      },
+      { defaultAudiences: audienceFilter },
+    )
     expect((b.body as { docs: LecturePlayerData[] }).docs).toEqual([])
   })
 
   it('returns 404 for unknown meditation', async () => {
-    const { status, body } = await callEndpoint(payload, 999999, { limit: 10 })
+    const { status, body } = await callEndpoint(payload, 999999, { limit: 10 }, {
+      defaultAudiences: audienceFilter,
+    })
     expect(status).toBe(404)
     expect((body as { errors: Array<{ message: string }> }).errors[0].message).toContain(
       'Meditation not found',
     )
   })
 
-  it('returns empty when audience filter rejects everything', async () => {
-    // Use a pathProgress outside the [0,100] range so no audience matches
+  it('returns empty when audiences filter rejects everything', async () => {
+    // Caller's resolved audiences don't include `audience`, so no lectures qualify.
     const { status, body } = await callEndpoint(
       payload,
       meditation.id,
-      { limit: 10, pathProgress: 999 },
+      { limit: 10 },
+      { defaultAudiences: String(unusedAudience.id) },
     )
     expect(status).toBe(200)
     expect((body as { docs: LecturePlayerData[] }).docs).toEqual([])
   })
 
+  it('returns 400 when audiences is missing', async () => {
+    const { status } = await callEndpoint(
+      payload,
+      meditation.id,
+      { limit: 10 },
+      { skipDefaultAudiences: true },
+    )
+    expect(status).toBe(400)
+  })
+
+  it('returns 400 when audiences is empty', async () => {
+    const { status } = await callEndpoint(payload, meditation.id, { audiences: '', limit: 10 })
+    expect(status).toBe(400)
+  })
+
+  it('returns 400 when audiences contains non-numeric values', async () => {
+    const { status } = await callEndpoint(payload, meditation.id, {
+      audiences: '1,abc',
+      limit: 10,
+    })
+    expect(status).toBe(400)
+  })
+
+  it('sets Cache-Control: public, max-age=600, s-maxage=600 on success', async () => {
+    const { status, headers } = await callEndpoint(
+      payload,
+      meditation.id,
+      { limit: 10 },
+      { defaultAudiences: audienceFilter },
+    )
+    expect(status).toBe(200)
+    expect(headers.get('Cache-Control')).toBe('public, max-age=600, s-maxage=600')
+  })
+
+  it('treats unsorted/duplicated audiences as equivalent to the canonical sorted form', async () => {
+    const messy = `${audience.id},${audience.id}`
+    const a = await callEndpoint(payload, meditation.id, { limit: 10 }, {
+      defaultAudiences: audienceFilter,
+    })
+    const b = await callEndpoint(payload, meditation.id, { audiences: messy, limit: 10 })
+    expect(a.status).toBe(200)
+    expect(b.status).toBe(200)
+    expect((a.body as { docs: LecturePlayerData[] }).docs.map((d) => d.id)).toEqual(
+      (b.body as { docs: LecturePlayerData[] }).docs.map((d) => d.id),
+    )
+  })
+
   it('emits the flat LecturePlayerData shape', async () => {
-    const { body } = await callEndpoint(payload, meditation.id, { limit: 1 })
+    const { body } = await callEndpoint(payload, meditation.id, { limit: 1 }, {
+      defaultAudiences: audienceFilter,
+    })
     const docs = (body as { docs: LecturePlayerData[] }).docs
     expect(docs.length).toBe(1)
     const expectedKeys = [
@@ -335,7 +408,9 @@ describe('meditationLectures endpoint', () => {
     })) as Meditation
     expect(cleared.subtleSystemNodeWeights).toBeFalsy()
 
-    const { status, body } = await callEndpoint(payload, meditation.id, { limit: 5 })
+    const { status, body } = await callEndpoint(payload, meditation.id, { limit: 5 }, {
+      defaultAudiences: audienceFilter,
+    })
     expect(status).toBe(200)
     const docs = (body as { docs: LecturePlayerData[] }).docs
     expect(docs.length).toBeGreaterThan(0)

--- a/tests/unit/audiences-query-param.spec.ts
+++ b/tests/unit/audiences-query-param.spec.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest'
+
+import { audiencesQueryParamSchema } from '@/lib/audiences/audiencesQueryParam'
+
+describe('audiencesQueryParamSchema', () => {
+  it('parses a comma-separated list', () => {
+    const result = audiencesQueryParamSchema.parse('1,2,3')
+    expect(result).toEqual([1, 2, 3])
+  })
+
+  it('deduplicates and sorts ascending', () => {
+    const result = audiencesQueryParamSchema.parse('3,1,2,1')
+    expect(result).toEqual([1, 2, 3])
+  })
+
+  it('rejects an empty string', () => {
+    const result = audiencesQueryParamSchema.safeParse('')
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects a non-numeric token', () => {
+    const result = audiencesQueryParamSchema.safeParse('1,abc,3')
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects undefined', () => {
+    const result = audiencesQueryParamSchema.safeParse(undefined)
+    expect(result.success).toBe(false)
+  })
+
+  it('coerces a string array (qs-esm output for repeated query params) to the canonical form', () => {
+    const result = audiencesQueryParamSchema.parse(['3', '1', '2'])
+    expect(result).toEqual([1, 2, 3])
+  })
+
+  it('coerces an empty array to a 400-rejecting empty input', () => {
+    const result = audiencesQueryParamSchema.safeParse([])
+    expect(result.success).toBe(false)
+  })
+})


### PR DESCRIPTION
Closes #340

## Summary

Splits per-request audience rule evaluation out of the three `/for-audience` data endpoints into a dedicated `GET /api/audiences/for-user` endpoint, so the data endpoints can become edge-cacheable.

- New `/api/audiences/for-user` takes the four rule-data params (`pathProgress`, `meditationsPerWeek`, `totalMeditationsViewed`, `totalLecturesViewed`) and returns the matched `{ audiences: number[] }` (sorted ascending). `Cache-Control: public, max-age=300, s-maxage=300`.
- The three data endpoints (`/api/lectures/for-audience`, `/api/app-cards/for-audience`, `/api/meditations/:id/related-lectures`) drop those rule-data params in favor of a single comma-separated `audiences` query param. Server normalizes the list (dedupe + sort ascending) so equivalent client requests collapse to the same edge-cache key. `Cache-Control: public, max-age=600, s-maxage=600`. _(The issue suggested `3600`; we picked `600` to keep CMS content-edit propagation snappy — happy to bump if hit-rate data warrants it.)_
- Shared `evaluateAudiencesForUser` helper in `src/lib/audiences/`. Shared `audiencesQueryParamSchema` Zod parser used by all three data endpoints. `AUDIENCE_DEFINITIONS` moved to `src/lib/audiences/definitions.ts` (re-exported from `Audiences.ts`) to break the import cycle the new endpoint registration introduced.
- OpenAPI shim updated: new `/api/audiences/for-user` path with the `AudienceIdList` response schema; data endpoints get the new `audiences` parameter shape and lose the rule-data params.

**Breaking change** — old query-param shape on the three data endpoints is removed in this PR; no aliasing or transition period.

## Test Results

- Unit tests: 248 passed (14 files)
- Integration tests: 621 passed (38 files)
- E2E tests: not present, skipped
- Build: ✓ Success
- Lint: ✓ Clean
- Type check (`tsc --noEmit`): ✓ Clean

## Test plan

- [x] Run `pnpm exec vitest run tests/int/audiences-for-user.int.spec.ts tests/int/lectures-for-audience.int.spec.ts tests/int/app-cards-for-audience.int.spec.ts tests/int/meditation-lectures.int.spec.ts tests/int/api-explorer.int.spec.ts` — all green.
- [x] `pnpm test` (full suite) — 869 passed.
- [x] `pnpm lint && pnpm build && pnpm exec tsc --noEmit` — all clean.
- [ ] Manual smoke (post-merge in dev): hit each endpoint with curl and confirm response bodies and `Cache-Control` headers match expectations.
- [ ] Manual smoke (post-merge in dev): confirm Scalar UI at `/api/docs` lists the new endpoint and removes the old rule-data params from the three data endpoints.

## Out of scope (per issue)

- Stable token / hash API to shrink the cache key further.
- Cache purging on Audience edits via Cloudflare Cache API. Worth a follow-up once we have hit-rate data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)