### PR TITLE
feat(docs): password protect API docs and prevent indexing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -131,6 +131,16 @@ ADMIN_PASSWORD=your-admin-password-here
 # CLOUDFLARE_R2_SECRET_ACCESS_KEY=your-r2-secret-access-key
 
 # ============================================
+# API DOCUMENTATION PROTECTION (Optional)
+# ============================================
+# When set, password-protects the /api/docs endpoint via HTTP Basic Auth.
+# Any username is accepted; only the password is checked.
+# Omit or leave blank to keep docs publicly accessible (e.g. local dev).
+# VALIDATION: Minimum 8 characters
+# Production: set via wrangler secret put DOCS_PASSWORD
+# DOCS_PASSWORD=your-docs-password-here
+
+# ============================================
 # VALIDATION NOTES
 # ============================================
 # All environment variables are validated at module load time using Zod schemas (src/lib/env.ts)

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Disallow: /api/docs
+Disallow: /api/openapi.json
+Disallow: /api/openapi-raw.json

--- a/src/app/(payload)/api/openapi.json/route.ts
+++ b/src/app/(payload)/api/openapi.json/route.ts
@@ -20,6 +20,7 @@ import { getPayload } from 'payload'
 import { generateV31Spec } from 'payload-oapi/dist/openapi/generators.js'
 
 import { isValidProject } from '@/lib/access'
+import { checkBasicAuth } from '@/lib/openapi/basicAuth'
 import { CUSTOM_ENDPOINT_PATHS, CUSTOM_ENDPOINT_SCHEMAS } from '@/lib/openapi/customEndpoints'
 import { filterSpec, type OpenAPISpec } from '@/lib/openapi/specFilter'
 import type { ProjectSlug } from '@/payload-types'
@@ -45,6 +46,21 @@ const OPENAPI_METADATA = {
 
 export async function GET(request: NextRequest) {
   try {
+    const docsPassword = process.env.DOCS_PASSWORD
+    if (docsPassword) {
+      const authHeader = request.headers.get('authorization') ?? ''
+      if (!checkBasicAuth(authHeader, docsPassword)) {
+        return new NextResponse('Authentication required', {
+          status: 401,
+          headers: {
+            'WWW-Authenticate': 'Basic realm="Sahaj Cloud API Documentation"',
+            'Content-Type': 'text/plain',
+            'Cache-Control': 'no-store',
+          },
+        })
+      }
+    }
+
     // Parse project from query params
     const projectParam = request.nextUrl.searchParams.get('project')
     const project: ProjectSlug | null =
@@ -54,9 +70,9 @@ export async function GET(request: NextRequest) {
     const cacheUrl = `https://cache.internal/openapi.json${project ? `?project=${project}` : ''}`
     const cacheKey = new Request(cacheUrl, { method: 'GET' })
 
-    // Check Cloudflare Cache API (only available in production Workers)
+    // Check Cloudflare Cache API (only available in production Workers, skip when password-protected)
     const cfCaches = typeof caches !== 'undefined' ? (caches as CloudflareCacheStorage) : null
-    const cache = cfCaches?.default ?? null
+    const cache = docsPassword ? null : (cfCaches?.default ?? null)
     if (cache) {
       const cachedResponse = await cache.match(cacheKey)
       if (cachedResponse) {
@@ -103,8 +119,8 @@ export async function GET(request: NextRequest) {
     const response = NextResponse.json(filteredSpec, {
       headers: {
         'Content-Type': 'application/json',
-        // Allow caching for 5 minutes, vary by project parameter
-        'Cache-Control': `public, max-age=${CACHE_TTL}`,
+        // Don't cache password-protected responses publicly
+        'Cache-Control': docsPassword ? 'private, no-store' : `public, max-age=${CACHE_TTL}`,
         Vary: 'Accept',
       },
     })

--- a/src/lib/env/server.ts
+++ b/src/lib/env/server.ts
@@ -140,6 +140,14 @@ const ServerEnvSchema = ClientEnvSchema.extend({
   SAHAJATLAS_URL: z.url(),
 
   /**
+   * API documentation password (HTTP Basic Auth)
+   * When set, password-protects the /api/docs endpoint
+   * Any username is accepted; only the password is checked
+   * Optional — docs are publicly accessible when not set
+   */
+  DOCS_PASSWORD: z.string().min(8, 'DOCS_PASSWORD must be at least 8 characters').optional(),
+
+  /**
    * Server port number
    * @default 3000
    */

--- a/src/lib/openapi/basicAuth.ts
+++ b/src/lib/openapi/basicAuth.ts
@@ -1,0 +1,15 @@
+/**
+ * Validates an HTTP Basic Auth header against a known password.
+ * Accepts any username — only the password is checked.
+ */
+export function checkBasicAuth(authHeader: string, password: string): boolean {
+  if (!authHeader.startsWith('Basic ')) return false
+  try {
+    const decoded = atob(authHeader.slice(6).trim())
+    const colonIdx = decoded.indexOf(':')
+    const pwd = colonIdx >= 0 ? decoded.slice(colonIdx + 1) : decoded
+    return pwd === password
+  } catch {
+    return false
+  }
+}

--- a/src/lib/openapi/scalarPlugin.ts
+++ b/src/lib/openapi/scalarPlugin.ts
@@ -13,23 +13,8 @@ import type { Config, Endpoint } from 'payload'
 import { getProjectIcon, getProjectLabel, getProjectOptions, isValidProject } from '@/lib/access'
 import { getScalarThemeColors, type ScalarThemeColors } from '@/lib/branding'
 import { serverEnv } from '@/lib/env'
+import { checkBasicAuth } from '@/lib/openapi/basicAuth'
 import type { ProjectSlug } from '@/payload-types'
-
-/**
- * Validates an HTTP Basic Auth header against a known password.
- * Accepts any username — only the password is checked.
- */
-export function checkBasicAuth(authHeader: string, password: string): boolean {
-  if (!authHeader.startsWith('Basic ')) return false
-  try {
-    const decoded = atob(authHeader.slice(6).trim())
-    const colonIdx = decoded.indexOf(':')
-    const pwd = colonIdx >= 0 ? decoded.slice(colonIdx + 1) : decoded
-    return pwd === password
-  } catch {
-    return false
-  }
-}
 
 export interface ScalarPluginOptions {
   /** Path to the OpenAPI spec endpoint (default: '/openapi.json') */
@@ -379,7 +364,6 @@ export const scalarPlugin =
           method: 'get',
           path: docsUrl,
           handler: async (req) => {
-            // Enforce Basic Auth when DOCS_PASSWORD is configured
             const docsPassword = serverEnv.DOCS_PASSWORD
             if (docsPassword) {
               const authHeader = req.headers.get('authorization') ?? ''
@@ -389,6 +373,7 @@ export const scalarPlugin =
                   headers: {
                     'WWW-Authenticate': 'Basic realm="Sahaj Cloud API Documentation"',
                     'Content-Type': 'text/plain',
+                    'Cache-Control': 'no-store',
                   },
                 })
               }

--- a/src/lib/openapi/scalarPlugin.ts
+++ b/src/lib/openapi/scalarPlugin.ts
@@ -12,7 +12,24 @@ import type { Config, Endpoint } from 'payload'
 
 import { getProjectIcon, getProjectLabel, getProjectOptions, isValidProject } from '@/lib/access'
 import { getScalarThemeColors, type ScalarThemeColors } from '@/lib/branding'
+import { serverEnv } from '@/lib/env'
 import type { ProjectSlug } from '@/payload-types'
+
+/**
+ * Validates an HTTP Basic Auth header against a known password.
+ * Accepts any username — only the password is checked.
+ */
+export function checkBasicAuth(authHeader: string, password: string): boolean {
+  if (!authHeader.startsWith('Basic ')) return false
+  try {
+    const decoded = atob(authHeader.slice(6).trim())
+    const colonIdx = decoded.indexOf(':')
+    const pwd = colonIdx >= 0 ? decoded.slice(colonIdx + 1) : decoded
+    return pwd === password
+  } catch {
+    return false
+  }
+}
 
 export interface ScalarPluginOptions {
   /** Path to the OpenAPI spec endpoint (default: '/openapi.json') */
@@ -100,6 +117,7 @@ function generateScalarHtml(specUrl: string, project: ProjectSlug | null, baseUr
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>${projectTitle} API Documentation</title>
   <meta name="description" content="REST API documentation for ${projectTitle}" />
+  <meta name="robots" content="noindex, nofollow" />
   <link rel="icon" type="image/svg+xml" href="${currentLogo}" />
   <!-- Critical CSS first to prevent flash of unstyled content -->
   <style>
@@ -361,6 +379,21 @@ export const scalarPlugin =
           method: 'get',
           path: docsUrl,
           handler: async (req) => {
+            // Enforce Basic Auth when DOCS_PASSWORD is configured
+            const docsPassword = serverEnv.DOCS_PASSWORD
+            if (docsPassword) {
+              const authHeader = req.headers.get('authorization') ?? ''
+              if (!checkBasicAuth(authHeader, docsPassword)) {
+                return new Response('Authentication required', {
+                  status: 401,
+                  headers: {
+                    'WWW-Authenticate': 'Basic realm="Sahaj Cloud API Documentation"',
+                    'Content-Type': 'text/plain',
+                  },
+                })
+              }
+            }
+
             // Construct base URL using payload-oapi pattern
             const baseUrl = `${req.protocol}//${req.headers.get('host')}`
             const fullSpecUrl = `${baseUrl}/api${specEndpoint}`
@@ -378,7 +411,9 @@ export const scalarPlugin =
             return new Response(html, {
               headers: {
                 'Content-Type': 'text/html',
-                'Cache-Control': 'public, max-age=3600', // Cache for 1 hour
+                // Don't cache password-protected pages publicly
+                'Cache-Control': docsPassword ? 'private, no-store' : 'public, max-age=3600',
+                'X-Robots-Tag': 'noindex, nofollow',
               },
             })
           },

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,26 @@
+import { NextResponse, type NextRequest } from 'next/server'
+
+import { checkBasicAuth } from '@/lib/openapi/basicAuth'
+
+export function middleware(request: NextRequest): NextResponse {
+  const docsPassword = process.env.DOCS_PASSWORD
+  if (!docsPassword) return NextResponse.next()
+
+  const authHeader = request.headers.get('authorization') ?? ''
+  if (!checkBasicAuth(authHeader, docsPassword)) {
+    return new NextResponse('Authentication required', {
+      status: 401,
+      headers: {
+        'WWW-Authenticate': 'Basic realm="Sahaj Cloud API Documentation"',
+        'Content-Type': 'text/plain',
+        'Cache-Control': 'no-store',
+      },
+    })
+  }
+
+  return NextResponse.next()
+}
+
+export const config = {
+  matcher: ['/api/openapi-raw.json'],
+}

--- a/tests/int/api-explorer.int.spec.ts
+++ b/tests/int/api-explorer.int.spec.ts
@@ -204,6 +204,10 @@ describe('API Explorer', () => {
       expect(html).toContain('All Endpoints')
       // Verify Scalar is loaded
       expect(html.toLowerCase()).toContain('scalar')
+      // Verify noindex meta tag (prevents search engine indexing)
+      expect(html).toContain('<meta name="robots" content="noindex, nofollow"')
+      // Verify X-Robots-Tag header
+      expect(response.headers.get('x-robots-tag')).toBe('noindex, nofollow')
     })
 
     it('applies project-specific theme when project is selected', async () => {

--- a/tests/unit/docs-auth.spec.ts
+++ b/tests/unit/docs-auth.spec.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest'
 
-import { checkBasicAuth } from '../../src/lib/openapi/scalarPlugin'
+import { checkBasicAuth } from '../../src/lib/openapi/basicAuth'
 
 const PASSWORD = 'correcthorsebatterystaple'
 

--- a/tests/unit/docs-auth.spec.ts
+++ b/tests/unit/docs-auth.spec.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest'
+
+import { checkBasicAuth } from '../../src/lib/openapi/scalarPlugin'
+
+const PASSWORD = 'correcthorsebatterystaple'
+
+function basicHeader(username: string, password: string): string {
+  return `Basic ${btoa(`${username}:${password}`)}`
+}
+
+describe('checkBasicAuth', () => {
+  it('returns false for empty Authorization header', () => {
+    expect(checkBasicAuth('', PASSWORD)).toBe(false)
+  })
+
+  it('returns false for Bearer token (wrong scheme)', () => {
+    expect(checkBasicAuth(`Bearer ${btoa('user:' + PASSWORD)}`, PASSWORD)).toBe(false)
+  })
+
+  it('returns true for correct password with any username', () => {
+    expect(checkBasicAuth(basicHeader('admin', PASSWORD), PASSWORD)).toBe(true)
+    expect(checkBasicAuth(basicHeader('', PASSWORD), PASSWORD)).toBe(true)
+    expect(checkBasicAuth(basicHeader('user@example.com', PASSWORD), PASSWORD)).toBe(true)
+  })
+
+  it('returns false for wrong password', () => {
+    expect(checkBasicAuth(basicHeader('admin', 'wrongpassword'), PASSWORD)).toBe(false)
+  })
+
+  it('returns false for invalid base64', () => {
+    expect(checkBasicAuth('Basic !!!not-base64!!!', PASSWORD)).toBe(false)
+  })
+
+  it('handles password containing colons', () => {
+    const complexPassword = 'pass:word:with:colons'
+    expect(checkBasicAuth(basicHeader('user', complexPassword), complexPassword)).toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary

- Add optional `DOCS_PASSWORD` env var that gates `/api/docs` behind HTTP Basic Auth (any username accepted, only password checked)
- Add `<meta name="robots" content="noindex, nofollow">` to the Scalar HTML and `X-Robots-Tag: noindex, nofollow` response header so crawlers skip the page even if they find it
- Create `public/robots.txt` that explicitly disallows `/api/docs`, `/api/openapi.json`, and `/api/openapi-raw.json`
- Use `Cache-Control: private, no-store` when a password is configured (avoids caching protected pages in a shared cache)

Set the password in production via `wrangler secret put DOCS_PASSWORD`. Omitting the variable leaves docs publicly accessible (unchanged behaviour for local dev).

Closes #355

## Test Results
- Unit tests: 281 passed (includes 6 new `checkBasicAuth` unit tests)
- Integration tests: 388 passed (includes 2 new noindex/X-Robots-Tag assertions)
- Build: ✓ Success

🤖 Generated with [Claude Code](https://claude.com/claude-code)