### PR TITLE
fix(lessons): strip stale lexical references

### DIFF
--- a/src/collections/content/Lessons.ts
+++ b/src/collections/content/Lessons.ts
@@ -2,6 +2,7 @@ import type { CollectionConfig } from 'payload'
 
 import { QuoteBlock } from '@/blocks/pages'
 import { mediaField } from '@/fields'
+import { removeDanglingLexicalReferencesAfterRead } from '@/hooks/lexicalHooks'
 import { fullRichTextEditor } from '@/lib/richEditor'
 import { subtitlesJsonSchema, validateSubtitles } from '@/lib/subtitles'
 
@@ -132,6 +133,9 @@ export const Lessons: CollectionConfig = {
               type: 'richText',
               localized: true,
               editor: fullRichTextEditor([QuoteBlock]),
+              hooks: {
+                afterRead: [removeDanglingLexicalReferencesAfterRead],
+              },
             },
           ],
         },

--- a/src/collections/content/Pages.ts
+++ b/src/collections/content/Pages.ts
@@ -2,6 +2,7 @@ import type { CollectionConfig } from 'payload'
 
 import { pageBlocks } from '@/blocks/pages'
 import { slugField } from '@/fields'
+import { removeDanglingLexicalReferencesAfterRead } from '@/hooks/lexicalHooks'
 import { PAGE_TAGS } from '@/lib/constants'
 import { fullRichTextEditor } from '@/lib/richEditor'
 
@@ -46,6 +47,9 @@ export const Pages: CollectionConfig = {
               type: 'richText',
               localized: true,
               editor: fullRichTextEditor(pageBlocks),
+              hooks: {
+                afterRead: [removeDanglingLexicalReferencesAfterRead],
+              },
             },
           ],
         },

--- a/src/hooks/lexicalHooks.ts
+++ b/src/hooks/lexicalHooks.ts
@@ -1,0 +1,89 @@
+import type { FieldHook } from 'payload'
+
+type LexicalNodeRecord = Record<string, unknown> & {
+  children?: unknown
+  relationTo?: unknown
+  type?: unknown
+  value?: unknown
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null
+}
+
+function isDanglingReferenceNode(
+  node: LexicalNodeRecord,
+  validCollectionSlugs: Set<string>,
+): boolean {
+  if (node.type !== 'relationship' && node.type !== 'upload') return false
+
+  if (typeof node.relationTo !== 'string') return true
+  if (!validCollectionSlugs.has(node.relationTo)) return true
+
+  return node.value === null || node.value === undefined || node.value === ''
+}
+
+function sanitizeNodes(
+  nodes: unknown[],
+  validCollectionSlugs: Set<string>,
+): { changed: boolean; nodes: unknown[] } {
+  let changed = false
+  const sanitized: unknown[] = []
+
+  for (const node of nodes) {
+    const result = sanitizeNode(node, validCollectionSlugs)
+    if (result.changed) changed = true
+    if (result.node === null) continue
+    sanitized.push(result.node)
+  }
+
+  return { changed, nodes: sanitized }
+}
+
+function sanitizeNode(
+  node: unknown,
+  validCollectionSlugs: Set<string>,
+): { changed: boolean; node: null | unknown } {
+  if (!isRecord(node)) return { changed: false, node }
+
+  if (isDanglingReferenceNode(node, validCollectionSlugs)) {
+    return { changed: true, node: null }
+  }
+
+  if (!Array.isArray(node.children)) return { changed: false, node }
+
+  const result = sanitizeNodes(node.children, validCollectionSlugs)
+  if (!result.changed) return { changed: false, node }
+
+  return {
+    changed: true,
+    node: {
+      ...node,
+      children: result.nodes,
+    },
+  }
+}
+
+export function removeDanglingLexicalReferences(
+  value: unknown,
+  validCollectionSlugs: Iterable<string>,
+): unknown {
+  if (!isRecord(value)) return value
+  if (!isRecord(value.root)) return value
+  if (!Array.isArray(value.root.children)) return value
+
+  const result = sanitizeNodes(value.root.children, new Set(validCollectionSlugs))
+  if (!result.changed) return value
+
+  return {
+    ...value,
+    root: {
+      ...value.root,
+      children: result.nodes,
+    },
+  }
+}
+
+export const removeDanglingLexicalReferencesAfterRead: FieldHook = ({ req, value }) => {
+  return removeDanglingLexicalReferences(value, Object.keys(req.payload.collections))
+}

--- a/src/hooks/lexicalHooks.ts
+++ b/src/hooks/lexicalHooks.ts
@@ -20,7 +20,7 @@ function isDanglingReferenceNode(
   if (typeof node.relationTo !== 'string') return true
   if (!validCollectionSlugs.has(node.relationTo)) return true
 
-  return node.value === null || node.value === undefined || node.value === ''
+  return node.value === null || node.value === undefined
 }
 
 function sanitizeNodes(

--- a/tests/int/lessons.int.spec.ts
+++ b/tests/int/lessons.int.spec.ts
@@ -5,14 +5,16 @@
  * this file holds tests for behavior that's project-specific.
  *
  * Currently: subtitle JSON behavior (documents that Payload's `jsonSchema`
- * is a Monaco editor hint, not API-enforced validation).
+ * is a Monaco editor hint, not API-enforced validation) and article rich-text
+ * cleanup for stale Lexical relationship nodes.
  */
 import type { Payload } from 'payload'
 
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 
-import type { Meditation } from '@/payload-types'
+import type { Lesson, Meditation } from '@/payload-types'
 
+import { createLexicalWithRelationshipNode } from '../utils/lexicalTestHelpers'
 import { testData } from '../utils/testData'
 import { createTestEnvironment } from '../utils/testHelpers'
 
@@ -78,6 +80,30 @@ describe('Lessons Collection — custom behavior', () => {
       })
 
       expect(lesson.introSubtitles).toEqual(subtitlesWithLegacyField)
+    })
+  })
+
+  describe('article rich text', () => {
+    it('strips stale relationship nodes for removed collections before rendering the editor', async () => {
+      const staleArticle = createLexicalWithRelationshipNode({
+        relationTo: 'lecture-clips',
+        value: 123,
+      }) as Lesson['article']
+
+      const lesson = await testData.createLesson(payload, {
+        title: 'Lesson with stale article relationship',
+        meditation: testMeditation.id,
+        article: staleArticle,
+      })
+
+      const fetched = await payload.findByID({
+        collection: 'lessons',
+        id: lesson.id,
+        depth: 0,
+      })
+
+      const articleRoot = fetched.article?.root as { children: unknown[] }
+      expect(articleRoot.children).toEqual([])
     })
   })
 })

--- a/tests/int/pages.int.spec.ts
+++ b/tests/int/pages.int.spec.ts
@@ -4,6 +4,7 @@ import { describe, it, beforeAll, afterAll, expect } from 'vitest'
 
 import {
   createLexicalWithQuoteBlock,
+  createLexicalWithRelationshipNode,
   createLexicalWithUploadNode,
 } from '../utils/lexicalTestHelpers'
 import { testData } from '../utils/testData'
@@ -199,6 +200,29 @@ describe('Pages Collection', () => {
       const fields = root.children[0].fields as Record<string, unknown>
       expect(fields.align).toBe('left')
       expect(fields.caption).toBe('A caption')
+    })
+  })
+
+  describe('content rich text', () => {
+    it('strips stale relationship nodes for removed collections before rendering the editor', async () => {
+      const staleContent = createLexicalWithRelationshipNode({
+        relationTo: 'lecture-clips',
+        value: 123,
+      })
+
+      const page = await testData.createPage(payload, {
+        title: 'Page with stale content relationship',
+        content: staleContent,
+      })
+
+      const fetched = await payload.findByID({
+        collection: 'pages',
+        id: page.id,
+        depth: 0,
+      })
+
+      const contentRoot = fetched.content?.root as { children: unknown[] }
+      expect(contentRoot.children).toEqual([])
     })
   })
 

--- a/tests/unit/lexical-hooks.spec.ts
+++ b/tests/unit/lexical-hooks.spec.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from 'vitest'
+
+import { removeDanglingLexicalReferences } from '@/hooks/lexicalHooks'
+
+const validCollections = ['pages', 'lectures', 'images']
+
+function lexicalWithChildren(children: unknown[]) {
+  return {
+    root: {
+      type: 'root',
+      children,
+      direction: null,
+      format: '',
+      indent: 0,
+      version: 1,
+    },
+  }
+}
+
+describe('removeDanglingLexicalReferences', () => {
+  it('removes relationship nodes that point at removed collections', () => {
+    const content = lexicalWithChildren([
+      {
+        type: 'relationship',
+        version: 2,
+        format: '',
+        relationTo: 'lecture-clips',
+        value: 123,
+      },
+      {
+        type: 'paragraph',
+        children: [{ type: 'text', text: 'Keep me', version: 1 }],
+        version: 1,
+      },
+    ])
+
+    const sanitized = removeDanglingLexicalReferences(content, validCollections) as typeof content
+
+    expect(sanitized.root.children).toEqual([
+      {
+        type: 'paragraph',
+        children: [{ type: 'text', text: 'Keep me', version: 1 }],
+        version: 1,
+      },
+    ])
+  })
+
+  it('removes upload and relationship nodes with null values', () => {
+    const content = lexicalWithChildren([
+      {
+        type: 'upload',
+        version: 3,
+        relationTo: 'images',
+        value: null,
+      },
+      {
+        type: 'relationship',
+        version: 2,
+        relationTo: 'lectures',
+        value: undefined,
+      },
+    ])
+
+    const sanitized = removeDanglingLexicalReferences(content, validCollections) as typeof content
+
+    expect(sanitized.root.children).toEqual([])
+  })
+
+  it('preserves valid references and sanitizes nested children', () => {
+    const validRelationship = {
+      type: 'relationship',
+      version: 2,
+      format: '',
+      relationTo: 'lectures',
+      value: 456,
+    }
+    const content = lexicalWithChildren([
+      {
+        type: 'paragraph',
+        children: [
+          {
+            type: 'relationship',
+            version: 2,
+            format: '',
+            relationTo: 'lecture-clips',
+            value: 123,
+          },
+          { type: 'text', text: 'Keep nested text', version: 1 },
+        ],
+        version: 1,
+      },
+      validRelationship,
+    ])
+
+    const sanitized = removeDanglingLexicalReferences(content, validCollections) as typeof content
+
+    expect(sanitized.root.children).toEqual([
+      {
+        type: 'paragraph',
+        children: [{ type: 'text', text: 'Keep nested text', version: 1 }],
+        version: 1,
+      },
+      validRelationship,
+    ])
+  })
+})

--- a/tests/unit/lexical-hooks.spec.ts
+++ b/tests/unit/lexical-hooks.spec.ts
@@ -66,6 +66,33 @@ describe('removeDanglingLexicalReferences', () => {
     expect(sanitized.root.children).toEqual([])
   })
 
+  it('removes upload nodes that point at removed collections', () => {
+    const content = lexicalWithChildren([
+      {
+        type: 'upload',
+        version: 3,
+        format: '',
+        relationTo: 'lecture-clips',
+        value: 123,
+      },
+      {
+        type: 'paragraph',
+        children: [{ type: 'text', text: 'Keep me', version: 1 }],
+        version: 1,
+      },
+    ])
+
+    const sanitized = removeDanglingLexicalReferences(content, validCollections) as typeof content
+
+    expect(sanitized.root.children).toEqual([
+      {
+        type: 'paragraph',
+        children: [{ type: 'text', text: 'Keep me', version: 1 }],
+        version: 1,
+      },
+    ])
+  })
+
   it('preserves valid references and sanitizes nested children', () => {
     const validRelationship = {
       type: 'relationship',

--- a/tests/utils/lexicalTestHelpers.ts
+++ b/tests/utils/lexicalTestHelpers.ts
@@ -177,6 +177,34 @@ export function createLexicalWithUploadNode(
 }
 
 /**
+ * Create Lexical content with a relationship node.
+ * Useful for regression tests around stale relationship collection slugs.
+ */
+export function createLexicalWithRelationshipNode(options: {
+  relationTo: string
+  value: unknown
+}): Page['content'] {
+  return {
+    root: {
+      type: 'root',
+      children: [
+        {
+          type: 'relationship',
+          version: 2,
+          format: '',
+          relationTo: options.relationTo,
+          value: options.value,
+        },
+      ],
+      direction: null,
+      format: '',
+      indent: 0,
+      version: 1,
+    },
+  } as unknown as Page['content']
+}
+
+/**
  * Create Lexical content with TableOfContentsBlock
  * Structure based on createBlockNode in seeds/lib/lexicalConverter.ts
  */


### PR DESCRIPTION
Fixes #344.

Summary:
- Strip stale or null Lexical relationship/upload nodes before rich text fields render in the admin.
- Apply the sanitizer to lesson articles and page content.
- Add unit and integration regression coverage for removed collection slugs like lecture-clips.

Tests:
- pnpm test:unit tests/unit/lexical-hooks.spec.ts
- pnpm test:int tests/int/lessons.int.spec.ts
- pnpm test:int tests/int/pages.int.spec.ts
- pnpm lint
- pnpm exec tsc --noEmit