### PR TITLE
feat(layout-block): add Text List style and upgrade style field to ToggleGroupField

### DIFF
--- a/src/app/(payload)/admin/importMap.js
+++ b/src/app/(payload)/admin/importMap.js
@@ -3,8 +3,8 @@ import { RscEntryLexicalField as RscEntryLexicalField_44fe37237e0ebf4470c9990d8c
 import { LexicalDiffComponent as LexicalDiffComponent_44fe37237e0ebf4470c9990d8cb7b07e } from '@payloadcms/richtext-lexical/rsc'
 import { BlocksFeatureClient as BlocksFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
 import { default as default_f91e9026f7498cd1e5fb4b586be3d1a1 } from '@/components/admin/ThumbnailCell/RelationshipThumbnailCell'
-import { default as default_fb8891978ae045ad6d23399fc1e14651 } from '@/components/admin/TableOfContentsField'
 import { default as default_153ca68fe8ddf15a21abb9e4fd2a6300 } from '@/components/admin/ToggleGroupField'
+import { default as default_fb8891978ae045ad6d23399fc1e14651 } from '@/components/admin/TableOfContentsField'
 import { UploadFeatureClient as UploadFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
 import { RelationshipFeatureClient as RelationshipFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
 import { HeadingFeatureClient as HeadingFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
@@ -66,8 +66,8 @@ export const importMap = {
   "@payloadcms/richtext-lexical/rsc#LexicalDiffComponent": LexicalDiffComponent_44fe37237e0ebf4470c9990d8cb7b07e,
   "@payloadcms/richtext-lexical/client#BlocksFeatureClient": BlocksFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
   "@/components/admin/ThumbnailCell/RelationshipThumbnailCell#default": default_f91e9026f7498cd1e5fb4b586be3d1a1,
-  "@/components/admin/TableOfContentsField#default": default_fb8891978ae045ad6d23399fc1e14651,
   "@/components/admin/ToggleGroupField#default": default_153ca68fe8ddf15a21abb9e4fd2a6300,
+  "@/components/admin/TableOfContentsField#default": default_fb8891978ae045ad6d23399fc1e14651,
   "@payloadcms/richtext-lexical/client#UploadFeatureClient": UploadFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
   "@payloadcms/richtext-lexical/client#RelationshipFeatureClient": RelationshipFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
   "@payloadcms/richtext-lexical/client#HeadingFeatureClient": HeadingFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,

--- a/src/blocks/pages/LayoutBlock.ts
+++ b/src/blocks/pages/LayoutBlock.ts
@@ -13,7 +13,7 @@ export const LayoutBlock: Block = {
   fields: [
     {
       name: 'style',
-      type: 'radio',
+      type: 'select',
       required: true,
       options: [
         {
@@ -32,7 +32,16 @@ export const LayoutBlock: Block = {
           label: 'List',
           value: 'list',
         },
+        {
+          label: 'Text List',
+          value: 'textList',
+        },
       ],
+      admin: {
+        components: {
+          Field: '@/components/admin/ToggleGroupField',
+        },
+      },
     },
     {
       name: 'title',
@@ -64,6 +73,9 @@ export const LayoutBlock: Block = {
         mediaField({
           name: 'image',
           orientation: 'landscape',
+          admin: {
+            condition: (data) => (data as { style?: string })?.style !== 'textList',
+          },
         }),
         {
           type: 'row',
@@ -77,7 +89,9 @@ export const LayoutBlock: Block = {
               type: 'text',
               label: 'Title Link',
               admin: {
-                condition: (_, siblingData) => Boolean(siblingData?.title),
+                condition: (data, siblingData) =>
+                  (data as { style?: string })?.style !== 'textList' &&
+                  Boolean(siblingData?.title),
               },
             },
           ],


### PR DESCRIPTION
## Summary

- Adds a new **Text List** (`textList`) style option to `LayoutBlock`, giving editors a way to differentiate text-only lists from image+title lists on the frontend
- Hides the `image` and `Title Link` fields when `textList` is selected (irrelevant for that style)
- Upgrades the `style` field from `radio` → `select` using `ToggleGroupField` for a cleaner segmented-button UI

No database migration required — `radio` and `select` both store a varchar value with identical column schema.

Closes #368

## Test Results
- Integration tests: 667 passed
- Build: ✓ Success
- Pre-existing failures fixed: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)