### PR TITLE
refactor(wm-app-translations): re-group by feature; 39 tabs -> 9, with screenshots

### DIFF
--- a/src/components/admin/TabScreenshot/TabScreenshot.tsx
+++ b/src/components/admin/TabScreenshot/TabScreenshot.tsx
@@ -1,0 +1,84 @@
+'use client'
+
+import type { UIFieldClientComponent } from 'payload'
+
+import React from 'react'
+
+/**
+ * Renders an orientation aid above a translations tab — either an image
+ * (when `screenshot` is a relative path or an image URL) or a clickable
+ * link (when `screenshot` is a Figma design URL).
+ *
+ * Wired in by `buildTranslationTabs` whenever a leaf group declares a
+ * `screenshot` in `translationsSchema.json`. UI-only — does not read or
+ * write any field data.
+ *
+ * Eventually intended to be replaced by a live in-CMS preview of the
+ * Flutter screen.
+ */
+export const TabScreenshot: UIFieldClientComponent = ({ field }) => {
+  const custom = field?.admin?.custom as
+    | { screenshot?: string; caption?: string }
+    | undefined
+
+  const src = custom?.screenshot
+  if (!src) return null
+
+  const isFigmaUrl = /^https?:\/\/(?:www\.)?figma\.com\//i.test(src)
+  const looksLikeImage =
+    src.startsWith('/') || /\.(png|jpe?g|webp|gif|svg)(\?|$)/i.test(src)
+
+  return (
+    <div
+      style={{
+        marginBottom: '1.25rem',
+        padding: '0.75rem',
+        border: '1px solid var(--theme-elevation-150)',
+        borderRadius: '4px',
+        backgroundColor: 'var(--theme-elevation-50)',
+      }}
+    >
+      {looksLikeImage && !isFigmaUrl ? (
+        <a href={src} target="_blank" rel="noopener noreferrer">
+          <img
+            src={src}
+            alt={custom?.caption || 'Screen preview'}
+            style={{
+              display: 'block',
+              maxHeight: '380px',
+              maxWidth: '100%',
+              height: 'auto',
+              borderRadius: '2px',
+            }}
+          />
+        </a>
+      ) : isFigmaUrl ? (
+        <a
+          href={src}
+          target="_blank"
+          rel="noopener noreferrer"
+          style={{
+            display: 'inline-flex',
+            alignItems: 'center',
+            gap: '0.5rem',
+            padding: '0.5rem 0.75rem',
+            border: '1px solid var(--theme-elevation-200)',
+            borderRadius: '4px',
+            textDecoration: 'none',
+            fontSize: '0.85rem',
+          }}
+        >
+          <span aria-hidden>🎨</span>
+          <span>View this screen in Figma</span>
+          <span aria-hidden>↗</span>
+        </a>
+      ) : (
+        <a href={src} target="_blank" rel="noopener noreferrer">
+          {src}
+        </a>
+      )}
+    </div>
+  )
+}
+
+export default TabScreenshot

--- a/src/components/admin/TabScreenshot/index.ts
+++ b/src/components/admin/TabScreenshot/index.ts
@@ -1,0 +1,1 @@
+export { TabScreenshot, default } from './TabScreenshot'

--- a/src/fields/translationsField.ts
+++ b/src/fields/translationsField.ts
@@ -23,12 +23,20 @@ interface StringPropertySchema {
 }
 
 /**
- * JSON Schema definition for a group of translations
+ * JSON Schema definition for a group of translations.
+ *
+ * A group is either:
+ * - a leaf group with `properties` of `StringPropertySchema` (renders as one tab
+ *   with a flat TranslationsTable), or
+ * - a parent group with `properties` of nested `GroupSchema` values (renders as
+ *   a tab containing inner sub-tabs, one per child group).
+ *
+ * Mixing string and object properties at the same level is not supported.
  */
 interface GroupSchema {
   type: 'object'
   description?: string
-  properties?: Record<string, StringPropertySchema>
+  properties?: Record<string, StringPropertySchema | GroupSchema>
   additionalProperties?: boolean
 }
 
@@ -40,6 +48,15 @@ export interface TranslationsSchema {
   type: 'object'
   properties?: Record<string, GroupSchema>
   additionalProperties?: boolean
+}
+
+/**
+ * Type guard: true when a property is a nested GroupSchema rather than a string leaf.
+ */
+function isGroupSchema(
+  prop: StringPropertySchema | GroupSchema | undefined,
+): prop is GroupSchema {
+  return !!prop && prop.type === 'object'
 }
 
 // ============================================================================
@@ -57,22 +74,27 @@ function toTitleCase(slug: string): string {
 }
 
 /**
- * Extracts schema entries from a group's properties
- * Each entry contains the key and its description for the TranslationsTable component
+ * Extracts schema entries from a leaf group's string properties.
+ * Each entry contains the key and its description for the TranslationsTable component.
+ * Any non-string (nested-group) entries are skipped — leaf groups are not expected
+ * to mix strings and nested groups.
  */
 function extractSchemaEntries(
-  groupProperties: Record<string, StringPropertySchema> | undefined,
+  groupProperties: Record<string, StringPropertySchema | GroupSchema> | undefined,
 ): SchemaEntry[] {
   if (!groupProperties) return []
 
-  return Object.entries(groupProperties).map(([key, prop]) => ({
-    key,
-    description: prop.description || '',
-  }))
+  return Object.entries(groupProperties)
+    .filter(([, prop]) => prop.type === 'string')
+    .map(([key, prop]) => ({
+      key,
+      description: prop.description || '',
+    }))
 }
 
 /**
- * Creates a JSON field configuration for a translation group
+ * Creates a JSON field configuration for a leaf translation group (one whose
+ * properties are all string leaves).
  */
 function createGroupJsonField(
   groupSlug: string,
@@ -81,14 +103,21 @@ function createGroupJsonField(
 ): JSONField {
   const schemaEntries = extractSchemaEntries(groupSchema.properties)
 
-  // Get all property keys to mark them as required
-  const requiredKeys = groupSchema.properties ? Object.keys(groupSchema.properties) : []
+  // Only string properties are required keys on the JSON field's own schema.
+  // Nested-group properties, if any, are rendered as separate sub-tabs and not
+  // included in this field's value.
+  const stringProperties: Record<string, StringPropertySchema> = Object.fromEntries(
+    Object.entries(groupSchema.properties || {}).filter(
+      ([, prop]) => prop.type === 'string',
+    ) as Array<[string, StringPropertySchema]>,
+  )
+  const requiredKeys = Object.keys(stringProperties)
 
   // Create a standalone JSON Schema for this group
   // This allows Monaco editor validation per-tab
   const groupJsonSchema: JSONSchema4 = {
     type: 'object',
-    properties: groupSchema.properties,
+    properties: stringProperties,
     required: requiredKeys.length > 0 ? requiredKeys : undefined,
     additionalProperties: groupSchema.additionalProperties ?? false,
   }
@@ -120,27 +149,23 @@ function createGroupJsonField(
 // ============================================================================
 
 /**
- * Converts a nested translations schema into PayloadCMS tabs configuration.
+ * Converts a translations schema into PayloadCMS tabs configuration.
  *
- * Each top-level property in the schema becomes a tab containing a JSON field
- * with the TranslationsTable component for editing.
+ * Top-level rules:
+ * - A top-level group whose `properties` are all `string` leaves becomes one tab
+ *   with a single JSON field rendered by the TranslationsTable component.
+ * - A top-level group whose `properties` are nested `GroupSchema` values becomes
+ *   one tab containing an inner tabs field, one sub-tab per child group. Each
+ *   sub-tab's JSON field is named `<parentSlug>_<childSlug>` so the global's
+ *   API/data shape stays flat (one top-level key per leaf group) — this is the
+ *   same field naming the previous flat schema used.
  *
- * @param schema - The translations schema with nested groups
+ * Mixing strings and nested groups at the same level is not supported. Backward
+ * compatible: schemas with no nested groups behave exactly as before.
+ *
+ * @param schema - The translations schema with optional nested groups
  * @param globalSlug - The global's slug for API fetching and unique URIs
  * @returns Array of tab configurations for use in a TabsField
- *
- * @example
- * ```typescript
- * const tabs = buildTranslationTabs(translationsSchema, 'wm-web-translations')
- *
- * // Use in global config:
- * fields: [
- *   {
- *     type: 'tabs',
- *     tabs,
- *   },
- * ]
- * ```
  */
 export function buildTranslationTabs(
   schema: TranslationsSchema,
@@ -150,9 +175,37 @@ export function buildTranslationTabs(
 
   return Object.entries(properties)
     .filter(([groupSlug]) => groupSlug.trim().length > 0) // Skip empty group slugs
-    .map(([groupSlug, groupSchema]) => ({
-      label: toTitleCase(groupSlug),
-      description: groupSchema.description,
-      fields: [createGroupJsonField(groupSlug, groupSchema, globalSlug)],
-    }))
+    .map(([groupSlug, groupSchema]) => {
+      const groupProps = groupSchema.properties || {}
+      const subgroups = Object.entries(groupProps).filter(
+        (entry): entry is [string, GroupSchema] => isGroupSchema(entry[1]),
+      )
+
+      // Parent group → outer tab containing one sub-tab per child group.
+      if (subgroups.length > 0) {
+        return {
+          label: toTitleCase(groupSlug),
+          description: groupSchema.description,
+          fields: [
+            {
+              type: 'tabs',
+              tabs: subgroups.map(([subSlug, subSchema]) => ({
+                label: toTitleCase(subSlug),
+                description: subSchema.description,
+                fields: [
+                  createGroupJsonField(`${groupSlug}_${subSlug}`, subSchema, globalSlug),
+                ],
+              })),
+            },
+          ],
+        }
+      }
+
+      // Leaf group → single tab with a flat translations table.
+      return {
+        label: toTitleCase(groupSlug),
+        description: groupSchema.description,
+        fields: [createGroupJsonField(groupSlug, groupSchema, globalSlug)],
+      }
+    })
 }

--- a/src/fields/translationsField.ts
+++ b/src/fields/translationsField.ts
@@ -1,5 +1,5 @@
 import type { JSONSchema4 } from 'json-schema'
-import type { JSONField, TabsField } from 'payload'
+import type { JSONField, TabsField, UIField } from 'payload'
 
 // ============================================================================
 // Types
@@ -32,12 +32,23 @@ interface StringPropertySchema {
  *   a tab containing inner sub-tabs, one per child group).
  *
  * Mixing string and object properties at the same level is not supported.
+ *
+ * Non-JSON-Schema extension fields (ignored by Monaco validation, consumed only
+ * by the Payload admin builder):
+ * - `screenshot`: relative path or URL to an image / Figma design that shows
+ *   where the strings in this group appear in the app. Rendered above the
+ *   TranslationsTable as orientation for translators. Only honoured on leaf
+ *   groups — parent groups are pure containers with no UI of their own.
+ *   Common forms:
+ *   - "/admin-screenshots/wm-app-translations/onboarding__name.png" — repo asset
+ *   - "https://www.figma.com/design/.../?node-id=11564-91404" — Figma URL link
  */
 interface GroupSchema {
   type: 'object'
   description?: string
   properties?: Record<string, StringPropertySchema | GroupSchema>
   additionalProperties?: boolean
+  screenshot?: string
 }
 
 /**
@@ -90,6 +101,35 @@ function extractSchemaEntries(
       key,
       description: prop.description || '',
     }))
+}
+
+/**
+ * Creates a UI-only field that renders a screenshot or design-context link
+ * above the translation table for a leaf group. Returns null when no
+ * screenshot is configured so the helper can skip the entry.
+ */
+function createScreenshotField(
+  groupSlug: string,
+  groupSchema: GroupSchema,
+  globalSlug: string,
+): UIField | null {
+  const screenshot = groupSchema.screenshot
+  if (!screenshot) return null
+
+  return {
+    name: `${groupSlug}__screenshot`,
+    type: 'ui',
+    admin: {
+      components: {
+        Field: '@/components/admin/TabScreenshot',
+      },
+      custom: {
+        screenshot,
+        caption: groupSchema.description,
+        globalSlug,
+      },
+    },
+  }
 }
 
 /**
@@ -182,6 +222,8 @@ export function buildTranslationTabs(
       )
 
       // Parent group → outer tab containing one sub-tab per child group.
+      // Screenshots configured on the parent are ignored (parents are pure
+      // containers); each child group renders its own optional screenshot.
       if (subgroups.length > 0) {
         return {
           label: toTitleCase(groupSlug),
@@ -189,23 +231,37 @@ export function buildTranslationTabs(
           fields: [
             {
               type: 'tabs',
-              tabs: subgroups.map(([subSlug, subSchema]) => ({
-                label: toTitleCase(subSlug),
-                description: subSchema.description,
-                fields: [
-                  createGroupJsonField(`${groupSlug}_${subSlug}`, subSchema, globalSlug),
-                ],
-              })),
+              tabs: subgroups.map(([subSlug, subSchema]) => {
+                const leafSlug = `${groupSlug}_${subSlug}`
+                const screenshotField = createScreenshotField(
+                  leafSlug,
+                  subSchema,
+                  globalSlug,
+                )
+                return {
+                  label: toTitleCase(subSlug),
+                  description: subSchema.description,
+                  fields: [
+                    ...(screenshotField ? [screenshotField] : []),
+                    createGroupJsonField(leafSlug, subSchema, globalSlug),
+                  ],
+                }
+              }),
             },
           ],
         }
       }
 
-      // Leaf group → single tab with a flat translations table.
+      // Leaf group → single tab with a flat translations table, optionally
+      // preceded by a screenshot for editor orientation.
+      const screenshotField = createScreenshotField(groupSlug, groupSchema, globalSlug)
       return {
         label: toTitleCase(groupSlug),
         description: groupSchema.description,
-        fields: [createGroupJsonField(groupSlug, groupSchema, globalSlug)],
+        fields: [
+          ...(screenshotField ? [screenshotField] : []),
+          createGroupJsonField(groupSlug, groupSchema, globalSlug),
+        ],
       }
     })
 }

--- a/src/globals/wemeditate-app/translationsSchema.json
+++ b/src/globals/wemeditate-app/translationsSchema.json
@@ -485,101 +485,101 @@
           },
           "additionalProperties": false,
           "screenshot": "https://www.figma.com/design/JkJK5lBTjB3oSwATMGqfUt/We-Meditate-App?node-id=7064-81297"
-        },
-        "explore": {
-          "type": "object",
-          "description": "Explore-style block embedded on the Home/Daily tab (a curated grid of Meditate / Learn / Join cards). Distinct from the standalone Explore tab.",
-          "properties": {
-            "section_label": {
-              "type": "string",
-              "description": "Eyebrow label for the embedded Explore block."
-            },
-            "section_meditate_title": {
-              "type": "string",
-              "description": "Section header for the Meditate column."
-            },
-            "section_learn_title": {
-              "type": "string",
-              "description": "Section header for the Learn column."
-            },
-            "section_join_title": {
-              "type": "string",
-              "description": "Section header for the Join Free Classes column."
-            },
-            "card_daily_title": {
-              "type": "string",
-              "description": "Card title for the Daily entry in the Explore block."
-            },
-            "card_daily_subtitle": {
-              "type": "string",
-              "description": "Card subtitle for the Daily entry in the Explore block."
-            },
-            "card_path_title": {
-              "type": "string",
-              "description": "Card title for the Path entry in the Explore block."
-            },
-            "card_path_subtitle": {
-              "type": "string",
-              "description": "Card subtitle for the Path entry in the Explore block."
-            },
-            "card_techniques_title": {
-              "type": "string",
-              "description": "Card title for the Techniques entry in the Explore block."
-            },
-            "card_techniques_subtitle": {
-              "type": "string",
-              "description": "Card subtitle for the Techniques entry in the Explore block."
-            },
-            "card_vibes_check_title": {
-              "type": "string",
-              "description": "Card title for the Vibes Check entry in the Explore block."
-            },
-            "card_vibes_check_subtitle": {
-              "type": "string",
-              "description": "Card subtitle for the Vibes Check entry in the Explore block."
-            },
-            "card_music_title": {
-              "type": "string",
-              "description": "Card title for the Music for Meditation entry in the Explore block."
-            },
-            "card_challenges_title": {
-              "type": "string",
-              "description": "Card title for the Challenges entry in the Explore block."
-            },
-            "card_talks_title": {
-              "type": "string",
-              "description": "Card title for the Shri Mataji Talks entry in the Explore block. Preserve the embedded line break (\\n)."
-            },
-            "card_subtle_system_title": {
-              "type": "string",
-              "description": "Card title for the Subtle System entry in the Explore block."
-            },
-            "card_who_is_title": {
-              "type": "string",
-              "description": "Card title for the 'Who is Shri Mataji' entry in the Explore block. Preserve the embedded line break (\\n)."
-            },
-            "card_what_is_title": {
-              "type": "string",
-              "description": "Card title for the 'What is Sahaja Yoga?' entry in the Explore block."
-            },
-            "card_live_online_title": {
-              "type": "string",
-              "description": "Card title for the Live Online Classes entry in the Explore block. Preserve the embedded line break (\\n)."
-            },
-            "card_find_classes_title": {
-              "type": "string",
-              "description": "Card title for the in-person class finder entry in the Explore block. Preserve the embedded line break (\\n)."
-            },
-            "card_coming_soon": {
-              "type": "string",
-              "description": "Generic 'Coming soon' badge used on locked Explore-block cards."
-            }
-          },
-          "additionalProperties": false,
-          "screenshot": "https://www.figma.com/design/JkJK5lBTjB3oSwATMGqfUt/We-Meditate-App?node-id=5878-10306"
         }
       },
       "additionalProperties": false
+    },
+    "explore": {
+      "type": "object",
+      "description": "Standalone Explore tab — curated grid of Meditate / Learn / Join cards linking into the rest of the app. Reached via the Explore entry in the bottom navigation bar.",
+      "properties": {
+        "section_label": {
+          "type": "string",
+          "description": "Eyebrow label for the embedded Explore block."
+        },
+        "section_meditate_title": {
+          "type": "string",
+          "description": "Section header for the Meditate column."
+        },
+        "section_learn_title": {
+          "type": "string",
+          "description": "Section header for the Learn column."
+        },
+        "section_join_title": {
+          "type": "string",
+          "description": "Section header for the Join Free Classes column."
+        },
+        "card_daily_title": {
+          "type": "string",
+          "description": "Card title for the Daily entry in the Explore block."
+        },
+        "card_daily_subtitle": {
+          "type": "string",
+          "description": "Card subtitle for the Daily entry in the Explore block."
+        },
+        "card_path_title": {
+          "type": "string",
+          "description": "Card title for the Path entry in the Explore block."
+        },
+        "card_path_subtitle": {
+          "type": "string",
+          "description": "Card subtitle for the Path entry in the Explore block."
+        },
+        "card_techniques_title": {
+          "type": "string",
+          "description": "Card title for the Techniques entry in the Explore block."
+        },
+        "card_techniques_subtitle": {
+          "type": "string",
+          "description": "Card subtitle for the Techniques entry in the Explore block."
+        },
+        "card_vibes_check_title": {
+          "type": "string",
+          "description": "Card title for the Vibes Check entry in the Explore block."
+        },
+        "card_vibes_check_subtitle": {
+          "type": "string",
+          "description": "Card subtitle for the Vibes Check entry in the Explore block."
+        },
+        "card_music_title": {
+          "type": "string",
+          "description": "Card title for the Music for Meditation entry in the Explore block."
+        },
+        "card_challenges_title": {
+          "type": "string",
+          "description": "Card title for the Challenges entry in the Explore block."
+        },
+        "card_talks_title": {
+          "type": "string",
+          "description": "Card title for the Shri Mataji Talks entry in the Explore block. Preserve the embedded line break (\\n)."
+        },
+        "card_subtle_system_title": {
+          "type": "string",
+          "description": "Card title for the Subtle System entry in the Explore block."
+        },
+        "card_who_is_title": {
+          "type": "string",
+          "description": "Card title for the 'Who is Shri Mataji' entry in the Explore block. Preserve the embedded line break (\\n)."
+        },
+        "card_what_is_title": {
+          "type": "string",
+          "description": "Card title for the 'What is Sahaja Yoga?' entry in the Explore block."
+        },
+        "card_live_online_title": {
+          "type": "string",
+          "description": "Card title for the Live Online Classes entry in the Explore block. Preserve the embedded line break (\\n)."
+        },
+        "card_find_classes_title": {
+          "type": "string",
+          "description": "Card title for the in-person class finder entry in the Explore block. Preserve the embedded line break (\\n)."
+        },
+        "card_coming_soon": {
+          "type": "string",
+          "description": "Generic 'Coming soon' badge used on locked Explore-block cards."
+        }
+      },
+      "additionalProperties": false,
+      "screenshot": "https://www.figma.com/design/JkJK5lBTjB3oSwATMGqfUt/We-Meditate-App?node-id=5878-10306"
     },
     "general": {
       "type": "object",

--- a/src/globals/wemeditate-app/translationsSchema.json
+++ b/src/globals/wemeditate-app/translationsSchema.json
@@ -1,66 +1,66 @@
 {
   "type": "object",
   "properties": {
-    "welcome": {
-      "type": "object",
-      "description": "First screen new users see before any onboarding. Legal disclaimer is inline below the primary CTAs.",
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Hero title on the welcome screen. Short greeting (e.g. 'Welcome, friend')."
-        },
-        "subtitle": {
-          "type": "string",
-          "description": "Hero subtitle below the welcome title."
-        },
-        "get_started": {
-          "type": "string",
-          "description": "Primary CTA that begins onboarding for a new user."
-        },
-        "use_existing_account": {
-          "type": "string",
-          "description": "Secondary CTA for returning users who already have an account."
-        },
-        "legal_disclaimer_prefix": {
-          "type": "string",
-          "description": "First inline-text fragment of the legal disclaimer shown under the CTAs. Followed by the Terms link, the connector, and the Privacy Policy link. Include any required trailing space."
-        },
-        "legal_disclaimer_and": {
-          "type": "string",
-          "description": "Connector word between the Terms link and the Privacy Policy link in the inline disclaimer. Include any required surrounding spaces (e.g. ' & ')."
-        },
-        "legal_terms": {
-          "type": "string",
-          "description": "Inline link label that opens the in-app Terms & Conditions webview."
-        },
-        "legal_privacy_policy": {
-          "type": "string",
-          "description": "Inline link label that opens the in-app Privacy Policy webview."
-        },
-        "privacy_policy_title": {
-          "type": "string",
-          "description": "Title of the in-app webview screen that displays the Privacy Policy. The Privacy Policy body itself is the CMS page referenced by wm-app-config.privacyPolicyPage, not a translation string."
-        },
-        "terms_and_conditions_title": {
-          "type": "string",
-          "description": "Title of the in-app webview screen that displays the Terms & Conditions. The body itself is the CMS page referenced by wm-app-config.termsAndConditionsPage."
-        },
-        "email_app_unavailable": {
-          "type": "string",
-          "description": "Error toast shown when the OS cannot find an installed email client to handle a mailto: link from the welcome screen."
-        },
-        "link_open_failed": {
-          "type": "string",
-          "description": "Generic error toast shown when an inline link on the welcome screen fails to open."
-        }
-      },
-      "additionalProperties": false,
-      "screenshot": "https://www.figma.com/design/JkJK5lBTjB3oSwATMGqfUt/We-Meditate-App?node-id=5390-8945"
-    },
     "onboarding": {
       "type": "object",
       "description": "Onboarding flow — name entry, greeting, user-type classification, and the intro carousel. Drives downstream personalisation and the analytics yogi-exclusion gate.",
       "properties": {
+        "welcome": {
+          "type": "object",
+          "description": "First screen new users see before any onboarding. Legal disclaimer is inline below the primary CTAs.",
+          "properties": {
+            "title": {
+              "type": "string",
+              "description": "Hero title on the welcome screen. Short greeting (e.g. 'Welcome, friend')."
+            },
+            "subtitle": {
+              "type": "string",
+              "description": "Hero subtitle below the welcome title."
+            },
+            "get_started": {
+              "type": "string",
+              "description": "Primary CTA that begins onboarding for a new user."
+            },
+            "use_existing_account": {
+              "type": "string",
+              "description": "Secondary CTA for returning users who already have an account."
+            },
+            "legal_disclaimer_prefix": {
+              "type": "string",
+              "description": "First inline-text fragment of the legal disclaimer shown under the CTAs. Followed by the Terms link, the connector, and the Privacy Policy link. Include any required trailing space."
+            },
+            "legal_disclaimer_and": {
+              "type": "string",
+              "description": "Connector word between the Terms link and the Privacy Policy link in the inline disclaimer. Include any required surrounding spaces (e.g. ' & ')."
+            },
+            "legal_terms": {
+              "type": "string",
+              "description": "Inline link label that opens the in-app Terms & Conditions webview."
+            },
+            "legal_privacy_policy": {
+              "type": "string",
+              "description": "Inline link label that opens the in-app Privacy Policy webview."
+            },
+            "privacy_policy_title": {
+              "type": "string",
+              "description": "Title of the in-app webview screen that displays the Privacy Policy. The Privacy Policy body itself is the CMS page referenced by wm-app-config.privacyPolicyPage, not a translation string."
+            },
+            "terms_and_conditions_title": {
+              "type": "string",
+              "description": "Title of the in-app webview screen that displays the Terms & Conditions. The body itself is the CMS page referenced by wm-app-config.termsAndConditionsPage."
+            },
+            "email_app_unavailable": {
+              "type": "string",
+              "description": "Error toast shown when the OS cannot find an installed email client to handle a mailto: link from the welcome screen."
+            },
+            "link_open_failed": {
+              "type": "string",
+              "description": "Generic error toast shown when an inline link on the welcome screen fails to open."
+            }
+          },
+          "additionalProperties": false,
+          "screenshot": "https://www.figma.com/design/JkJK5lBTjB3oSwATMGqfUt/We-Meditate-App?node-id=5390-8945"
+        },
         "name": {
           "type": "object",
           "description": "Onboarding step where the new user enters their first name.",

--- a/src/globals/wemeditate-app/translationsSchema.json
+++ b/src/globals/wemeditate-app/translationsSchema.json
@@ -56,106 +56,520 @@
       },
       "additionalProperties": false
     },
-    "onboarding_name": {
+    "onboarding": {
       "type": "object",
-      "description": "Onboarding step where the new user enters their first name.",
+      "description": "Onboarding flow — name entry, greeting, user-type classification, and the intro carousel. Drives downstream personalisation and the analytics yogi-exclusion gate.",
       "properties": {
-        "title": {
-          "type": "string",
-          "description": "Screen prompt asking the user for their name (e.g. “What’s your name?”)."
+        "name": {
+          "type": "object",
+          "description": "Onboarding step where the new user enters their first name.",
+          "properties": {
+            "title": {
+              "type": "string",
+              "description": "Screen prompt asking the user for their name (e.g. “What’s your name?”)."
+            },
+            "placeholder": {
+              "type": "string",
+              "description": "Input field placeholder hint for the name field."
+            },
+            "continue": {
+              "type": "string",
+              "description": "Primary CTA to confirm the entered name and continue onboarding."
+            }
+          },
+          "additionalProperties": false
         },
-        "placeholder": {
-          "type": "string",
-          "description": "Input field placeholder hint for the name field."
+        "greeting": {
+          "type": "object",
+          "description": "Brief greeting screen shown immediately after the user enters their name.",
+          "properties": {
+            "message_prefix": {
+              "type": "string",
+              "description": "Multi-line greeting prefix shown above the user’s name. Preserve the embedded line breaks (\\n) — they control where the text wraps in the hero layout."
+            }
+          },
+          "additionalProperties": false
         },
-        "continue": {
-          "type": "string",
-          "description": "Primary CTA to confirm the entered name and continue onboarding."
+        "user_type": {
+          "type": "object",
+          "description": "Onboarding step where the user self-classifies (complete beginner, tried before, attending classes, yogi). Drives downstream personalisation and the analytics yogi-exclusion gate.",
+          "properties": {
+            "title_prefix": {
+              "type": "string",
+              "description": "First text fragment of the screen title. Combined with title_brand and title_suffix to form the full prompt (e.g. 'Have you tried Sahaja Yoga before?'). Preserve the trailing line break (\\n)."
+            },
+            "title_brand": {
+              "type": "string",
+              "description": "The 'Sahaja Yoga' brand fragment in the title. Usually kept in original spelling, with optional locale-script transliteration."
+            },
+            "title_suffix": {
+              "type": "string",
+              "description": "Closing text fragment of the title (typically ' before?'). Include the leading space if needed for the locale."
+            },
+            "get_started": {
+              "type": "string",
+              "description": "Primary CTA used after the user picks their classification."
+            },
+            "option_complete_beginner": {
+              "type": "string",
+              "description": "Selectable option for users completely new to meditation. Maps to userType = user-complete-beginner."
+            },
+            "option_tried_before": {
+              "type": "string",
+              "description": "Selectable option for users who have tried meditation before but not deeply. Maps to userType = user-tried-before."
+            },
+            "option_attending_classes": {
+              "type": "string",
+              "description": "Selectable option for users currently in an in-person or online newcomer class. Maps to userType = user-attending-classes."
+            },
+            "option_yogi": {
+              "type": "string",
+              "description": "Selectable option for long-time Sahaja Yoga practitioners. Maps to userType = yogi (excluded from the ad-measurement path)."
+            }
+          },
+          "additionalProperties": false
+        },
+        "carousel": {
+          "type": "object",
+          "description": "Three-slide intro carousel shown early in onboarding.",
+          "properties": {
+            "page_moment_title": {
+              "type": "string",
+              "description": "Slide 1 title (e.g. 'A moment of peace')."
+            },
+            "page_moment_subtitle": {
+              "type": "string",
+              "description": "Slide 1 supporting copy."
+            },
+            "page_true_self_prefix": {
+              "type": "string",
+              "description": "Slide 2 title prefix; combined inline with page_true_self_highlight (e.g. 'Get to know your true self'). Include the trailing space."
+            },
+            "page_true_self_highlight": {
+              "type": "string",
+              "description": "Highlighted phrase at the end of slide 2 title, typically rendered in an accent colour (e.g. 'true self')."
+            },
+            "page_true_self_subtitle": {
+              "type": "string",
+              "description": "Slide 2 supporting copy."
+            },
+            "page_unlock_potential_title": {
+              "type": "string",
+              "description": "Slide 3 title (e.g. 'Unlock your potential')."
+            },
+            "page_unlock_potential_subtitle": {
+              "type": "string",
+              "description": "Slide 3 supporting copy."
+            }
+          },
+          "additionalProperties": false
         }
       },
       "additionalProperties": false
     },
-    "onboarding_greeting": {
+    "home": {
       "type": "object",
-      "description": "Brief greeting screen shown immediately after the user enters their name.",
+      "description": "Home (Daily) tab — hero, daily/quick/personalised cards, time-of-day variants, plus the curated Explore-style grid embedded on Home.",
       "properties": {
-        "message_prefix": {
-          "type": "string",
-          "description": "Multi-line greeting prefix shown above the user’s name. Preserve the embedded line breaks (\\n) — they control where the text wraps in the hero layout."
-        }
-      },
-      "additionalProperties": false
-    },
-    "onboarding_user_type": {
-      "type": "object",
-      "description": "Onboarding step where the user self-classifies (complete beginner, tried before, attending classes, yogi). Drives downstream personalisation and the analytics yogi-exclusion gate.",
-      "properties": {
-        "title_prefix": {
-          "type": "string",
-          "description": "First text fragment of the screen title. Combined with title_brand and title_suffix to form the full prompt (e.g. 'Have you tried Sahaja Yoga before?'). Preserve the trailing line break (\\n)."
+        "common": {
+          "type": "object",
+          "description": "Shared messages and error toasts on the Home (Daily) tab.",
+          "properties": {
+            "unlock_after_first_meditation": {
+              "type": "string",
+              "description": "Locked-state message shown on Home cards that are gated behind completing the first meditation."
+            },
+            "path_coming_soon": {
+              "type": "string",
+              "description": "Placeholder shown when the Path tile on Home is not yet available for the current user/locale."
+            },
+            "something_went_wrong": {
+              "type": "string",
+              "description": "Generic error message shown on Home when a section fails to load."
+            },
+            "retry": {
+              "type": "string",
+              "description": "Retry CTA used on Home error states."
+            },
+            "external_link_coming_soon": {
+              "type": "string",
+              "description": "Toast shown when an external link card on Home is not yet wired up."
+            },
+            "card_action_not_available": {
+              "type": "string",
+              "description": "Toast shown when tapping a Home card whose action is not yet implemented."
+            },
+            "map_coming_soon": {
+              "type": "string",
+              "description": "Placeholder shown for the in-person class finder on Home before the feature ships."
+            },
+            "music_coming_soon": {
+              "type": "string",
+              "description": "Placeholder shown for the music section on Home before the feature ships."
+            }
+          },
+          "additionalProperties": false
         },
-        "title_brand": {
-          "type": "string",
-          "description": "The 'Sahaja Yoga' brand fragment in the title. Usually kept in original spelling, with optional locale-script transliteration."
+        "load_info": {
+          "type": "object",
+          "description": "Inline info banners on Home that explain why a section is showing fallback content (network or content failure).",
+          "properties": {
+            "top_daily_unavailable": {
+              "type": "string",
+              "description": "Banner shown when the hero Daily meditation could not be resolved at all."
+            },
+            "top_daily_failed": {
+              "type": "string",
+              "description": "Banner shown when the hero Daily meditation failed to load due to a network or content error."
+            },
+            "top_daily_random": {
+              "type": "string",
+              "description": "Banner shown when the hero Daily meditation has been replaced by a random meditation fallback."
+            },
+            "quick_daily_unavailable": {
+              "type": "string",
+              "description": "Banner shown when the Quick meditations row could not be resolved."
+            },
+            "quick_daily_failed": {
+              "type": "string",
+              "description": "Banner shown when the Quick meditations row failed to load."
+            },
+            "quick_daily_random": {
+              "type": "string",
+              "description": "Banner shown when the Quick meditations row has been replaced by random fallbacks."
+            }
+          },
+          "additionalProperties": false
         },
-        "title_suffix": {
-          "type": "string",
-          "description": "Closing text fragment of the title (typically ' before?'). Include the leading space if needed for the locale."
+        "daily": {
+          "type": "object",
+          "description": "Hero, cards, and CTAs on the Daily tab. Includes the time-of-day hero variants (morning/afternoon/evening) and Path / Talks / Live / In-person promo blocks.",
+          "properties": {
+            "start_meditation": {
+              "type": "string",
+              "description": "Primary CTA on the hero card that begins the suggested meditation."
+            },
+            "start_now": {
+              "type": "string",
+              "description": "Compact CTA used on secondary cards to start a meditation immediately."
+            },
+            "start_course": {
+              "type": "string",
+              "description": "CTA on the Path promo card when the user has not started the course."
+            },
+            "continue_course": {
+              "type": "string",
+              "description": "CTA on the Path promo card when the user has progress to resume."
+            },
+            "start_the_course": {
+              "type": "string",
+              "description": "Long-form variant of start_course used in alternate layouts."
+            },
+            "continue_the_course": {
+              "type": "string",
+              "description": "Long-form variant of continue_course used in alternate layouts."
+            },
+            "scroll_to_the_path": {
+              "type": "string",
+              "description": "Accessibility / link label inviting the user to scroll down to the Path section."
+            },
+            "the_path_going_deeper": {
+              "type": "string",
+              "description": "Eyebrow label above the Path promo block (typically uppercase, e.g. 'THE PATH: GOING DEEPER')."
+            },
+            "your_morning_meditation": {
+              "type": "string",
+              "description": "Hero title used in the morning time-of-day variant."
+            },
+            "your_afternoon_meditation": {
+              "type": "string",
+              "description": "Hero title used in the afternoon time-of-day variant."
+            },
+            "your_evening_meditation": {
+              "type": "string",
+              "description": "Hero title used in the evening time-of-day variant."
+            },
+            "morning_meditation_subtitle": {
+              "type": "string",
+              "description": "Hero subtitle for the morning variant. Preserve the embedded line break (\\n) — it controls hero layout."
+            },
+            "afternoon_meditation_subtitle": {
+              "type": "string",
+              "description": "Hero subtitle for the afternoon variant. Preserve the embedded line break (\\n)."
+            },
+            "evening_meditation_subtitle": {
+              "type": "string",
+              "description": "Hero subtitle for the evening variant."
+            },
+            "path_going_deeper_title": {
+              "type": "string",
+              "description": "Title of the Path promo card on Home. Preserve the embedded line break (\\n)."
+            },
+            "path_going_deeper_subtitle": {
+              "type": "string",
+              "description": "Subtitle of the Path promo card on Home."
+            },
+            "learn_from_source": {
+              "type": "string",
+              "description": "Eyebrow label above the Shri Mataji talks section on Home (typically uppercase)."
+            },
+            "hero_label_get_started": {
+              "type": "string",
+              "description": "Eyebrow chip label on the hero card for pre-activation users (‘Get started’)."
+            },
+            "hero_label_try_something_new": {
+              "type": "string",
+              "description": "Eyebrow chip label on the hero card encouraging variation."
+            },
+            "hero_label_learn_from_source": {
+              "type": "string",
+              "description": "Eyebrow chip label on the hero card promoting Shri Mataji content."
+            },
+            "hero_label_meditate_with_others": {
+              "type": "string",
+              "description": "Eyebrow chip label on the hero card promoting community sessions."
+            },
+            "hero_label_discover": {
+              "type": "string",
+              "description": "Eyebrow chip label on the hero card promoting discovery / Explore."
+            },
+            "shri_mataji_talks_title": {
+              "type": "string",
+              "description": "Section title of the Shri Mataji talks block on Home."
+            },
+            "shri_mataji_talks_subtitle": {
+              "type": "string",
+              "description": "Section subtitle of the Shri Mataji talks block on Home."
+            },
+            "see_more": {
+              "type": "string",
+              "description": "Inline link/CTA to expand a section or view more items."
+            },
+            "whats_your_priority_today": {
+              "type": "string",
+              "description": "Eyebrow above the priority chooser on Home, daytime variant (typically uppercase)."
+            },
+            "whats_your_priority_tonight": {
+              "type": "string",
+              "description": "Eyebrow above the priority chooser on Home, evening variant (typically uppercase)."
+            },
+            "whats_your_priority_tag": {
+              "type": "string",
+              "description": "Chip tag label categorising priority-chooser cards."
+            },
+            "meditate_with_others_tag": {
+              "type": "string",
+              "description": "Chip tag label categorising community-session cards."
+            },
+            "improve_meditation_tag": {
+              "type": "string",
+              "description": "Chip tag label categorising improvement / techniques cards."
+            },
+            "quick_morning": {
+              "type": "string",
+              "description": "Quick-meditation card title (morning). Preserve the embedded line break (\\n)."
+            },
+            "quick_afternoon": {
+              "type": "string",
+              "description": "Quick-meditation card title (afternoon). Preserve the embedded line break (\\n) and quoted punctuation."
+            },
+            "quick_evening": {
+              "type": "string",
+              "description": "Quick-meditation card title (evening). Preserve the embedded line break (\\n)."
+            },
+            "longer_session": {
+              "type": "string",
+              "description": "Card title for the longer/personalised session. Preserve the embedded line break (\\n)."
+            },
+            "help_me_deal": {
+              "type": "string",
+              "description": "Card title inviting users to find a meditation matched to a current feeling. Preserve the embedded line break (\\n)."
+            },
+            "help_me_deal_custom_title": {
+              "type": "string",
+              "description": "Title of the follow-up screen after the user taps the 'Help me deal' card. Preserve the embedded line break (\\n)."
+            },
+            "explore_deeper": {
+              "type": "string",
+              "description": "Card title promoting deeper exploration of the practice. Preserve the embedded line break (\\n)."
+            },
+            "unlock_guided_meditations": {
+              "type": "string",
+              "description": "Locked-state label shown on cards gated behind the first meditation."
+            },
+            "meditate_with_others": {
+              "type": "string",
+              "description": "Eyebrow above the community block on Home (typically uppercase)."
+            },
+            "find_class_near_you": {
+              "type": "string",
+              "description": "Community card inviting the user to find a local in-person class. Preserve the embedded line break (\\n)."
+            },
+            "join_live_online_class": {
+              "type": "string",
+              "description": "Community card inviting the user to join a live online class. Preserve the embedded line break (\\n)."
+            },
+            "improve_your_meditation": {
+              "type": "string",
+              "description": "Eyebrow above the improvement / techniques block on Home (typically uppercase)."
+            },
+            "improve_card_techniques_title": {
+              "type": "string",
+              "description": "Title of the Techniques card in the Improve block."
+            },
+            "improve_card_techniques_subtitle": {
+              "type": "string",
+              "description": "Subtitle of the Techniques card in the Improve block."
+            },
+            "improve_card_subtle_system_title": {
+              "type": "string",
+              "description": "Title of the Subtle System card in the Improve block."
+            },
+            "improve_card_subtle_system_subtitle": {
+              "type": "string",
+              "description": "Subtitle of the Subtle System card in the Improve block."
+            },
+            "highlights_title": {
+              "type": "string",
+              "description": "Eyebrow above the Highlights carousel on Home (typically uppercase)."
+            },
+            "get_back_in_the_flow": {
+              "type": "string",
+              "description": "Title used on the resume-card prompting the user back into the flow. Preserve the embedded line break (\\n)."
+            },
+            "live_now": {
+              "type": "string",
+              "description": "Badge shown on the live-meditation card when a live session is currently in progress."
+            },
+            "minutes_short": {
+              "type": "string",
+              "description": "Short abbreviation for minutes used in card chips (e.g. 'min')."
+            },
+            "live_countdown_days": {
+              "type": "string",
+              "description": "Unit label for the days portion of the live-meditation countdown."
+            },
+            "live_countdown_hours": {
+              "type": "string",
+              "description": "Unit label for the hours portion of the live-meditation countdown."
+            },
+            "live_countdown_minutes": {
+              "type": "string",
+              "description": "Unit label for the minutes portion of the live-meditation countdown."
+            },
+            "live_reminder_button_active": {
+              "type": "string",
+              "description": "Label shown on the live-meditation reminder button when a 30-minute reminder is already scheduled."
+            },
+            "live_reminder_notification_title": {
+              "type": "string",
+              "description": "Title of the scheduled local notification that reminds the user about an upcoming live meditation."
+            },
+            "live_reminder_notification_body": {
+              "type": "string",
+              "description": "Body of the scheduled local notification that reminds the user about an upcoming live meditation."
+            },
+            "live_reminder_permission_denied": {
+              "type": "string",
+              "description": "Inline message shown after the user denies the notification permission required for live-meditation reminders."
+            },
+            "live_reminder_permission_settings": {
+              "type": "string",
+              "description": "Inline message asking the user to enable notifications in OS Settings to receive live-meditation reminders."
+            }
+          },
+          "additionalProperties": false
         },
-        "get_started": {
-          "type": "string",
-          "description": "Primary CTA used after the user picks their classification."
-        },
-        "option_complete_beginner": {
-          "type": "string",
-          "description": "Selectable option for users completely new to meditation. Maps to userType = user-complete-beginner."
-        },
-        "option_tried_before": {
-          "type": "string",
-          "description": "Selectable option for users who have tried meditation before but not deeply. Maps to userType = user-tried-before."
-        },
-        "option_attending_classes": {
-          "type": "string",
-          "description": "Selectable option for users currently in an in-person or online newcomer class. Maps to userType = user-attending-classes."
-        },
-        "option_yogi": {
-          "type": "string",
-          "description": "Selectable option for long-time Sahaja Yoga practitioners. Maps to userType = yogi (excluded from the ad-measurement path)."
-        }
-      },
-      "additionalProperties": false
-    },
-    "onboarding_carousel": {
-      "type": "object",
-      "description": "Three-slide intro carousel shown early in onboarding.",
-      "properties": {
-        "page_moment_title": {
-          "type": "string",
-          "description": "Slide 1 title (e.g. 'A moment of peace')."
-        },
-        "page_moment_subtitle": {
-          "type": "string",
-          "description": "Slide 1 supporting copy."
-        },
-        "page_true_self_prefix": {
-          "type": "string",
-          "description": "Slide 2 title prefix; combined inline with page_true_self_highlight (e.g. 'Get to know your true self'). Include the trailing space."
-        },
-        "page_true_self_highlight": {
-          "type": "string",
-          "description": "Highlighted phrase at the end of slide 2 title, typically rendered in an accent colour (e.g. 'true self')."
-        },
-        "page_true_self_subtitle": {
-          "type": "string",
-          "description": "Slide 2 supporting copy."
-        },
-        "page_unlock_potential_title": {
-          "type": "string",
-          "description": "Slide 3 title (e.g. 'Unlock your potential')."
-        },
-        "page_unlock_potential_subtitle": {
-          "type": "string",
-          "description": "Slide 3 supporting copy."
+        "explore": {
+          "type": "object",
+          "description": "Explore-style block embedded on the Home/Daily tab (a curated grid of Meditate / Learn / Join cards). Distinct from the standalone Explore tab.",
+          "properties": {
+            "section_label": {
+              "type": "string",
+              "description": "Eyebrow label for the embedded Explore block."
+            },
+            "section_meditate_title": {
+              "type": "string",
+              "description": "Section header for the Meditate column."
+            },
+            "section_learn_title": {
+              "type": "string",
+              "description": "Section header for the Learn column."
+            },
+            "section_join_title": {
+              "type": "string",
+              "description": "Section header for the Join Free Classes column."
+            },
+            "card_daily_title": {
+              "type": "string",
+              "description": "Card title for the Daily entry in the Explore block."
+            },
+            "card_daily_subtitle": {
+              "type": "string",
+              "description": "Card subtitle for the Daily entry in the Explore block."
+            },
+            "card_path_title": {
+              "type": "string",
+              "description": "Card title for the Path entry in the Explore block."
+            },
+            "card_path_subtitle": {
+              "type": "string",
+              "description": "Card subtitle for the Path entry in the Explore block."
+            },
+            "card_techniques_title": {
+              "type": "string",
+              "description": "Card title for the Techniques entry in the Explore block."
+            },
+            "card_techniques_subtitle": {
+              "type": "string",
+              "description": "Card subtitle for the Techniques entry in the Explore block."
+            },
+            "card_vibes_check_title": {
+              "type": "string",
+              "description": "Card title for the Vibes Check entry in the Explore block."
+            },
+            "card_vibes_check_subtitle": {
+              "type": "string",
+              "description": "Card subtitle for the Vibes Check entry in the Explore block."
+            },
+            "card_music_title": {
+              "type": "string",
+              "description": "Card title for the Music for Meditation entry in the Explore block."
+            },
+            "card_challenges_title": {
+              "type": "string",
+              "description": "Card title for the Challenges entry in the Explore block."
+            },
+            "card_talks_title": {
+              "type": "string",
+              "description": "Card title for the Shri Mataji Talks entry in the Explore block. Preserve the embedded line break (\\n)."
+            },
+            "card_subtle_system_title": {
+              "type": "string",
+              "description": "Card title for the Subtle System entry in the Explore block."
+            },
+            "card_who_is_title": {
+              "type": "string",
+              "description": "Card title for the 'Who is Shri Mataji' entry in the Explore block. Preserve the embedded line break (\\n)."
+            },
+            "card_what_is_title": {
+              "type": "string",
+              "description": "Card title for the 'What is Sahaja Yoga?' entry in the Explore block."
+            },
+            "card_live_online_title": {
+              "type": "string",
+              "description": "Card title for the Live Online Classes entry in the Explore block. Preserve the embedded line break (\\n)."
+            },
+            "card_find_classes_title": {
+              "type": "string",
+              "description": "Card title for the in-person class finder entry in the Explore block. Preserve the embedded line break (\\n)."
+            },
+            "card_coming_soon": {
+              "type": "string",
+              "description": "Generic 'Coming soon' badge used on locked Explore-block cards."
+            }
+          },
+          "additionalProperties": false
         }
       },
       "additionalProperties": false
@@ -202,2006 +616,1648 @@
       },
       "additionalProperties": false
     },
-    "home_common": {
+    "meditation": {
       "type": "object",
-      "description": "Shared messages and error toasts on the Home (Daily) tab.",
+      "description": "Meditation player and the surrounding intro flow (pre-meditation intent, footsoak, Vibes Check, subtle-system diagram).",
       "properties": {
-        "unlock_after_first_meditation": {
-          "type": "string",
-          "description": "Locked-state message shown on Home cards that are gated behind completing the first meditation."
+        "intent": {
+          "type": "object",
+          "description": "Pre-meditation intent / set-up flow: time-of-day picker, quick vs. personalised selection, reminder prompts, and notification-permission rationale screens.",
+          "properties": {
+            "carousel_continue": {
+              "type": "string",
+              "description": "Continue CTA on the intent carousel."
+            },
+            "skip_video_and_continue": {
+              "type": "string",
+              "description": "Skip-link shown over the intent video that lets the user proceed without watching."
+            },
+            "repeat_video": {
+              "type": "string",
+              "description": "Replay-link shown after the intent video ends."
+            },
+            "start_meditation": {
+              "type": "string",
+              "description": "Primary CTA that starts the actual meditation after the intent flow."
+            },
+            "skip_and_explore_the_app": {
+              "type": "string",
+              "description": "Tertiary CTA letting a new user skip the first meditation and just browse the app. Tied to the onboarding_ready_action / skip_and_explore_app_press analytics event."
+            },
+            "step_label": {
+              "type": "string",
+              "description": "Step indicator (e.g. 'Step 1 of 3') at the top of the intent flow."
+            },
+            "title_today": {
+              "type": "string",
+              "description": "Intent screen title shown during the day. Preserve the embedded line break (\\n)."
+            },
+            "title_tonight": {
+              "type": "string",
+              "description": "Intent screen title shown in the evening. Preserve the embedded line break (\\n)."
+            },
+            "first_meditation_title": {
+              "type": "string",
+              "description": "Title of the locked first-meditation card before activation."
+            },
+            "first_meditation_subtitle": {
+              "type": "string",
+              "description": "Subtitle of the locked first-meditation card."
+            },
+            "repeat_first_meditation_title": {
+              "type": "string",
+              "description": "Title shown when a returning user is invited to repeat the first meditation."
+            },
+            "repeat_first_meditation_subtitle": {
+              "type": "string",
+              "description": "Subtitle shown when a returning user is invited to repeat the first meditation."
+            },
+            "ready_to_try_title": {
+              "type": "string",
+              "description": "Title shown on the 'ready to try?' confirmation step before starting the first meditation."
+            },
+            "ready_to_try_subtitle_beginner": {
+              "type": "string",
+              "description": "Subtitle for the 'ready to try?' step, beginner variant."
+            },
+            "ready_to_try_subtitle_repeat": {
+              "type": "string",
+              "description": "Subtitle for the 'ready to try?' step, repeat variant."
+            },
+            "quick_morning_title": {
+              "type": "string",
+              "description": "Title of the morning quick-meditation card in the intent flow."
+            },
+            "quick_afternoon_title": {
+              "type": "string",
+              "description": "Title of the afternoon quick-meditation card in the intent flow."
+            },
+            "quick_evening_title": {
+              "type": "string",
+              "description": "Title of the evening quick-meditation card in the intent flow."
+            },
+            "quick_morning_subtitle": {
+              "type": "string",
+              "description": "Subtitle of the morning quick-meditation card."
+            },
+            "quick_afternoon_subtitle": {
+              "type": "string",
+              "description": "Subtitle of the afternoon quick-meditation card. Preserve the embedded line break (\\n)."
+            },
+            "quick_evening_subtitle": {
+              "type": "string",
+              "description": "Subtitle of the evening quick-meditation card."
+            },
+            "personalized_title": {
+              "type": "string",
+              "description": "Title of the personalised long-session card in the intent flow."
+            },
+            "personalized_subtitle": {
+              "type": "string",
+              "description": "Subtitle of the personalised long-session card."
+            },
+            "locked_subtitle": {
+              "type": "string",
+              "description": "Subtitle shown on cards that are locked until the user completes their first meditation."
+            },
+            "learn_more": {
+              "type": "string",
+              "description": "Inline link/CTA used on intent-flow cards to view more detail."
+            },
+            "go_to_first_meditation": {
+              "type": "string",
+              "description": "CTA on a locked card that takes the user back to the first meditation flow."
+            },
+            "set_reminder_for_later": {
+              "type": "string",
+              "description": "CTA opening the 'schedule for later' bottom sheet."
+            },
+            "reminder_prompt_title": {
+              "type": "string",
+              "description": "Title of the prompt that suggests scheduling the first meditation for later. Preserve the embedded line break (\\n)."
+            },
+            "reminder_prompt_subtitle": {
+              "type": "string",
+              "description": "Subtitle of the same scheduling prompt. Preserve the embedded line break (\\n)."
+            },
+            "reminder_prompt_set_reminder": {
+              "type": "string",
+              "description": "Primary CTA on the scheduling prompt."
+            },
+            "reminder_prompt_no_thanks": {
+              "type": "string",
+              "description": "Decline CTA on the scheduling prompt."
+            },
+            "reminder_prompt_allow_notifications_title": {
+              "type": "string",
+              "description": "Title of the rationale screen explaining why notification permission is needed before showing the OS prompt."
+            },
+            "reminder_prompt_allow_notifications_subtitle": {
+              "type": "string",
+              "description": "Subtitle of the same rationale screen. References the wording on the next (OS) screen — keep 'Allow' consistent with the OS prompt translation if locale-specific."
+            },
+            "reminder_prompt_allow_notifications_primary": {
+              "type": "string",
+              "description": "Primary CTA on the notification-rationale screen that triggers the OS permission prompt."
+            },
+            "reminder_prompt_not_now": {
+              "type": "string",
+              "description": "Decline CTA on the notification-rationale screen."
+            },
+            "reminder_prompt_turn_on_notifications_title": {
+              "type": "string",
+              "description": "Title shown when notifications were previously denied and need to be re-enabled from OS Settings."
+            },
+            "reminder_prompt_turn_on_notifications_subtitle": {
+              "type": "string",
+              "description": "Subtitle of the same 'open Settings' prompt."
+            },
+            "reminder_prompt_open_settings": {
+              "type": "string",
+              "description": "CTA that deep-links to the app’s OS notification settings."
+            },
+            "reminder_sheet_title": {
+              "type": "string",
+              "description": "Title of the bottom sheet where the user picks a reminder time. Preserve the embedded line break (\\n)."
+            },
+            "reminder_sheet_dont_set": {
+              "type": "string",
+              "description": "Dismiss action on the reminder bottom sheet."
+            },
+            "reminder_sheet_done": {
+              "type": "string",
+              "description": "Confirm CTA on the reminder bottom sheet."
+            },
+            "reminder_sheet_return_to_meditation": {
+              "type": "string",
+              "description": "CTA letting the user return to the meditation flow from the reminder sheet."
+            },
+            "reminder_sheet_leave_meditation": {
+              "type": "string",
+              "description": "CTA letting the user exit the meditation flow from the reminder sheet."
+            },
+            "reminder_sheet_success_title": {
+              "type": "string",
+              "description": "Title of the success confirmation after a reminder is scheduled."
+            },
+            "reminder_sheet_success_subtitle": {
+              "type": "string",
+              "description": "Subtitle of the success confirmation after a reminder is scheduled."
+            },
+            "reminder_sheet_explore_app": {
+              "type": "string",
+              "description": "CTA on the success confirmation suggesting the user explores the app while waiting."
+            },
+            "reminder_sheet_start_first_meditation": {
+              "type": "string",
+              "description": "CTA on the success confirmation suggesting the user starts the first meditation immediately instead."
+            },
+            "reminder_sheet_error": {
+              "type": "string",
+              "description": "Error toast shown when scheduling the reminder fails."
+            },
+            "reminder_preset_unwind_later_today": {
+              "type": "string",
+              "description": "Preset chip label suggesting a reminder later the same day."
+            },
+            "reminder_preset_start_your_week_calm": {
+              "type": "string",
+              "description": "Preset chip label suggesting a reminder at the start of the week."
+            },
+            "reminder_preset_find_your_midweek_balance": {
+              "type": "string",
+              "description": "Preset chip label suggesting a reminder midweek."
+            },
+            "reminder_preset_pause_and_recharge": {
+              "type": "string",
+              "description": "Preset chip label suggesting a recharge break."
+            },
+            "reminder_preset_mindful_break_before_weekend": {
+              "type": "string",
+              "description": "Preset chip label suggesting a reminder before the weekend."
+            },
+            "reminder_preset_end_your_week_with_peace": {
+              "type": "string",
+              "description": "Preset chip label suggesting a reminder at the end of the work week."
+            },
+            "reminder_preset_slow_down_weekend": {
+              "type": "string",
+              "description": "Preset chip label suggesting a weekend slow-down reminder."
+            },
+            "reminder_preset_reset_for_week_ahead": {
+              "type": "string",
+              "description": "Preset chip label suggesting a Sunday reset reminder."
+            },
+            "reminder_notification_title": {
+              "type": "string",
+              "description": "Title of the scheduled local notification used by the generic meditation reminder."
+            },
+            "reminder_notification_body_locked": {
+              "type": "string",
+              "description": "Notification body used when the meditation is still locked at the time the reminder fires."
+            },
+            "reminder_notification_body_exit": {
+              "type": "string",
+              "description": "Notification body used when the reminder is for a previously exited meditation."
+            },
+            "reminder_allow_notifications_screen_title": {
+              "type": "string",
+              "description": "Title of the dedicated full-screen rationale used when reminder scheduling requires notification permission."
+            },
+            "reminder_allow_notifications_screen_subtitle": {
+              "type": "string",
+              "description": "Subtitle of the same full-screen rationale. Preserve the embedded line break (\\n) and the trailing sparkle emoji (✨) if used in copy."
+            },
+            "locked_quick_start_title": {
+              "type": "string",
+              "description": "Title shown in the locked-preview card for Quick meditations (‘Start right away’)."
+            },
+            "locked_quick_start_description_morning": {
+              "type": "string",
+              "description": "Locked-preview description for morning Quick meditations."
+            },
+            "locked_quick_start_description_afternoon": {
+              "type": "string",
+              "description": "Locked-preview description for afternoon Quick meditations."
+            },
+            "locked_quick_start_description_evening": {
+              "type": "string",
+              "description": "Locked-preview description for evening Quick meditations."
+            },
+            "locked_quick_custom_time_title": {
+              "type": "string",
+              "description": "Title of the custom-time row in the Quick locked preview."
+            },
+            "locked_quick_custom_time_description": {
+              "type": "string",
+              "description": "Description of the custom-time row in the Quick locked preview."
+            },
+            "locked_personalized_feeling_title": {
+              "type": "string",
+              "description": "Title of the feeling-picker row in the Personalised locked preview."
+            },
+            "locked_personalized_feeling_description": {
+              "type": "string",
+              "description": "Description of the feeling-picker row in the Personalised locked preview."
+            },
+            "locked_personalized_custom_time_title": {
+              "type": "string",
+              "description": "Title of the custom-time row in the Personalised locked preview."
+            },
+            "locked_personalized_custom_time_description": {
+              "type": "string",
+              "description": "Description of the custom-time row in the Personalised locked preview."
+            }
+          },
+          "additionalProperties": false
         },
-        "path_coming_soon": {
-          "type": "string",
-          "description": "Placeholder shown when the Path tile on Home is not yet available for the current user/locale."
+        "player": {
+          "type": "object",
+          "description": "Meditation audio player (voice + background music). v1 only carries an error title; controls are pictographic.",
+          "properties": {
+            "load_error_title": {
+              "type": "string",
+              "description": "Error title shown when the meditation track fails to load in the player."
+            }
+          },
+          "additionalProperties": false
         },
-        "something_went_wrong": {
-          "type": "string",
-          "description": "Generic error message shown on Home when a section fails to load."
+        "footsoak": {
+          "type": "object",
+          "description": "Step 3 of 3 in the meditation intro: invites the user to do an optional foot-soak before meditating.",
+          "properties": {
+            "step_label": {
+              "type": "string",
+              "description": "Step indicator (e.g. 'Step 3 of 3') at the top of the foot-soak screen."
+            },
+            "title": {
+              "type": "string",
+              "description": "Screen title asking whether the user wants to foot-soak with this meditation."
+            },
+            "description_prefix": {
+              "type": "string",
+              "description": "Body-copy prefix; combined inline with description_emphasis and description_suffix to form a single sentence. Include trailing space if the locale needs one."
+            },
+            "description_emphasis": {
+              "type": "string",
+              "description": "Emphasised word in the foot-soak body copy, typically rendered in italic or bold (e.g. 'really')."
+            },
+            "description_suffix": {
+              "type": "string",
+              "description": "Body-copy suffix completing the foot-soak description sentence. Include the leading space."
+            },
+            "tutorial_cta": {
+              "type": "string",
+              "description": "Inline link/CTA opening the foot-soak tutorial."
+            },
+            "start_with_footsoak": {
+              "type": "string",
+              "description": "Primary CTA that starts the meditation with a foot-soak."
+            },
+            "start_meditation": {
+              "type": "string",
+              "description": "Secondary CTA that starts the meditation without a foot-soak."
+            }
+          },
+          "additionalProperties": false
         },
-        "retry": {
-          "type": "string",
-          "description": "Retry CTA used on Home error states."
+        "vibes_check": {
+          "type": "object",
+          "description": "Vibes Check post-meditation flow: asks what the user felt on each hand. Strictly first-party copy — the raw selections never ship in analytics (see analytics-simplified/02-product-event-taxonomy.md).",
+          "properties": {
+            "intro_question": {
+              "type": "string",
+              "description": "Initial Vibes Check question shown before the per-hand prompt. Preserve the embedded line break (\\n)."
+            },
+            "question_prefix": {
+              "type": "string",
+              "description": "Per-hand question prefix; combined with left_hand or right_hand and question_suffix to form the full prompt (e.g. 'What do you feel on your left hand?'). Preserve the trailing line break (\\n)."
+            },
+            "question_suffix": {
+              "type": "string",
+              "description": "Per-hand question suffix (typically ' hand?'). Include the leading space."
+            },
+            "left_hand": {
+              "type": "string",
+              "description": "Inline noun for the left hand, plugged into the per-hand question template."
+            },
+            "right_hand": {
+              "type": "string",
+              "description": "Inline noun for the right hand, plugged into the per-hand question template."
+            },
+            "cool": {
+              "type": "string",
+              "description": "Selectable sensation: cool. Maps to raw selection 'cool' (first-party storage only)."
+            },
+            "warm": {
+              "type": "string",
+              "description": "Selectable sensation: warm."
+            },
+            "fingers_tingling": {
+              "type": "string",
+              "description": "Selectable sensation: fingers tingling."
+            },
+            "nothing": {
+              "type": "string",
+              "description": "Selectable sensation: nothing felt."
+            },
+            "continue_action": {
+              "type": "string",
+              "description": "Primary CTA to confirm the current Vibes Check answer and continue."
+            },
+            "not_sure": {
+              "type": "string",
+              "description": "Skip-like CTA used when the user is unsure what they felt. Maps to derived firstMedExperience = not_sure."
+            },
+            "got_it": {
+              "type": "string",
+              "description": "Acknowledge CTA at the end of the Vibes Check explanation."
+            },
+            "interpretation_nothing": {
+              "type": "string",
+              "description": "Reassurance shown when the user selects 'nothing' for both hands."
+            },
+            "interpretation_intro": {
+              "type": "string",
+              "description": "Intro line of the Vibes Check interpretation screen."
+            },
+            "interpretation_detail": {
+              "type": "string",
+              "description": "Per-hand detail copy in the Vibes Check interpretation screen."
+            },
+            "skip_vibes_check": {
+              "type": "string",
+              "description": "Inline action that opens the skip-confirmation prompt."
+            },
+            "skip_prompt_title": {
+              "type": "string",
+              "description": "Title of the skip-confirmation prompt."
+            },
+            "skip_prompt_description": {
+              "type": "string",
+              "description": "Body copy of the skip-confirmation prompt."
+            },
+            "back_to_explanation": {
+              "type": "string",
+              "description": "CTA returning the user from the skip prompt to the Vibes Check explanation."
+            },
+            "return_to_meditation_prompt_title": {
+              "type": "string",
+              "description": "Title of the prompt offering to restart the first meditation from the beginning."
+            },
+            "return_to_meditation_prompt_description": {
+              "type": "string",
+              "description": "Body copy of the same restart prompt."
+            },
+            "return_to_meditation_action": {
+              "type": "string",
+              "description": "Primary CTA on the restart prompt."
+            },
+            "skip_it": {
+              "type": "string",
+              "description": "Decline CTA on the restart prompt."
+            }
+          },
+          "additionalProperties": false
         },
-        "external_link_coming_soon": {
-          "type": "string",
-          "description": "Toast shown when an external link card on Home is not yet wired up."
-        },
-        "card_action_not_available": {
-          "type": "string",
-          "description": "Toast shown when tapping a Home card whose action is not yet implemented."
-        },
-        "map_coming_soon": {
-          "type": "string",
-          "description": "Placeholder shown for the in-person class finder on Home before the feature ships."
-        },
-        "music_coming_soon": {
-          "type": "string",
-          "description": "Placeholder shown for the music section on Home before the feature ships."
+        "subtle_system": {
+          "type": "object",
+          "description": "Subtle-system intro diagram shown during the meditation intro (chakras / channels diagram).",
+          "properties": {
+            "screen_label": {
+              "type": "string",
+              "description": "Eyebrow / route label for the subtle-system screen."
+            },
+            "diagram_title": {
+              "type": "string",
+              "description": "Diagram title."
+            },
+            "diagram_subtitle": {
+              "type": "string",
+              "description": "Diagram subtitle prompting the user to tap to learn more."
+            },
+            "mode_chakras": {
+              "type": "string",
+              "description": "Tab label switching the diagram to chakra view."
+            },
+            "mode_channels": {
+              "type": "string",
+              "description": "Tab label switching the diagram to channel view."
+            },
+            "front_view_mirrored": {
+              "type": "string",
+              "description": "Caption clarifying that the diagram shows a front view (left/right are mirrored relative to the viewer)."
+            },
+            "chip_right": {
+              "type": "string",
+              "description": "Filter chip label for the Right channel."
+            },
+            "chip_center": {
+              "type": "string",
+              "description": "Filter chip label for the Center channel."
+            },
+            "chip_left": {
+              "type": "string",
+              "description": "Filter chip label for the Left channel."
+            },
+            "aspect_right": {
+              "type": "string",
+              "description": "Detail label for the Right Aspect of a chakra."
+            },
+            "aspect_center": {
+              "type": "string",
+              "description": "Detail label for the Center Aspect of a chakra."
+            },
+            "aspect_left": {
+              "type": "string",
+              "description": "Detail label for the Left Aspect of a chakra."
+            }
+          },
+          "additionalProperties": false
         }
       },
       "additionalProperties": false
     },
-    "home_load_info": {
+    "talks": {
       "type": "object",
-      "description": "Inline info banners on Home that explain why a section is showing fallback content (network or content failure).",
+      "description": "Shri Mataji talks — intro/placement, list screen, and player.",
       "properties": {
-        "top_daily_unavailable": {
-          "type": "string",
-          "description": "Banner shown when the hero Daily meditation could not be resolved at all."
-        },
-        "top_daily_failed": {
-          "type": "string",
-          "description": "Banner shown when the hero Daily meditation failed to load due to a network or content error."
-        },
-        "top_daily_random": {
-          "type": "string",
-          "description": "Banner shown when the hero Daily meditation has been replaced by a random meditation fallback."
-        },
-        "quick_daily_unavailable": {
-          "type": "string",
-          "description": "Banner shown when the Quick meditations row could not be resolved."
-        },
-        "quick_daily_failed": {
-          "type": "string",
-          "description": "Banner shown when the Quick meditations row failed to load."
-        },
-        "quick_daily_random": {
-          "type": "string",
-          "description": "Banner shown when the Quick meditations row has been replaced by random fallbacks."
-        }
-      },
-      "additionalProperties": false
-    },
-    "home_daily": {
-      "type": "object",
-      "description": "Hero, cards, and CTAs on the Daily tab. Includes the time-of-day hero variants (morning/afternoon/evening) and Path / Talks / Live / In-person promo blocks.",
-      "properties": {
-        "start_meditation": {
-          "type": "string",
-          "description": "Primary CTA on the hero card that begins the suggested meditation."
-        },
-        "start_now": {
-          "type": "string",
-          "description": "Compact CTA used on secondary cards to start a meditation immediately."
-        },
-        "start_course": {
-          "type": "string",
-          "description": "CTA on the Path promo card when the user has not started the course."
-        },
-        "continue_course": {
-          "type": "string",
-          "description": "CTA on the Path promo card when the user has progress to resume."
-        },
-        "start_the_course": {
-          "type": "string",
-          "description": "Long-form variant of start_course used in alternate layouts."
-        },
-        "continue_the_course": {
-          "type": "string",
-          "description": "Long-form variant of continue_course used in alternate layouts."
-        },
-        "scroll_to_the_path": {
-          "type": "string",
-          "description": "Accessibility / link label inviting the user to scroll down to the Path section."
-        },
-        "the_path_going_deeper": {
-          "type": "string",
-          "description": "Eyebrow label above the Path promo block (typically uppercase, e.g. 'THE PATH: GOING DEEPER')."
-        },
-        "your_morning_meditation": {
-          "type": "string",
-          "description": "Hero title used in the morning time-of-day variant."
-        },
-        "your_afternoon_meditation": {
-          "type": "string",
-          "description": "Hero title used in the afternoon time-of-day variant."
-        },
-        "your_evening_meditation": {
-          "type": "string",
-          "description": "Hero title used in the evening time-of-day variant."
-        },
-        "morning_meditation_subtitle": {
-          "type": "string",
-          "description": "Hero subtitle for the morning variant. Preserve the embedded line break (\\n) — it controls hero layout."
-        },
-        "afternoon_meditation_subtitle": {
-          "type": "string",
-          "description": "Hero subtitle for the afternoon variant. Preserve the embedded line break (\\n)."
-        },
-        "evening_meditation_subtitle": {
-          "type": "string",
-          "description": "Hero subtitle for the evening variant."
-        },
-        "path_going_deeper_title": {
-          "type": "string",
-          "description": "Title of the Path promo card on Home. Preserve the embedded line break (\\n)."
-        },
-        "path_going_deeper_subtitle": {
-          "type": "string",
-          "description": "Subtitle of the Path promo card on Home."
-        },
-        "learn_from_source": {
-          "type": "string",
-          "description": "Eyebrow label above the Shri Mataji talks section on Home (typically uppercase)."
-        },
-        "hero_label_get_started": {
-          "type": "string",
-          "description": "Eyebrow chip label on the hero card for pre-activation users (‘Get started’)."
-        },
-        "hero_label_try_something_new": {
-          "type": "string",
-          "description": "Eyebrow chip label on the hero card encouraging variation."
-        },
-        "hero_label_learn_from_source": {
-          "type": "string",
-          "description": "Eyebrow chip label on the hero card promoting Shri Mataji content."
-        },
-        "hero_label_meditate_with_others": {
-          "type": "string",
-          "description": "Eyebrow chip label on the hero card promoting community sessions."
-        },
-        "hero_label_discover": {
-          "type": "string",
-          "description": "Eyebrow chip label on the hero card promoting discovery / Explore."
-        },
-        "shri_mataji_talks_title": {
-          "type": "string",
-          "description": "Section title of the Shri Mataji talks block on Home."
-        },
-        "shri_mataji_talks_subtitle": {
-          "type": "string",
-          "description": "Section subtitle of the Shri Mataji talks block on Home."
-        },
-        "see_more": {
-          "type": "string",
-          "description": "Inline link/CTA to expand a section or view more items."
-        },
-        "whats_your_priority_today": {
-          "type": "string",
-          "description": "Eyebrow above the priority chooser on Home, daytime variant (typically uppercase)."
-        },
-        "whats_your_priority_tonight": {
-          "type": "string",
-          "description": "Eyebrow above the priority chooser on Home, evening variant (typically uppercase)."
-        },
-        "whats_your_priority_tag": {
-          "type": "string",
-          "description": "Chip tag label categorising priority-chooser cards."
-        },
-        "meditate_with_others_tag": {
-          "type": "string",
-          "description": "Chip tag label categorising community-session cards."
-        },
-        "improve_meditation_tag": {
-          "type": "string",
-          "description": "Chip tag label categorising improvement / techniques cards."
-        },
-        "quick_morning": {
-          "type": "string",
-          "description": "Quick-meditation card title (morning). Preserve the embedded line break (\\n)."
-        },
-        "quick_afternoon": {
-          "type": "string",
-          "description": "Quick-meditation card title (afternoon). Preserve the embedded line break (\\n) and quoted punctuation."
-        },
-        "quick_evening": {
-          "type": "string",
-          "description": "Quick-meditation card title (evening). Preserve the embedded line break (\\n)."
-        },
-        "longer_session": {
-          "type": "string",
-          "description": "Card title for the longer/personalised session. Preserve the embedded line break (\\n)."
-        },
-        "help_me_deal": {
-          "type": "string",
-          "description": "Card title inviting users to find a meditation matched to a current feeling. Preserve the embedded line break (\\n)."
-        },
-        "help_me_deal_custom_title": {
-          "type": "string",
-          "description": "Title of the follow-up screen after the user taps the 'Help me deal' card. Preserve the embedded line break (\\n)."
-        },
-        "explore_deeper": {
-          "type": "string",
-          "description": "Card title promoting deeper exploration of the practice. Preserve the embedded line break (\\n)."
-        },
-        "unlock_guided_meditations": {
-          "type": "string",
-          "description": "Locked-state label shown on cards gated behind the first meditation."
-        },
-        "meditate_with_others": {
-          "type": "string",
-          "description": "Eyebrow above the community block on Home (typically uppercase)."
-        },
-        "find_class_near_you": {
-          "type": "string",
-          "description": "Community card inviting the user to find a local in-person class. Preserve the embedded line break (\\n)."
-        },
-        "join_live_online_class": {
-          "type": "string",
-          "description": "Community card inviting the user to join a live online class. Preserve the embedded line break (\\n)."
-        },
-        "improve_your_meditation": {
-          "type": "string",
-          "description": "Eyebrow above the improvement / techniques block on Home (typically uppercase)."
-        },
-        "improve_card_techniques_title": {
-          "type": "string",
-          "description": "Title of the Techniques card in the Improve block."
-        },
-        "improve_card_techniques_subtitle": {
-          "type": "string",
-          "description": "Subtitle of the Techniques card in the Improve block."
-        },
-        "improve_card_subtle_system_title": {
-          "type": "string",
-          "description": "Title of the Subtle System card in the Improve block."
-        },
-        "improve_card_subtle_system_subtitle": {
-          "type": "string",
-          "description": "Subtitle of the Subtle System card in the Improve block."
-        },
-        "highlights_title": {
-          "type": "string",
-          "description": "Eyebrow above the Highlights carousel on Home (typically uppercase)."
-        },
-        "get_back_in_the_flow": {
-          "type": "string",
-          "description": "Title used on the resume-card prompting the user back into the flow. Preserve the embedded line break (\\n)."
-        },
-        "live_now": {
-          "type": "string",
-          "description": "Badge shown on the live-meditation card when a live session is currently in progress."
-        },
-        "minutes_short": {
-          "type": "string",
-          "description": "Short abbreviation for minutes used in card chips (e.g. 'min')."
-        },
-        "live_countdown_days": {
-          "type": "string",
-          "description": "Unit label for the days portion of the live-meditation countdown."
-        },
-        "live_countdown_hours": {
-          "type": "string",
-          "description": "Unit label for the hours portion of the live-meditation countdown."
-        },
-        "live_countdown_minutes": {
-          "type": "string",
-          "description": "Unit label for the minutes portion of the live-meditation countdown."
-        },
-        "live_reminder_button_active": {
-          "type": "string",
-          "description": "Label shown on the live-meditation reminder button when a 30-minute reminder is already scheduled."
-        },
-        "live_reminder_notification_title": {
-          "type": "string",
-          "description": "Title of the scheduled local notification that reminds the user about an upcoming live meditation."
-        },
-        "live_reminder_notification_body": {
-          "type": "string",
-          "description": "Body of the scheduled local notification that reminds the user about an upcoming live meditation."
-        },
-        "live_reminder_permission_denied": {
-          "type": "string",
-          "description": "Inline message shown after the user denies the notification permission required for live-meditation reminders."
-        },
-        "live_reminder_permission_settings": {
-          "type": "string",
-          "description": "Inline message asking the user to enable notifications in OS Settings to receive live-meditation reminders."
-        }
-      },
-      "additionalProperties": false
-    },
-    "home_explore": {
-      "type": "object",
-      "description": "Explore-style block embedded on the Home/Daily tab (a curated grid of Meditate / Learn / Join cards). Distinct from the standalone Explore tab.",
-      "properties": {
-        "section_label": {
-          "type": "string",
-          "description": "Eyebrow label for the embedded Explore block."
-        },
-        "section_meditate_title": {
-          "type": "string",
-          "description": "Section header for the Meditate column."
-        },
-        "section_learn_title": {
-          "type": "string",
-          "description": "Section header for the Learn column."
-        },
-        "section_join_title": {
-          "type": "string",
-          "description": "Section header for the Join Free Classes column."
-        },
-        "card_daily_title": {
-          "type": "string",
-          "description": "Card title for the Daily entry in the Explore block."
-        },
-        "card_daily_subtitle": {
-          "type": "string",
-          "description": "Card subtitle for the Daily entry in the Explore block."
-        },
-        "card_path_title": {
-          "type": "string",
-          "description": "Card title for the Path entry in the Explore block."
-        },
-        "card_path_subtitle": {
-          "type": "string",
-          "description": "Card subtitle for the Path entry in the Explore block."
-        },
-        "card_techniques_title": {
-          "type": "string",
-          "description": "Card title for the Techniques entry in the Explore block."
-        },
-        "card_techniques_subtitle": {
-          "type": "string",
-          "description": "Card subtitle for the Techniques entry in the Explore block."
-        },
-        "card_vibes_check_title": {
-          "type": "string",
-          "description": "Card title for the Vibes Check entry in the Explore block."
-        },
-        "card_vibes_check_subtitle": {
-          "type": "string",
-          "description": "Card subtitle for the Vibes Check entry in the Explore block."
-        },
-        "card_music_title": {
-          "type": "string",
-          "description": "Card title for the Music for Meditation entry in the Explore block."
-        },
-        "card_challenges_title": {
-          "type": "string",
-          "description": "Card title for the Challenges entry in the Explore block."
-        },
-        "card_talks_title": {
-          "type": "string",
-          "description": "Card title for the Shri Mataji Talks entry in the Explore block. Preserve the embedded line break (\\n)."
-        },
-        "card_subtle_system_title": {
-          "type": "string",
-          "description": "Card title for the Subtle System entry in the Explore block."
-        },
-        "card_who_is_title": {
-          "type": "string",
-          "description": "Card title for the 'Who is Shri Mataji' entry in the Explore block. Preserve the embedded line break (\\n)."
-        },
-        "card_what_is_title": {
-          "type": "string",
-          "description": "Card title for the 'What is Sahaja Yoga?' entry in the Explore block."
-        },
-        "card_live_online_title": {
-          "type": "string",
-          "description": "Card title for the Live Online Classes entry in the Explore block. Preserve the embedded line break (\\n)."
-        },
-        "card_find_classes_title": {
-          "type": "string",
-          "description": "Card title for the in-person class finder entry in the Explore block. Preserve the embedded line break (\\n)."
-        },
-        "card_coming_soon": {
-          "type": "string",
-          "description": "Generic 'Coming soon' badge used on locked Explore-block cards."
-        }
-      },
-      "additionalProperties": false
-    },
-    "meditation_intent": {
-      "type": "object",
-      "description": "Pre-meditation intent / set-up flow: time-of-day picker, quick vs. personalised selection, reminder prompts, and notification-permission rationale screens.",
-      "properties": {
-        "carousel_continue": {
-          "type": "string",
-          "description": "Continue CTA on the intent carousel."
-        },
-        "skip_video_and_continue": {
-          "type": "string",
-          "description": "Skip-link shown over the intent video that lets the user proceed without watching."
-        },
-        "repeat_video": {
-          "type": "string",
-          "description": "Replay-link shown after the intent video ends."
-        },
-        "start_meditation": {
-          "type": "string",
-          "description": "Primary CTA that starts the actual meditation after the intent flow."
-        },
-        "skip_and_explore_the_app": {
-          "type": "string",
-          "description": "Tertiary CTA letting a new user skip the first meditation and just browse the app. Tied to the onboarding_ready_action / skip_and_explore_app_press analytics event."
-        },
-        "step_label": {
-          "type": "string",
-          "description": "Step indicator (e.g. 'Step 1 of 3') at the top of the intent flow."
-        },
-        "title_today": {
-          "type": "string",
-          "description": "Intent screen title shown during the day. Preserve the embedded line break (\\n)."
-        },
-        "title_tonight": {
-          "type": "string",
-          "description": "Intent screen title shown in the evening. Preserve the embedded line break (\\n)."
-        },
-        "first_meditation_title": {
-          "type": "string",
-          "description": "Title of the locked first-meditation card before activation."
-        },
-        "first_meditation_subtitle": {
-          "type": "string",
-          "description": "Subtitle of the locked first-meditation card."
-        },
-        "repeat_first_meditation_title": {
-          "type": "string",
-          "description": "Title shown when a returning user is invited to repeat the first meditation."
-        },
-        "repeat_first_meditation_subtitle": {
-          "type": "string",
-          "description": "Subtitle shown when a returning user is invited to repeat the first meditation."
-        },
-        "ready_to_try_title": {
-          "type": "string",
-          "description": "Title shown on the 'ready to try?' confirmation step before starting the first meditation."
-        },
-        "ready_to_try_subtitle_beginner": {
-          "type": "string",
-          "description": "Subtitle for the 'ready to try?' step, beginner variant."
-        },
-        "ready_to_try_subtitle_repeat": {
-          "type": "string",
-          "description": "Subtitle for the 'ready to try?' step, repeat variant."
-        },
-        "quick_morning_title": {
-          "type": "string",
-          "description": "Title of the morning quick-meditation card in the intent flow."
-        },
-        "quick_afternoon_title": {
-          "type": "string",
-          "description": "Title of the afternoon quick-meditation card in the intent flow."
-        },
-        "quick_evening_title": {
-          "type": "string",
-          "description": "Title of the evening quick-meditation card in the intent flow."
-        },
-        "quick_morning_subtitle": {
-          "type": "string",
-          "description": "Subtitle of the morning quick-meditation card."
-        },
-        "quick_afternoon_subtitle": {
-          "type": "string",
-          "description": "Subtitle of the afternoon quick-meditation card. Preserve the embedded line break (\\n)."
-        },
-        "quick_evening_subtitle": {
-          "type": "string",
-          "description": "Subtitle of the evening quick-meditation card."
-        },
-        "personalized_title": {
-          "type": "string",
-          "description": "Title of the personalised long-session card in the intent flow."
-        },
-        "personalized_subtitle": {
-          "type": "string",
-          "description": "Subtitle of the personalised long-session card."
-        },
-        "locked_subtitle": {
-          "type": "string",
-          "description": "Subtitle shown on cards that are locked until the user completes their first meditation."
-        },
-        "learn_more": {
-          "type": "string",
-          "description": "Inline link/CTA used on intent-flow cards to view more detail."
-        },
-        "go_to_first_meditation": {
-          "type": "string",
-          "description": "CTA on a locked card that takes the user back to the first meditation flow."
-        },
-        "set_reminder_for_later": {
-          "type": "string",
-          "description": "CTA opening the 'schedule for later' bottom sheet."
-        },
-        "reminder_prompt_title": {
-          "type": "string",
-          "description": "Title of the prompt that suggests scheduling the first meditation for later. Preserve the embedded line break (\\n)."
-        },
-        "reminder_prompt_subtitle": {
-          "type": "string",
-          "description": "Subtitle of the same scheduling prompt. Preserve the embedded line break (\\n)."
-        },
-        "reminder_prompt_set_reminder": {
-          "type": "string",
-          "description": "Primary CTA on the scheduling prompt."
-        },
-        "reminder_prompt_no_thanks": {
-          "type": "string",
-          "description": "Decline CTA on the scheduling prompt."
-        },
-        "reminder_prompt_allow_notifications_title": {
-          "type": "string",
-          "description": "Title of the rationale screen explaining why notification permission is needed before showing the OS prompt."
-        },
-        "reminder_prompt_allow_notifications_subtitle": {
-          "type": "string",
-          "description": "Subtitle of the same rationale screen. References the wording on the next (OS) screen — keep 'Allow' consistent with the OS prompt translation if locale-specific."
-        },
-        "reminder_prompt_allow_notifications_primary": {
-          "type": "string",
-          "description": "Primary CTA on the notification-rationale screen that triggers the OS permission prompt."
-        },
-        "reminder_prompt_not_now": {
-          "type": "string",
-          "description": "Decline CTA on the notification-rationale screen."
-        },
-        "reminder_prompt_turn_on_notifications_title": {
-          "type": "string",
-          "description": "Title shown when notifications were previously denied and need to be re-enabled from OS Settings."
-        },
-        "reminder_prompt_turn_on_notifications_subtitle": {
-          "type": "string",
-          "description": "Subtitle of the same 'open Settings' prompt."
-        },
-        "reminder_prompt_open_settings": {
-          "type": "string",
-          "description": "CTA that deep-links to the app’s OS notification settings."
-        },
-        "reminder_sheet_title": {
-          "type": "string",
-          "description": "Title of the bottom sheet where the user picks a reminder time. Preserve the embedded line break (\\n)."
-        },
-        "reminder_sheet_dont_set": {
-          "type": "string",
-          "description": "Dismiss action on the reminder bottom sheet."
-        },
-        "reminder_sheet_done": {
-          "type": "string",
-          "description": "Confirm CTA on the reminder bottom sheet."
-        },
-        "reminder_sheet_return_to_meditation": {
-          "type": "string",
-          "description": "CTA letting the user return to the meditation flow from the reminder sheet."
-        },
-        "reminder_sheet_leave_meditation": {
-          "type": "string",
-          "description": "CTA letting the user exit the meditation flow from the reminder sheet."
-        },
-        "reminder_sheet_success_title": {
-          "type": "string",
-          "description": "Title of the success confirmation after a reminder is scheduled."
-        },
-        "reminder_sheet_success_subtitle": {
-          "type": "string",
-          "description": "Subtitle of the success confirmation after a reminder is scheduled."
-        },
-        "reminder_sheet_explore_app": {
-          "type": "string",
-          "description": "CTA on the success confirmation suggesting the user explores the app while waiting."
-        },
-        "reminder_sheet_start_first_meditation": {
-          "type": "string",
-          "description": "CTA on the success confirmation suggesting the user starts the first meditation immediately instead."
-        },
-        "reminder_sheet_error": {
-          "type": "string",
-          "description": "Error toast shown when scheduling the reminder fails."
-        },
-        "reminder_preset_unwind_later_today": {
-          "type": "string",
-          "description": "Preset chip label suggesting a reminder later the same day."
-        },
-        "reminder_preset_start_your_week_calm": {
-          "type": "string",
-          "description": "Preset chip label suggesting a reminder at the start of the week."
-        },
-        "reminder_preset_find_your_midweek_balance": {
-          "type": "string",
-          "description": "Preset chip label suggesting a reminder midweek."
-        },
-        "reminder_preset_pause_and_recharge": {
-          "type": "string",
-          "description": "Preset chip label suggesting a recharge break."
-        },
-        "reminder_preset_mindful_break_before_weekend": {
-          "type": "string",
-          "description": "Preset chip label suggesting a reminder before the weekend."
-        },
-        "reminder_preset_end_your_week_with_peace": {
-          "type": "string",
-          "description": "Preset chip label suggesting a reminder at the end of the work week."
-        },
-        "reminder_preset_slow_down_weekend": {
-          "type": "string",
-          "description": "Preset chip label suggesting a weekend slow-down reminder."
-        },
-        "reminder_preset_reset_for_week_ahead": {
-          "type": "string",
-          "description": "Preset chip label suggesting a Sunday reset reminder."
-        },
-        "reminder_notification_title": {
-          "type": "string",
-          "description": "Title of the scheduled local notification used by the generic meditation reminder."
-        },
-        "reminder_notification_body_locked": {
-          "type": "string",
-          "description": "Notification body used when the meditation is still locked at the time the reminder fires."
-        },
-        "reminder_notification_body_exit": {
-          "type": "string",
-          "description": "Notification body used when the reminder is for a previously exited meditation."
-        },
-        "reminder_allow_notifications_screen_title": {
-          "type": "string",
-          "description": "Title of the dedicated full-screen rationale used when reminder scheduling requires notification permission."
-        },
-        "reminder_allow_notifications_screen_subtitle": {
-          "type": "string",
-          "description": "Subtitle of the same full-screen rationale. Preserve the embedded line break (\\n) and the trailing sparkle emoji (✨) if used in copy."
-        },
-        "locked_quick_start_title": {
-          "type": "string",
-          "description": "Title shown in the locked-preview card for Quick meditations (‘Start right away’)."
-        },
-        "locked_quick_start_description_morning": {
-          "type": "string",
-          "description": "Locked-preview description for morning Quick meditations."
-        },
-        "locked_quick_start_description_afternoon": {
-          "type": "string",
-          "description": "Locked-preview description for afternoon Quick meditations."
-        },
-        "locked_quick_start_description_evening": {
-          "type": "string",
-          "description": "Locked-preview description for evening Quick meditations."
-        },
-        "locked_quick_custom_time_title": {
-          "type": "string",
-          "description": "Title of the custom-time row in the Quick locked preview."
-        },
-        "locked_quick_custom_time_description": {
-          "type": "string",
-          "description": "Description of the custom-time row in the Quick locked preview."
-        },
-        "locked_personalized_feeling_title": {
-          "type": "string",
-          "description": "Title of the feeling-picker row in the Personalised locked preview."
-        },
-        "locked_personalized_feeling_description": {
-          "type": "string",
-          "description": "Description of the feeling-picker row in the Personalised locked preview."
-        },
-        "locked_personalized_custom_time_title": {
-          "type": "string",
-          "description": "Title of the custom-time row in the Personalised locked preview."
-        },
-        "locked_personalized_custom_time_description": {
-          "type": "string",
-          "description": "Description of the custom-time row in the Personalised locked preview."
-        }
-      },
-      "additionalProperties": false
-    },
-    "meditation_player": {
-      "type": "object",
-      "description": "Meditation audio player (voice + background music). v1 only carries an error title; controls are pictographic.",
-      "properties": {
-        "load_error_title": {
-          "type": "string",
-          "description": "Error title shown when the meditation track fails to load in the player."
-        }
-      },
-      "additionalProperties": false
-    },
-    "meditation_footsoak": {
-      "type": "object",
-      "description": "Step 3 of 3 in the meditation intro: invites the user to do an optional foot-soak before meditating.",
-      "properties": {
-        "step_label": {
-          "type": "string",
-          "description": "Step indicator (e.g. 'Step 3 of 3') at the top of the foot-soak screen."
-        },
-        "title": {
-          "type": "string",
-          "description": "Screen title asking whether the user wants to foot-soak with this meditation."
-        },
-        "description_prefix": {
-          "type": "string",
-          "description": "Body-copy prefix; combined inline with description_emphasis and description_suffix to form a single sentence. Include trailing space if the locale needs one."
-        },
-        "description_emphasis": {
-          "type": "string",
-          "description": "Emphasised word in the foot-soak body copy, typically rendered in italic or bold (e.g. 'really')."
-        },
-        "description_suffix": {
-          "type": "string",
-          "description": "Body-copy suffix completing the foot-soak description sentence. Include the leading space."
-        },
-        "tutorial_cta": {
-          "type": "string",
-          "description": "Inline link/CTA opening the foot-soak tutorial."
-        },
-        "start_with_footsoak": {
-          "type": "string",
-          "description": "Primary CTA that starts the meditation with a foot-soak."
-        },
-        "start_meditation": {
-          "type": "string",
-          "description": "Secondary CTA that starts the meditation without a foot-soak."
-        }
-      },
-      "additionalProperties": false
-    },
-    "meditation_vibes_check": {
-      "type": "object",
-      "description": "Vibes Check post-meditation flow: asks what the user felt on each hand. Strictly first-party copy — the raw selections never ship in analytics (see analytics-simplified/02-product-event-taxonomy.md).",
-      "properties": {
-        "intro_question": {
-          "type": "string",
-          "description": "Initial Vibes Check question shown before the per-hand prompt. Preserve the embedded line break (\\n)."
-        },
-        "question_prefix": {
-          "type": "string",
-          "description": "Per-hand question prefix; combined with left_hand or right_hand and question_suffix to form the full prompt (e.g. 'What do you feel on your left hand?'). Preserve the trailing line break (\\n)."
-        },
-        "question_suffix": {
-          "type": "string",
-          "description": "Per-hand question suffix (typically ' hand?'). Include the leading space."
-        },
-        "left_hand": {
-          "type": "string",
-          "description": "Inline noun for the left hand, plugged into the per-hand question template."
-        },
-        "right_hand": {
-          "type": "string",
-          "description": "Inline noun for the right hand, plugged into the per-hand question template."
-        },
-        "cool": {
-          "type": "string",
-          "description": "Selectable sensation: cool. Maps to raw selection 'cool' (first-party storage only)."
-        },
-        "warm": {
-          "type": "string",
-          "description": "Selectable sensation: warm."
-        },
-        "fingers_tingling": {
-          "type": "string",
-          "description": "Selectable sensation: fingers tingling."
-        },
-        "nothing": {
-          "type": "string",
-          "description": "Selectable sensation: nothing felt."
-        },
-        "continue_action": {
-          "type": "string",
-          "description": "Primary CTA to confirm the current Vibes Check answer and continue."
-        },
-        "not_sure": {
-          "type": "string",
-          "description": "Skip-like CTA used when the user is unsure what they felt. Maps to derived firstMedExperience = not_sure."
-        },
-        "got_it": {
-          "type": "string",
-          "description": "Acknowledge CTA at the end of the Vibes Check explanation."
-        },
-        "interpretation_nothing": {
-          "type": "string",
-          "description": "Reassurance shown when the user selects 'nothing' for both hands."
-        },
-        "interpretation_intro": {
-          "type": "string",
-          "description": "Intro line of the Vibes Check interpretation screen."
-        },
-        "interpretation_detail": {
-          "type": "string",
-          "description": "Per-hand detail copy in the Vibes Check interpretation screen."
-        },
-        "skip_vibes_check": {
-          "type": "string",
-          "description": "Inline action that opens the skip-confirmation prompt."
-        },
-        "skip_prompt_title": {
-          "type": "string",
-          "description": "Title of the skip-confirmation prompt."
-        },
-        "skip_prompt_description": {
-          "type": "string",
-          "description": "Body copy of the skip-confirmation prompt."
-        },
-        "back_to_explanation": {
-          "type": "string",
-          "description": "CTA returning the user from the skip prompt to the Vibes Check explanation."
-        },
-        "return_to_meditation_prompt_title": {
-          "type": "string",
-          "description": "Title of the prompt offering to restart the first meditation from the beginning."
-        },
-        "return_to_meditation_prompt_description": {
-          "type": "string",
-          "description": "Body copy of the same restart prompt."
-        },
-        "return_to_meditation_action": {
-          "type": "string",
-          "description": "Primary CTA on the restart prompt."
-        },
-        "skip_it": {
-          "type": "string",
-          "description": "Decline CTA on the restart prompt."
-        }
-      },
-      "additionalProperties": false
-    },
-    "meditation_subtle_system": {
-      "type": "object",
-      "description": "Subtle-system intro diagram shown during the meditation intro (chakras / channels diagram).",
-      "properties": {
-        "screen_label": {
-          "type": "string",
-          "description": "Eyebrow / route label for the subtle-system screen."
-        },
-        "diagram_title": {
-          "type": "string",
-          "description": "Diagram title."
-        },
-        "diagram_subtitle": {
-          "type": "string",
-          "description": "Diagram subtitle prompting the user to tap to learn more."
-        },
-        "mode_chakras": {
-          "type": "string",
-          "description": "Tab label switching the diagram to chakra view."
-        },
-        "mode_channels": {
-          "type": "string",
-          "description": "Tab label switching the diagram to channel view."
-        },
-        "front_view_mirrored": {
-          "type": "string",
-          "description": "Caption clarifying that the diagram shows a front view (left/right are mirrored relative to the viewer)."
-        },
-        "chip_right": {
-          "type": "string",
-          "description": "Filter chip label for the Right channel."
-        },
-        "chip_center": {
-          "type": "string",
-          "description": "Filter chip label for the Center channel."
-        },
-        "chip_left": {
-          "type": "string",
-          "description": "Filter chip label for the Left channel."
-        },
-        "aspect_right": {
-          "type": "string",
-          "description": "Detail label for the Right Aspect of a chakra."
-        },
-        "aspect_center": {
-          "type": "string",
-          "description": "Detail label for the Center Aspect of a chakra."
-        },
-        "aspect_left": {
-          "type": "string",
-          "description": "Detail label for the Left Aspect of a chakra."
-        }
-      },
-      "additionalProperties": false
-    },
-    "talks_intro": {
-      "type": "object",
-      "description": "Intro / placement copy used when a Shri Mataji talk is surfaced, including the post-first-meditation intro and inline placement cards.",
-      "properties": {
-        "unavailable": {
-          "type": "string",
-          "description": "Inline message when a talk is temporarily unavailable to play."
-        },
-        "title": {
-          "type": "string",
-          "description": "Title of the talks intro screen."
-        },
-        "generic_description": {
-          "type": "string",
-          "description": "Long-form description of Shri Mataji and Sahaja Yoga used as fallback intro copy when a specific talk-clip description is unavailable."
-        },
-        "clip_description": {
-          "type": "string",
-          "description": "Short clip-level description shown before a specific talk clip starts."
-        },
-        "post_first_meditation_name": {
-          "type": "string",
-          "description": "Speaker name shown on the talk card placed after the first meditation (e.g. 'Shri Mataji,'). The trailing comma is intentional — it precedes the role line."
-        },
-        "post_first_meditation_subtitle": {
-          "type": "string",
-          "description": "Speaker role/subtitle on the post-first-meditation talk card (e.g. 'The founder of Sahaja Yoga')."
-        },
-        "post_first_meditation_description": {
-          "type": "string",
-          "description": "Body copy on the post-first-meditation talk card."
-        },
-        "start": {
-          "type": "string",
-          "description": "Primary CTA that begins the talk."
-        },
-        "maybe_later": {
-          "type": "string",
-          "description": "Decline CTA on the post-first-meditation talk card."
-        },
-        "watch_now": {
-          "type": "string",
-          "description": "Alternative CTA used on inline talk placements."
-        }
-      },
-      "additionalProperties": false
-    },
-    "talks_list": {
-      "type": "object",
-      "description": "Standalone Shri Mataji talks list screen.",
-      "properties": {
-        "screen_title": {
-          "type": "string",
-          "description": "Eyebrow / route title for the talks list screen (typically uppercase)."
-        },
-        "section_title": {
-          "type": "string",
-          "description": "Section title above the list."
-        },
-        "description": {
-          "type": "string",
-          "description": "Section description above the list."
-        },
-        "all_tags": {
-          "type": "string",
-          "description": "Default filter chip label ('All tags')."
-        },
-        "learn_more": {
-          "type": "string",
-          "description": "Inline link/CTA opening more information about a talk."
-        },
-        "start": {
-          "type": "string",
-          "description": "Card CTA that begins a talk."
-        },
-        "watched": {
-          "type": "string",
-          "description": "Status label shown on talks that the user has already watched."
-        }
-      },
-      "additionalProperties": false
-    },
-    "talks_player": {
-      "type": "object",
-      "description": "Shri Mataji talks player controls and subtitle picker.",
-      "properties": {
-        "unavailable": {
-          "type": "string",
-          "description": "Error message shown when the player cannot load the requested talk."
-        },
-        "play": {
-          "type": "string",
-          "description": "Player play-control label."
-        },
-        "pause": {
-          "type": "string",
-          "description": "Player pause-control label."
-        },
-        "replay": {
-          "type": "string",
-          "description": "Player replay-control label."
-        },
-        "subtitles_title": {
-          "type": "string",
-          "description": "Title of the subtitles bottom sheet."
-        },
-        "subtitles_off": {
-          "type": "string",
-          "description": "Subtitles option label disabling captions."
-        },
-        "subtitles_english": {
-          "type": "string",
-          "description": "Subtitles language label — English."
-        },
-        "subtitles_turkish": {
-          "type": "string",
-          "description": "Subtitles language label — Turkish."
-        },
-        "subtitles_bulgarian": {
-          "type": "string",
-          "description": "Subtitles language label — Bulgarian."
-        },
-        "subtitles_portuguese_brazil": {
-          "type": "string",
-          "description": "Subtitles language label — Brazilian Portuguese."
-        },
-        "subtitles_french": {
-          "type": "string",
-          "description": "Subtitles language label — French."
-        },
-        "subtitles_spanish": {
-          "type": "string",
-          "description": "Subtitles language label — Spanish."
+        "intro": {
+          "type": "object",
+          "description": "Intro / placement copy used when a Shri Mataji talk is surfaced, including the post-first-meditation intro and inline placement cards.",
+          "properties": {
+            "unavailable": {
+              "type": "string",
+              "description": "Inline message when a talk is temporarily unavailable to play."
+            },
+            "title": {
+              "type": "string",
+              "description": "Title of the talks intro screen."
+            },
+            "generic_description": {
+              "type": "string",
+              "description": "Long-form description of Shri Mataji and Sahaja Yoga used as fallback intro copy when a specific talk-clip description is unavailable."
+            },
+            "clip_description": {
+              "type": "string",
+              "description": "Short clip-level description shown before a specific talk clip starts."
+            },
+            "post_first_meditation_name": {
+              "type": "string",
+              "description": "Speaker name shown on the talk card placed after the first meditation (e.g. 'Shri Mataji,'). The trailing comma is intentional — it precedes the role line."
+            },
+            "post_first_meditation_subtitle": {
+              "type": "string",
+              "description": "Speaker role/subtitle on the post-first-meditation talk card (e.g. 'The founder of Sahaja Yoga')."
+            },
+            "post_first_meditation_description": {
+              "type": "string",
+              "description": "Body copy on the post-first-meditation talk card."
+            },
+            "start": {
+              "type": "string",
+              "description": "Primary CTA that begins the talk."
+            },
+            "maybe_later": {
+              "type": "string",
+              "description": "Decline CTA on the post-first-meditation talk card."
+            },
+            "watch_now": {
+              "type": "string",
+              "description": "Alternative CTA used on inline talk placements."
+            }
+          },
+          "additionalProperties": false
+        },
+        "list": {
+          "type": "object",
+          "description": "Standalone Shri Mataji talks list screen.",
+          "properties": {
+            "screen_title": {
+              "type": "string",
+              "description": "Eyebrow / route title for the talks list screen (typically uppercase)."
+            },
+            "section_title": {
+              "type": "string",
+              "description": "Section title above the list."
+            },
+            "description": {
+              "type": "string",
+              "description": "Section description above the list."
+            },
+            "all_tags": {
+              "type": "string",
+              "description": "Default filter chip label ('All tags')."
+            },
+            "learn_more": {
+              "type": "string",
+              "description": "Inline link/CTA opening more information about a talk."
+            },
+            "start": {
+              "type": "string",
+              "description": "Card CTA that begins a talk."
+            },
+            "watched": {
+              "type": "string",
+              "description": "Status label shown on talks that the user has already watched."
+            }
+          },
+          "additionalProperties": false
+        },
+        "player": {
+          "type": "object",
+          "description": "Shri Mataji talks player controls and subtitle picker.",
+          "properties": {
+            "unavailable": {
+              "type": "string",
+              "description": "Error message shown when the player cannot load the requested talk."
+            },
+            "play": {
+              "type": "string",
+              "description": "Player play-control label."
+            },
+            "pause": {
+              "type": "string",
+              "description": "Player pause-control label."
+            },
+            "replay": {
+              "type": "string",
+              "description": "Player replay-control label."
+            },
+            "subtitles_title": {
+              "type": "string",
+              "description": "Title of the subtitles bottom sheet."
+            },
+            "subtitles_off": {
+              "type": "string",
+              "description": "Subtitles option label disabling captions."
+            },
+            "subtitles_english": {
+              "type": "string",
+              "description": "Subtitles language label — English."
+            },
+            "subtitles_turkish": {
+              "type": "string",
+              "description": "Subtitles language label — Turkish."
+            },
+            "subtitles_bulgarian": {
+              "type": "string",
+              "description": "Subtitles language label — Bulgarian."
+            },
+            "subtitles_portuguese_brazil": {
+              "type": "string",
+              "description": "Subtitles language label — Brazilian Portuguese."
+            },
+            "subtitles_french": {
+              "type": "string",
+              "description": "Subtitles language label — French."
+            },
+            "subtitles_spanish": {
+              "type": "string",
+              "description": "Subtitles language label — Spanish."
+            }
+          },
+          "additionalProperties": false
         }
       },
       "additionalProperties": false
     },
     "path": {
       "type": "object",
-      "description": "Path tab top-level chrome (list view, errors, unit header).",
+      "description": "Path tab — guided 4-step learning course, intro carousel, step completion, and post-meditation feedback.",
       "properties": {
-        "error_message": {
-          "type": "string",
-          "description": "Error message shown when the Path tab fails to load."
+        "overview": {
+          "type": "object",
+          "description": "Path tab top-level chrome (list view, errors, unit header).",
+          "properties": {
+            "error_message": {
+              "type": "string",
+              "description": "Error message shown when the Path tab fails to load."
+            },
+            "unit": {
+              "type": "string",
+              "description": "Eyebrow label above each unit on the Path overview (typically uppercase, e.g. 'UNIT')."
+            },
+            "retry": {
+              "type": "string",
+              "description": "Retry CTA on the Path error state."
+            },
+            "more_steps_coming_soon": {
+              "type": "string",
+              "description": "Placeholder shown at the bottom of the Path when no further steps are released yet (typically uppercase)."
+            }
+          },
+          "additionalProperties": false
         },
-        "unit": {
-          "type": "string",
-          "description": "Eyebrow label above each unit on the Path overview (typically uppercase, e.g. 'UNIT')."
+        "info": {
+          "type": "object",
+          "description": "Three-screen intro carousel shown the first time a user opens the Path tab. Embedded \\\\n sequences in the source YAML render as literal backslash-n on screen if not escaped — keep them as-is (they are intentional paragraph separators in the existing source).",
+          "properties": {
+            "first_title": {
+              "type": "string",
+              "description": "Carousel slide 1 title."
+            },
+            "first_text": {
+              "type": "string",
+              "description": "Carousel slide 1 body. Two paragraphs separated by \\\\n\\\\n in the source."
+            },
+            "second_title": {
+              "type": "string",
+              "description": "Carousel slide 2 title."
+            },
+            "second_text": {
+              "type": "string",
+              "description": "Carousel slide 2 body. Two paragraphs separated by \\\\n\\\\n in the source."
+            },
+            "third_title": {
+              "type": "string",
+              "description": "Carousel slide 3 title."
+            },
+            "third_text": {
+              "type": "string",
+              "description": "Carousel slide 3 body. Two paragraphs separated by \\\\n\\\\n in the source."
+            }
+          },
+          "additionalProperties": false
         },
-        "retry": {
-          "type": "string",
-          "description": "Retry CTA on the Path error state."
+        "step_1": {
+          "type": "object",
+          "description": "Path step 1 intro screen — quote and entry CTA.",
+          "properties": {
+            "default_intro_quote": {
+              "type": "string",
+              "description": "Default intro quote used when no CMS-driven quote is available."
+            },
+            "author": {
+              "type": "string",
+              "description": "Attribution under the intro quote."
+            },
+            "begin": {
+              "type": "string",
+              "description": "Primary CTA that begins step 1."
+            },
+            "skip_title": {
+              "type": "string",
+              "description": "Title of the exit-confirmation prompt shown when the user tries to leave step 1 early."
+            },
+            "skip_continue": {
+              "type": "string",
+              "description": "CTA on the exit-confirmation prompt that keeps the user inside step 1."
+            },
+            "back_to_path": {
+              "type": "string",
+              "description": "CTA on the exit-confirmation prompt that returns the user to the Path overview."
+            }
+          },
+          "additionalProperties": false
         },
-        "more_steps_coming_soon": {
-          "type": "string",
-          "description": "Placeholder shown at the bottom of the Path when no further steps are released yet (typically uppercase)."
+        "step_2": {
+          "type": "object",
+          "description": "Path step 2 — currently only an inline Continue CTA.",
+          "properties": {
+            "continue_button": {
+              "type": "string",
+              "description": "Continue CTA used in step 2 screens."
+            }
+          },
+          "additionalProperties": false
+        },
+        "step_3": {
+          "type": "object",
+          "description": "Path step 3 — meditation intro and skip flow before starting the meditation.",
+          "properties": {
+            "meditation_intro": {
+              "type": "string",
+              "description": "Eyebrow above the step 3 meditation intro (typically uppercase)."
+            },
+            "skip_intro": {
+              "type": "string",
+              "description": "Inline action that opens the skip-intro confirmation."
+            },
+            "start_meditation": {
+              "type": "string",
+              "description": "Primary CTA that starts the step 3 meditation."
+            },
+            "skip_title": {
+              "type": "string",
+              "description": "Title of the skip-intro confirmation prompt."
+            },
+            "skip_continue": {
+              "type": "string",
+              "description": "Confirm CTA on the skip-intro prompt that jumps to the meditation."
+            },
+            "back_to_intro": {
+              "type": "string",
+              "description": "Decline CTA on the skip-intro prompt that returns to the intro."
+            },
+            "exit": {
+              "type": "string",
+              "description": "Exit CTA used on the step 3 screen."
+            },
+            "back_to_step": {
+              "type": "string",
+              "description": "Back CTA returning the user to the step overview."
+            }
+          },
+          "additionalProperties": false
+        },
+        "step_4": {
+          "type": "object",
+          "description": "Path step 4 — ‘delving deeper’ lecture screen shown after the step 3 meditation.",
+          "properties": {
+            "delving_deeper": {
+              "type": "string",
+              "description": "Eyebrow on the step 4 screen (typically uppercase)."
+            },
+            "lecture_prompt": {
+              "type": "string",
+              "description": "Prompt above the lecture media inviting the user to keep meditating while listening."
+            },
+            "media_card_fallback_title": {
+              "type": "string",
+              "description": "Fallback title used on the lecture media card when no CMS-driven title is available. Source uses curly quotes “” intentionally."
+            },
+            "media_card_author": {
+              "type": "string",
+              "description": "Author label on the lecture media card (e.g. 'Talk by Shri Mataji')."
+            },
+            "media_card_author_subtitle": {
+              "type": "string",
+              "description": "Author subtitle on the lecture media card (e.g. 'The founder of Sahaja Yoga')."
+            },
+            "media_card_watch_later": {
+              "type": "string",
+              "description": "Secondary CTA on the lecture media card."
+            },
+            "complete_step": {
+              "type": "string",
+              "description": "Primary CTA that completes step 4."
+            }
+          },
+          "additionalProperties": false
+        },
+        "step_complete": {
+          "type": "object",
+          "description": "Confirmation screen shown after the user completes a Path step.",
+          "properties": {
+            "title": {
+              "type": "string",
+              "description": "Title of the step-complete confirmation."
+            },
+            "subtitle": {
+              "type": "string",
+              "description": "Subtitle of the step-complete confirmation."
+            },
+            "back_to_path": {
+              "type": "string",
+              "description": "CTA returning the user to the Path overview after completing a step."
+            }
+          },
+          "additionalProperties": false
+        },
+        "meditation_feedback": {
+          "type": "object",
+          "description": "Free-text feedback form shown after a Path meditation. The text itself is first-party only — it never reaches the ad path.",
+          "properties": {
+            "title": {
+              "type": "string",
+              "description": "Form title."
+            },
+            "description": {
+              "type": "string",
+              "description": "Form description / prompt for free-text feedback."
+            },
+            "error_length": {
+              "type": "string",
+              "description": "Validation error shown when the feedback is shorter than the minimum length (50 characters)."
+            },
+            "hint": {
+              "type": "string",
+              "description": "Input field placeholder hint for the feedback text area."
+            },
+            "send": {
+              "type": "string",
+              "description": "Submit CTA on the feedback form."
+            },
+            "thank_you": {
+              "type": "string",
+              "description": "Title of the thank-you confirmation after the feedback is submitted."
+            },
+            "thank_you_description": {
+              "type": "string",
+              "description": "Body of the thank-you confirmation. Preserve the embedded line breaks (\\n) — they control the hero layout."
+            },
+            "close": {
+              "type": "string",
+              "description": "Close CTA on the thank-you confirmation."
+            }
+          },
+          "additionalProperties": false
         }
       },
       "additionalProperties": false
     },
-    "path_info": {
+    "auth": {
       "type": "object",
-      "description": "Three-screen intro carousel shown the first time a user opens the Path tab. Embedded \\\\n sequences in the source YAML render as literal backslash-n on screen if not escaped — keep them as-is (they are intentional paragraph separators in the existing source).",
+      "description": "Authentication flows — login, account creation, password recovery, and shared social-auth chrome.",
       "properties": {
-        "first_title": {
-          "type": "string",
-          "description": "Carousel slide 1 title."
-        },
-        "first_text": {
-          "type": "string",
-          "description": "Carousel slide 1 body. Two paragraphs separated by \\\\n\\\\n in the source."
-        },
-        "second_title": {
-          "type": "string",
-          "description": "Carousel slide 2 title."
-        },
-        "second_text": {
-          "type": "string",
-          "description": "Carousel slide 2 body. Two paragraphs separated by \\\\n\\\\n in the source."
-        },
-        "third_title": {
-          "type": "string",
-          "description": "Carousel slide 3 title."
-        },
-        "third_text": {
-          "type": "string",
-          "description": "Carousel slide 3 body. Two paragraphs separated by \\\\n\\\\n in the source."
-        }
-      },
-      "additionalProperties": false
-    },
-    "path_step_1": {
-      "type": "object",
-      "description": "Path step 1 intro screen — quote and entry CTA.",
-      "properties": {
-        "default_intro_quote": {
-          "type": "string",
-          "description": "Default intro quote used when no CMS-driven quote is available."
-        },
-        "author": {
-          "type": "string",
-          "description": "Attribution under the intro quote."
-        },
-        "begin": {
-          "type": "string",
-          "description": "Primary CTA that begins step 1."
-        },
-        "skip_title": {
-          "type": "string",
-          "description": "Title of the exit-confirmation prompt shown when the user tries to leave step 1 early."
-        },
-        "skip_continue": {
-          "type": "string",
-          "description": "CTA on the exit-confirmation prompt that keeps the user inside step 1."
-        },
-        "back_to_path": {
-          "type": "string",
-          "description": "CTA on the exit-confirmation prompt that returns the user to the Path overview."
-        }
-      },
-      "additionalProperties": false
-    },
-    "path_step_2": {
-      "type": "object",
-      "description": "Path step 2 — currently only an inline Continue CTA.",
-      "properties": {
-        "continue_button": {
-          "type": "string",
-          "description": "Continue CTA used in step 2 screens."
-        }
-      },
-      "additionalProperties": false
-    },
-    "path_step_3": {
-      "type": "object",
-      "description": "Path step 3 — meditation intro and skip flow before starting the meditation.",
-      "properties": {
-        "meditation_intro": {
-          "type": "string",
-          "description": "Eyebrow above the step 3 meditation intro (typically uppercase)."
-        },
-        "skip_intro": {
-          "type": "string",
-          "description": "Inline action that opens the skip-intro confirmation."
-        },
-        "start_meditation": {
-          "type": "string",
-          "description": "Primary CTA that starts the step 3 meditation."
-        },
-        "skip_title": {
-          "type": "string",
-          "description": "Title of the skip-intro confirmation prompt."
-        },
-        "skip_continue": {
-          "type": "string",
-          "description": "Confirm CTA on the skip-intro prompt that jumps to the meditation."
-        },
-        "back_to_intro": {
-          "type": "string",
-          "description": "Decline CTA on the skip-intro prompt that returns to the intro."
-        },
-        "exit": {
-          "type": "string",
-          "description": "Exit CTA used on the step 3 screen."
-        },
-        "back_to_step": {
-          "type": "string",
-          "description": "Back CTA returning the user to the step overview."
-        }
-      },
-      "additionalProperties": false
-    },
-    "path_step_4": {
-      "type": "object",
-      "description": "Path step 4 — ‘delving deeper’ lecture screen shown after the step 3 meditation.",
-      "properties": {
-        "delving_deeper": {
-          "type": "string",
-          "description": "Eyebrow on the step 4 screen (typically uppercase)."
-        },
-        "lecture_prompt": {
-          "type": "string",
-          "description": "Prompt above the lecture media inviting the user to keep meditating while listening."
-        },
-        "media_card_fallback_title": {
-          "type": "string",
-          "description": "Fallback title used on the lecture media card when no CMS-driven title is available. Source uses curly quotes “” intentionally."
-        },
-        "media_card_author": {
-          "type": "string",
-          "description": "Author label on the lecture media card (e.g. 'Talk by Shri Mataji')."
-        },
-        "media_card_author_subtitle": {
-          "type": "string",
-          "description": "Author subtitle on the lecture media card (e.g. 'The founder of Sahaja Yoga')."
-        },
-        "media_card_watch_later": {
-          "type": "string",
-          "description": "Secondary CTA on the lecture media card."
-        },
-        "complete_step": {
-          "type": "string",
-          "description": "Primary CTA that completes step 4."
-        }
-      },
-      "additionalProperties": false
-    },
-    "path_step_complete": {
-      "type": "object",
-      "description": "Confirmation screen shown after the user completes a Path step.",
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Title of the step-complete confirmation."
-        },
-        "subtitle": {
-          "type": "string",
-          "description": "Subtitle of the step-complete confirmation."
-        },
-        "back_to_path": {
-          "type": "string",
-          "description": "CTA returning the user to the Path overview after completing a step."
-        }
-      },
-      "additionalProperties": false
-    },
-    "path_meditation_feedback": {
-      "type": "object",
-      "description": "Free-text feedback form shown after a Path meditation. The text itself is first-party only — it never reaches the ad path.",
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Form title."
-        },
-        "description": {
-          "type": "string",
-          "description": "Form description / prompt for free-text feedback."
-        },
-        "error_length": {
-          "type": "string",
-          "description": "Validation error shown when the feedback is shorter than the minimum length (50 characters)."
-        },
-        "hint": {
-          "type": "string",
-          "description": "Input field placeholder hint for the feedback text area."
-        },
-        "send": {
-          "type": "string",
-          "description": "Submit CTA on the feedback form."
-        },
-        "thank_you": {
-          "type": "string",
-          "description": "Title of the thank-you confirmation after the feedback is submitted."
-        },
-        "thank_you_description": {
-          "type": "string",
-          "description": "Body of the thank-you confirmation. Preserve the embedded line breaks (\\n) — they control the hero layout."
-        },
-        "close": {
-          "type": "string",
-          "description": "Close CTA on the thank-you confirmation."
-        }
-      },
-      "additionalProperties": false
-    },
-    "auth_common": {
-      "type": "object",
-      "description": "Shared strings across all auth screens (login, signup, password recovery): divider, social providers, common errors.",
-      "properties": {
-        "or": {
-          "type": "string",
-          "description": "Divider label between email and social-provider auth options."
-        },
-        "continue_with_apple": {
-          "type": "string",
-          "description": "Social-auth button label for Apple Sign-In."
-        },
-        "continue_with_google": {
-          "type": "string",
-          "description": "Social-auth button label for Google Sign-In."
-        },
-        "continue_with_facebook": {
-          "type": "string",
-          "description": "Social-auth button label for Facebook Sign-In."
-        },
-        "continue_with_email": {
-          "type": "string",
-          "description": "Auth-method button label that opens the email/password flow."
-        },
-        "cancel": {
-          "type": "string",
-          "description": "Generic cancel CTA used on auth modals and prompts."
-        },
-        "error_enter_email": {
-          "type": "string",
-          "description": "Validation error shown when the email field is empty."
-        },
-        "error_invalid_email": {
-          "type": "string",
-          "description": "Validation error shown when the email field is not a valid email."
-        },
-        "error_enter_password": {
-          "type": "string",
-          "description": "Validation error shown when the password field is empty."
-        },
-        "error_password_min_length": {
-          "type": "string",
-          "description": "Validation error shown when the password is shorter than the minimum length (6 characters)."
-        }
-      },
-      "additionalProperties": false
-    },
-    "auth_login": {
-      "type": "object",
-      "description": "Email/password login screen, including the account-exists / account-not-found branching states.",
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Login screen title."
-        },
-        "email_label": {
-          "type": "string",
-          "description": "Label for the email input."
-        },
-        "email_placeholder": {
-          "type": "string",
-          "description": "Placeholder hint for the email input."
-        },
-        "password_label": {
-          "type": "string",
-          "description": "Label for the password input."
-        },
-        "password_placeholder": {
-          "type": "string",
-          "description": "Placeholder hint for the password input."
-        },
-        "next": {
-          "type": "string",
-          "description": "Primary CTA on the login form."
-        },
-        "signing_in": {
-          "type": "string",
-          "description": "Loading-state label shown on the primary CTA while sign-in is in flight."
-        },
-        "forgot_password": {
-          "type": "string",
-          "description": "Link opening the password recovery flow."
-        },
-        "continue_as_new_user": {
-          "type": "string",
-          "description": "Tertiary link that routes the user to account creation instead of login."
-        },
-        "account_not_found_title": {
-          "type": "string",
-          "description": "Title of the branch shown when the entered email has no matching account."
-        },
-        "account_not_found_subtitle": {
-          "type": "string",
-          "description": "Subtitle of the same branch."
-        },
-        "account_exists_title": {
-          "type": "string",
-          "description": "Title of the branch shown when the entered email matches an account that uses a different sign-in method."
-        },
-        "account_exists_subtitle": {
-          "type": "string",
-          "description": "Subtitle of the same branch. MUST preserve the {providers} placeholder — it is replaced at runtime with the localized provider list (e.g. 'Google or Apple')."
-        },
-        "create_new_account": {
-          "type": "string",
-          "description": "CTA on the account-not-found branch routing the user to account creation."
-        },
-        "try_different_account": {
-          "type": "string",
-          "description": "CTA on the account-not-found branch letting the user re-enter a different email."
-        },
-        "account_exists_existing_provider_fallback": {
-          "type": "string",
-          "description": "Fallback value injected into the {providers} placeholder when the existing provider list is empty or unresolved."
-        },
-        "open_login": {
-          "type": "string",
-          "description": "CTA on the account-exists branch that reopens the login flow."
-        },
-        "error_cannot_continue_with_email": {
-          "type": "string",
-          "description": "Error shown when the email-continuation branch cannot proceed."
-        },
-        "error_invalid_credentials": {
-          "type": "string",
-          "description": "Error shown for invalid email/password combinations."
-        },
-        "error_too_many_requests": {
-          "type": "string",
-          "description": "Error shown when sign-in is rate-limited."
-        },
-        "error_session_persistence": {
-          "type": "string",
-          "description": "Error shown when sign-in succeeds at Firebase but the local session cannot be persisted."
-        },
-        "error_generic": {
-          "type": "string",
-          "description": "Generic sign-in failure error."
-        }
-      },
-      "additionalProperties": false
-    },
-    "auth_restore_password": {
-      "type": "object",
-      "description": "Password recovery form screen.",
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Password recovery screen title."
-        },
-        "description": {
-          "type": "string",
-          "description": "Body copy explaining the recovery-link flow."
-        },
-        "email_label": {
-          "type": "string",
-          "description": "Label for the email input on the recovery form."
-        },
-        "email_placeholder": {
-          "type": "string",
-          "description": "Placeholder hint for the email input on the recovery form."
-        },
-        "submit": {
-          "type": "string",
-          "description": "Primary CTA submitting the recovery request."
-        },
-        "error_invalid_email": {
-          "type": "string",
-          "description": "Validation error on the recovery form for an invalid email."
-        }
-      },
-      "additionalProperties": false
-    },
-    "auth_restore_password_email_sent": {
-      "type": "object",
-      "description": "Confirmation screen shown after a password recovery email has been sent.",
-      "properties": {
-        "message": {
-          "type": "string",
-          "description": "Confirmation message. Preserve the embedded line break (\\n)."
-        },
-        "ok": {
-          "type": "string",
-          "description": "Acknowledge CTA on the confirmation."
-        }
-      },
-      "additionalProperties": false
-    },
-    "auth_create_account": {
-      "type": "object",
-      "description": "Account creation screen with the inline Terms & Privacy consent checkbox. This consent is independent of the ad-measurement consent (see consent_ad_modal / consent_settings).",
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Sheet / modal title shown in the navigation chrome."
-        },
-        "screen_title": {
-          "type": "string",
-          "description": "Hero title on the account creation screen."
-        },
-        "screen_subtitle": {
-          "type": "string",
-          "description": "Hero subtitle on the account creation screen."
-        },
-        "skip_and_explore": {
-          "type": "string",
-          "description": "Tertiary action allowing a guest user to skip account creation."
-        },
-        "consent_prefix": {
-          "type": "string",
-          "description": "Inline-text prefix of the consent checkbox label. Combined with consent_terms, consent_and_acknowledge, and consent_privacy. Include any trailing space."
-        },
-        "consent_terms": {
-          "type": "string",
-          "description": "Inline link text for the Terms & Conditions, opening the in-app webview."
-        },
-        "consent_and_acknowledge": {
-          "type": "string",
-          "description": "Connector text between the Terms link and the Privacy Policy link. Include any required spaces."
-        },
-        "consent_privacy": {
-          "type": "string",
-          "description": "Inline link text for the Privacy Policy, opening the in-app webview."
-        },
-        "error_check_consent": {
-          "type": "string",
-          "description": "Validation error shown when the user tries to submit without checking the consent box."
-        },
-        "email_label": {
-          "type": "string",
-          "description": "Label for the email input."
-        },
-        "email_placeholder": {
-          "type": "string",
-          "description": "Placeholder hint for the email input."
-        },
-        "password_label": {
-          "type": "string",
-          "description": "Label for the password input."
-        },
-        "password_placeholder": {
-          "type": "string",
-          "description": "Placeholder hint for the password input."
-        },
-        "submit": {
-          "type": "string",
-          "description": "Primary CTA submitting account creation."
-        },
-        "creating": {
-          "type": "string",
-          "description": "Loading-state label shown on the primary CTA while account creation is in flight."
-        },
-        "error_email_in_use": {
-          "type": "string",
-          "description": "Error shown when the email is already associated with an account."
-        },
-        "login_with_existing_account": {
-          "type": "string",
-          "description": "CTA on the email-in-use branch redirecting to login."
-        },
-        "error_invalid_email": {
-          "type": "string",
-          "description": "Validation error for an invalid email."
-        },
-        "error_weak_password": {
-          "type": "string",
-          "description": "Validation error for a password shorter than the minimum length."
-        },
-        "error_too_many_requests": {
-          "type": "string",
-          "description": "Error shown when account creation is rate-limited."
-        },
-        "error_session_persistence": {
-          "type": "string",
-          "description": "Error shown when the account is created but the local session cannot be persisted."
-        },
-        "error_generic": {
-          "type": "string",
-          "description": "Generic account-creation failure error."
-        },
-        "error_google_failed": {
-          "type": "string",
-          "description": "Error shown when Google sign-in fails during account creation."
-        },
-        "error_apple_failed": {
-          "type": "string",
-          "description": "Error shown when Apple sign-in fails during account creation."
-        },
-        "error_facebook_failed": {
-          "type": "string",
-          "description": "Error shown when Facebook sign-in fails during account creation."
-        },
-        "error_provider_cancelled": {
-          "type": "string",
-          "description": "Message shown when the user cancels the social-auth flow."
-        }
-      },
-      "additionalProperties": false
-    },
-    "profile_main": {
-      "type": "object",
-      "description": "Profile tab main screen — settings entries, favourites preview, joined-date copy, and the new Privacy & advertising entry.",
-      "properties": {
-        "favourites_header": {
-          "type": "string",
-          "description": "Eyebrow above the favourites preview block on Profile (typically uppercase)."
-        },
-        "see_all": {
-          "type": "string",
-          "description": "Inline link expanding a preview block to its full screen."
-        },
-        "no_favourites_title": {
-          "type": "string",
-          "description": "Empty-state title in the favourites preview block."
-        },
-        "no_favourites_subtitle": {
-          "type": "string",
-          "description": "Empty-state subtitle in the favourites preview block."
-        },
-        "history_title": {
-          "type": "string",
-          "description": "Title of the History entry in the Profile menu."
-        },
-        "history_subtitle": {
-          "type": "string",
-          "description": "Subtitle of the History entry in the Profile menu."
-        },
-        "account_title": {
-          "type": "string",
-          "description": "Title of the Account entry in the Profile menu."
-        },
-        "account_subtitle": {
-          "type": "string",
-          "description": "Subtitle of the Account entry in the Profile menu."
-        },
-        "privacy_and_advertising_title": {
-          "type": "string",
-          "description": "Title of the Privacy & advertising entry in the Profile menu — opens the consent settings screen (see consent_settings). NEW: introduced together with the ad-measurement consent surface."
-        },
-        "privacy_and_advertising_subtitle": {
-          "type": "string",
-          "description": "Subtitle of the Privacy & advertising entry in the Profile menu. NEW: introduced together with the ad-measurement consent surface."
-        },
-        "feedback_header": {
-          "type": "string",
-          "description": "Eyebrow above the feedback block on Profile (typically uppercase)."
-        },
-        "contact_title": {
-          "type": "string",
-          "description": "Title of the Contact us entry in the Profile menu."
-        },
-        "contact_subtitle": {
-          "type": "string",
-          "description": "Subtitle of the Contact us entry in the Profile menu."
-        },
-        "joined_fallback": {
-          "type": "string",
-          "description": "Fallback joined-date string when no usable creation timestamp is available."
-        },
-        "joined_one_month": {
-          "type": "string",
-          "description": "Joined-date string for exactly one month ago (singular)."
-        },
-        "joined_months": {
-          "type": "string",
-          "description": "Joined-date string for the multi-month range. MUST preserve the {months} placeholder — it is replaced at runtime with the month count."
-        },
-        "joined_less_than_year": {
-          "type": "string",
-          "description": "Joined-date string for less than a year ago (fallback before the months-since helper)."
-        },
-        "joined_one_year": {
-          "type": "string",
-          "description": "Joined-date string for exactly one year ago (singular)."
-        },
-        "joined_years": {
-          "type": "string",
-          "description": "Joined-date string for multiple years ago. MUST preserve the {years} placeholder — it is replaced at runtime with the year count."
-        }
-      },
-      "additionalProperties": false
-    },
-    "profile_history": {
-      "type": "object",
-      "description": "Profile → History screen.",
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Screen title (typically uppercase)."
-        },
-        "empty_title": {
-          "type": "string",
-          "description": "Empty-state title when the user has no history entries."
-        },
-        "empty_subtitle": {
-          "type": "string",
-          "description": "Empty-state subtitle when the user has no history entries."
-        }
-      },
-      "additionalProperties": false
-    },
-    "profile_favourites": {
-      "type": "object",
-      "description": "Profile → Favourites screen.",
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Screen title (typically uppercase)."
-        },
-        "removed_from_favourites": {
-          "type": "string",
-          "description": "Snackbar shown after a favourite is removed (paired with the global Undo action from the general group)."
-        }
-      },
-      "additionalProperties": false
-    },
-    "profile_account": {
-      "type": "object",
-      "description": "Profile → Account settings screen — edit name/email, change password, delete account.",
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Screen title."
-        },
-        "details_header": {
-          "type": "string",
-          "description": "Eyebrow above the details block (typically uppercase)."
-        },
-        "name_label": {
-          "type": "string",
-          "description": "Label for the name input."
-        },
-        "name_hint": {
-          "type": "string",
-          "description": "Placeholder hint for the name input."
-        },
-        "save": {
-          "type": "string",
-          "description": "Save CTA used on inline forms."
-        },
-        "saving": {
-          "type": "string",
-          "description": "Loading-state label shown on the Save CTA while saving."
-        },
-        "saved": {
-          "type": "string",
-          "description": "Confirmation toast shown after settings are saved."
-        },
-        "first_name_label": {
-          "type": "string",
-          "description": "Label used by the dedicated first-name edit row."
-        },
-        "email_label": {
-          "type": "string",
-          "description": "Label used by the email row."
-        },
-        "password_label": {
-          "type": "string",
-          "description": "Label used by the password row."
-        },
-        "edit_action": {
-          "type": "string",
-          "description": "Edit CTA used on read-only rows that open an edit modal."
-        },
-        "edit_first_name_title": {
-          "type": "string",
-          "description": "Title of the edit-first-name modal."
-        },
-        "edit_email_title": {
-          "type": "string",
-          "description": "Title of the edit-email modal."
-        },
-        "cancel": {
-          "type": "string",
-          "description": "Cancel CTA used in edit modals."
-        },
-        "save_changes": {
-          "type": "string",
-          "description": "Primary CTA in edit modals."
-        },
-        "save_failed": {
-          "type": "string",
-          "description": "Error shown when saving account settings fails."
-        },
-        "reset_password_title": {
-          "type": "string",
-          "description": "Title of the reset-password modal."
-        },
-        "reset_password_description": {
-          "type": "string",
-          "description": "Body copy of the reset-password modal."
-        },
-        "reset_password_action": {
-          "type": "string",
-          "description": "Primary CTA in the reset-password modal."
-        },
-        "reset_password_sent": {
-          "type": "string",
-          "description": "Confirmation toast shown after the reset link has been emailed."
-        },
-        "reset_password_error": {
-          "type": "string",
-          "description": "Error shown when sending the reset link fails."
-        },
-        "email_edit_unavailable": {
-          "type": "string",
-          "description": "Toast shown when email editing is not yet available."
-        },
-        "email_unavailable": {
-          "type": "string",
-          "description": "Inline placeholder shown when no email is available for the account."
-        },
-        "create_account": {
-          "type": "string",
-          "description": "CTA shown for guest users prompting them to create an account."
-        },
-        "delete_account_title": {
-          "type": "string",
-          "description": "Title of the delete-account confirmation."
-        },
-        "delete_account_description": {
-          "type": "string",
-          "description": "Body copy of the delete-account confirmation."
-        },
-        "delete_account_error": {
-          "type": "string",
-          "description": "Error shown when delete-account fails."
-        },
-        "delete_account_requires_recent_login": {
-          "type": "string",
-          "description": "Error shown when delete-account requires the user to log in again first."
-        },
-        "reauthenticate_title": {
-          "type": "string",
-          "description": "Title of the password re-entry modal used before destructive actions."
-        },
-        "reauthenticate_description": {
-          "type": "string",
-          "description": "Body copy of the password re-entry modal."
-        },
-        "reauthenticate_required": {
-          "type": "string",
-          "description": "Validation error shown when the password field is empty in the re-entry modal."
-        },
-        "reauthenticate_invalid": {
-          "type": "string",
-          "description": "Error shown when the re-entered password is incorrect."
-        },
-        "continue_action": {
-          "type": "string",
-          "description": "Primary CTA on the password re-entry modal."
-        },
-        "guest_email_prompt": {
-          "type": "string",
-          "description": "Inline prompt shown on the email row for guest users."
-        },
-        "guest_password_prompt": {
-          "type": "string",
-          "description": "Inline prompt shown on the password row for guest users."
+        "common": {
+          "type": "object",
+          "description": "Shared strings across all auth screens (login, signup, password recovery): divider, social providers, common errors.",
+          "properties": {
+            "or": {
+              "type": "string",
+              "description": "Divider label between email and social-provider auth options."
+            },
+            "continue_with_apple": {
+              "type": "string",
+              "description": "Social-auth button label for Apple Sign-In."
+            },
+            "continue_with_google": {
+              "type": "string",
+              "description": "Social-auth button label for Google Sign-In."
+            },
+            "continue_with_facebook": {
+              "type": "string",
+              "description": "Social-auth button label for Facebook Sign-In."
+            },
+            "continue_with_email": {
+              "type": "string",
+              "description": "Auth-method button label that opens the email/password flow."
+            },
+            "cancel": {
+              "type": "string",
+              "description": "Generic cancel CTA used on auth modals and prompts."
+            },
+            "error_enter_email": {
+              "type": "string",
+              "description": "Validation error shown when the email field is empty."
+            },
+            "error_invalid_email": {
+              "type": "string",
+              "description": "Validation error shown when the email field is not a valid email."
+            },
+            "error_enter_password": {
+              "type": "string",
+              "description": "Validation error shown when the password field is empty."
+            },
+            "error_password_min_length": {
+              "type": "string",
+              "description": "Validation error shown when the password is shorter than the minimum length (6 characters)."
+            }
+          },
+          "additionalProperties": false
         },
         "login": {
-          "type": "string",
-          "description": "Login CTA used in the guest prompts."
+          "type": "object",
+          "description": "Email/password login screen, including the account-exists / account-not-found branching states.",
+          "properties": {
+            "title": {
+              "type": "string",
+              "description": "Login screen title."
+            },
+            "email_label": {
+              "type": "string",
+              "description": "Label for the email input."
+            },
+            "email_placeholder": {
+              "type": "string",
+              "description": "Placeholder hint for the email input."
+            },
+            "password_label": {
+              "type": "string",
+              "description": "Label for the password input."
+            },
+            "password_placeholder": {
+              "type": "string",
+              "description": "Placeholder hint for the password input."
+            },
+            "next": {
+              "type": "string",
+              "description": "Primary CTA on the login form."
+            },
+            "signing_in": {
+              "type": "string",
+              "description": "Loading-state label shown on the primary CTA while sign-in is in flight."
+            },
+            "forgot_password": {
+              "type": "string",
+              "description": "Link opening the password recovery flow."
+            },
+            "continue_as_new_user": {
+              "type": "string",
+              "description": "Tertiary link that routes the user to account creation instead of login."
+            },
+            "account_not_found_title": {
+              "type": "string",
+              "description": "Title of the branch shown when the entered email has no matching account."
+            },
+            "account_not_found_subtitle": {
+              "type": "string",
+              "description": "Subtitle of the same branch."
+            },
+            "account_exists_title": {
+              "type": "string",
+              "description": "Title of the branch shown when the entered email matches an account that uses a different sign-in method."
+            },
+            "account_exists_subtitle": {
+              "type": "string",
+              "description": "Subtitle of the same branch. MUST preserve the {providers} placeholder — it is replaced at runtime with the localized provider list (e.g. 'Google or Apple')."
+            },
+            "create_new_account": {
+              "type": "string",
+              "description": "CTA on the account-not-found branch routing the user to account creation."
+            },
+            "try_different_account": {
+              "type": "string",
+              "description": "CTA on the account-not-found branch letting the user re-enter a different email."
+            },
+            "account_exists_existing_provider_fallback": {
+              "type": "string",
+              "description": "Fallback value injected into the {providers} placeholder when the existing provider list is empty or unresolved."
+            },
+            "open_login": {
+              "type": "string",
+              "description": "CTA on the account-exists branch that reopens the login flow."
+            },
+            "error_cannot_continue_with_email": {
+              "type": "string",
+              "description": "Error shown when the email-continuation branch cannot proceed."
+            },
+            "error_invalid_credentials": {
+              "type": "string",
+              "description": "Error shown for invalid email/password combinations."
+            },
+            "error_too_many_requests": {
+              "type": "string",
+              "description": "Error shown when sign-in is rate-limited."
+            },
+            "error_session_persistence": {
+              "type": "string",
+              "description": "Error shown when sign-in succeeds at Firebase but the local session cannot be persisted."
+            },
+            "error_generic": {
+              "type": "string",
+              "description": "Generic sign-in failure error."
+            }
+          },
+          "additionalProperties": false
         },
-        "logout": {
-          "type": "string",
-          "description": "Logout CTA in the account screen."
+        "restore_password": {
+          "type": "object",
+          "description": "Password recovery form screen.",
+          "properties": {
+            "title": {
+              "type": "string",
+              "description": "Password recovery screen title."
+            },
+            "description": {
+              "type": "string",
+              "description": "Body copy explaining the recovery-link flow."
+            },
+            "email_label": {
+              "type": "string",
+              "description": "Label for the email input on the recovery form."
+            },
+            "email_placeholder": {
+              "type": "string",
+              "description": "Placeholder hint for the email input on the recovery form."
+            },
+            "submit": {
+              "type": "string",
+              "description": "Primary CTA submitting the recovery request."
+            },
+            "error_invalid_email": {
+              "type": "string",
+              "description": "Validation error on the recovery form for an invalid email."
+            }
+          },
+          "additionalProperties": false
         },
-        "privacy_policy": {
-          "type": "string",
-          "description": "Inline link opening the Privacy Policy webview from the account screen."
+        "restore_password_email_sent": {
+          "type": "object",
+          "description": "Confirmation screen shown after a password recovery email has been sent.",
+          "properties": {
+            "message": {
+              "type": "string",
+              "description": "Confirmation message. Preserve the embedded line break (\\n)."
+            },
+            "ok": {
+              "type": "string",
+              "description": "Acknowledge CTA on the confirmation."
+            }
+          },
+          "additionalProperties": false
         },
-        "delete_account": {
-          "type": "string",
-          "description": "Destructive CTA opening the delete-account flow."
+        "create_account": {
+          "type": "object",
+          "description": "Account creation screen with the inline Terms & Privacy consent checkbox. This consent is independent of the ad-measurement consent (see consent.ad_modal / consent.settings).",
+          "properties": {
+            "title": {
+              "type": "string",
+              "description": "Sheet / modal title shown in the navigation chrome."
+            },
+            "screen_title": {
+              "type": "string",
+              "description": "Hero title on the account creation screen."
+            },
+            "screen_subtitle": {
+              "type": "string",
+              "description": "Hero subtitle on the account creation screen."
+            },
+            "skip_and_explore": {
+              "type": "string",
+              "description": "Tertiary action allowing a guest user to skip account creation."
+            },
+            "consent_prefix": {
+              "type": "string",
+              "description": "Inline-text prefix of the consent checkbox label. Combined with consent_terms, consent_and_acknowledge, and consent_privacy. Include any trailing space."
+            },
+            "consent_terms": {
+              "type": "string",
+              "description": "Inline link text for the Terms & Conditions, opening the in-app webview."
+            },
+            "consent_and_acknowledge": {
+              "type": "string",
+              "description": "Connector text between the Terms link and the Privacy Policy link. Include any required spaces."
+            },
+            "consent_privacy": {
+              "type": "string",
+              "description": "Inline link text for the Privacy Policy, opening the in-app webview."
+            },
+            "error_check_consent": {
+              "type": "string",
+              "description": "Validation error shown when the user tries to submit without checking the consent box."
+            },
+            "email_label": {
+              "type": "string",
+              "description": "Label for the email input."
+            },
+            "email_placeholder": {
+              "type": "string",
+              "description": "Placeholder hint for the email input."
+            },
+            "password_label": {
+              "type": "string",
+              "description": "Label for the password input."
+            },
+            "password_placeholder": {
+              "type": "string",
+              "description": "Placeholder hint for the password input."
+            },
+            "submit": {
+              "type": "string",
+              "description": "Primary CTA submitting account creation."
+            },
+            "creating": {
+              "type": "string",
+              "description": "Loading-state label shown on the primary CTA while account creation is in flight."
+            },
+            "error_email_in_use": {
+              "type": "string",
+              "description": "Error shown when the email is already associated with an account."
+            },
+            "login_with_existing_account": {
+              "type": "string",
+              "description": "CTA on the email-in-use branch redirecting to login."
+            },
+            "error_invalid_email": {
+              "type": "string",
+              "description": "Validation error for an invalid email."
+            },
+            "error_weak_password": {
+              "type": "string",
+              "description": "Validation error for a password shorter than the minimum length."
+            },
+            "error_too_many_requests": {
+              "type": "string",
+              "description": "Error shown when account creation is rate-limited."
+            },
+            "error_session_persistence": {
+              "type": "string",
+              "description": "Error shown when the account is created but the local session cannot be persisted."
+            },
+            "error_generic": {
+              "type": "string",
+              "description": "Generic account-creation failure error."
+            },
+            "error_google_failed": {
+              "type": "string",
+              "description": "Error shown when Google sign-in fails during account creation."
+            },
+            "error_apple_failed": {
+              "type": "string",
+              "description": "Error shown when Apple sign-in fails during account creation."
+            },
+            "error_facebook_failed": {
+              "type": "string",
+              "description": "Error shown when Facebook sign-in fails during account creation."
+            },
+            "error_provider_cancelled": {
+              "type": "string",
+              "description": "Message shown when the user cancels the social-auth flow."
+            }
+          },
+          "additionalProperties": false
         }
       },
       "additionalProperties": false
     },
-    "profile_contact": {
+    "profile": {
       "type": "object",
-      "description": "Profile → Contact us screen — free-text feedback form. The text itself is first-party only — it never reaches the ad path.",
+      "description": "Profile tab — main menu (with the Privacy & advertising entry point), history, favourites, account settings, and contact us.",
       "properties": {
-        "title": {
-          "type": "string",
-          "description": "Screen title (typically uppercase)."
+        "main": {
+          "type": "object",
+          "description": "Profile tab main screen — settings entries, favourites preview, joined-date copy, and the Privacy & advertising entry.",
+          "properties": {
+            "favourites_header": {
+              "type": "string",
+              "description": "Eyebrow above the favourites preview block on Profile (typically uppercase)."
+            },
+            "see_all": {
+              "type": "string",
+              "description": "Inline link expanding a preview block to its full screen."
+            },
+            "no_favourites_title": {
+              "type": "string",
+              "description": "Empty-state title in the favourites preview block."
+            },
+            "no_favourites_subtitle": {
+              "type": "string",
+              "description": "Empty-state subtitle in the favourites preview block."
+            },
+            "history_title": {
+              "type": "string",
+              "description": "Title of the History entry in the Profile menu."
+            },
+            "history_subtitle": {
+              "type": "string",
+              "description": "Subtitle of the History entry in the Profile menu."
+            },
+            "account_title": {
+              "type": "string",
+              "description": "Title of the Account entry in the Profile menu."
+            },
+            "account_subtitle": {
+              "type": "string",
+              "description": "Subtitle of the Account entry in the Profile menu."
+            },
+            "privacy_and_advertising_title": {
+              "type": "string",
+              "description": "Title of the Privacy & advertising entry in the Profile menu — opens the consent settings screen (see consent.settings)."
+            },
+            "privacy_and_advertising_subtitle": {
+              "type": "string",
+              "description": "Subtitle of the Privacy & advertising entry in the Profile menu."
+            },
+            "feedback_header": {
+              "type": "string",
+              "description": "Eyebrow above the feedback block on Profile (typically uppercase)."
+            },
+            "contact_title": {
+              "type": "string",
+              "description": "Title of the Contact us entry in the Profile menu."
+            },
+            "contact_subtitle": {
+              "type": "string",
+              "description": "Subtitle of the Contact us entry in the Profile menu."
+            },
+            "joined_fallback": {
+              "type": "string",
+              "description": "Fallback joined-date string when no usable creation timestamp is available."
+            },
+            "joined_one_month": {
+              "type": "string",
+              "description": "Joined-date string for exactly one month ago (singular)."
+            },
+            "joined_months": {
+              "type": "string",
+              "description": "Joined-date string for the multi-month range. MUST preserve the {months} placeholder — it is replaced at runtime with the month count."
+            },
+            "joined_less_than_year": {
+              "type": "string",
+              "description": "Joined-date string for less than a year ago (fallback before the months-since helper)."
+            },
+            "joined_one_year": {
+              "type": "string",
+              "description": "Joined-date string for exactly one year ago (singular)."
+            },
+            "joined_years": {
+              "type": "string",
+              "description": "Joined-date string for multiple years ago. MUST preserve the {years} placeholder — it is replaced at runtime with the year count."
+            }
+          },
+          "additionalProperties": false
         },
-        "header": {
-          "type": "string",
-          "description": "Hero copy above the form."
+        "history": {
+          "type": "object",
+          "description": "Profile → History screen.",
+          "properties": {
+            "title": {
+              "type": "string",
+              "description": "Screen title (typically uppercase)."
+            },
+            "empty_title": {
+              "type": "string",
+              "description": "Empty-state title when the user has no history entries."
+            },
+            "empty_subtitle": {
+              "type": "string",
+              "description": "Empty-state subtitle when the user has no history entries."
+            }
+          },
+          "additionalProperties": false
         },
-        "subtitle": {
-          "type": "string",
-          "description": "Subtitle below the hero copy."
+        "favourites": {
+          "type": "object",
+          "description": "Profile → Favourites screen.",
+          "properties": {
+            "title": {
+              "type": "string",
+              "description": "Screen title (typically uppercase)."
+            },
+            "removed_from_favourites": {
+              "type": "string",
+              "description": "Snackbar shown after a favourite is removed (paired with the global Undo action from the general group)."
+            }
+          },
+          "additionalProperties": false
         },
-        "placeholder": {
-          "type": "string",
-          "description": "Input field placeholder hint for the feedback text area."
+        "account": {
+          "type": "object",
+          "description": "Profile → Account settings screen — edit name/email, change password, delete account.",
+          "properties": {
+            "title": {
+              "type": "string",
+              "description": "Screen title."
+            },
+            "details_header": {
+              "type": "string",
+              "description": "Eyebrow above the details block (typically uppercase)."
+            },
+            "name_label": {
+              "type": "string",
+              "description": "Label for the name input."
+            },
+            "name_hint": {
+              "type": "string",
+              "description": "Placeholder hint for the name input."
+            },
+            "save": {
+              "type": "string",
+              "description": "Save CTA used on inline forms."
+            },
+            "saving": {
+              "type": "string",
+              "description": "Loading-state label shown on the Save CTA while saving."
+            },
+            "saved": {
+              "type": "string",
+              "description": "Confirmation toast shown after settings are saved."
+            },
+            "first_name_label": {
+              "type": "string",
+              "description": "Label used by the dedicated first-name edit row."
+            },
+            "email_label": {
+              "type": "string",
+              "description": "Label used by the email row."
+            },
+            "password_label": {
+              "type": "string",
+              "description": "Label used by the password row."
+            },
+            "edit_action": {
+              "type": "string",
+              "description": "Edit CTA used on read-only rows that open an edit modal."
+            },
+            "edit_first_name_title": {
+              "type": "string",
+              "description": "Title of the edit-first-name modal."
+            },
+            "edit_email_title": {
+              "type": "string",
+              "description": "Title of the edit-email modal."
+            },
+            "cancel": {
+              "type": "string",
+              "description": "Cancel CTA used in edit modals."
+            },
+            "save_changes": {
+              "type": "string",
+              "description": "Primary CTA in edit modals."
+            },
+            "save_failed": {
+              "type": "string",
+              "description": "Error shown when saving account settings fails."
+            },
+            "reset_password_title": {
+              "type": "string",
+              "description": "Title of the reset-password modal."
+            },
+            "reset_password_description": {
+              "type": "string",
+              "description": "Body copy of the reset-password modal."
+            },
+            "reset_password_action": {
+              "type": "string",
+              "description": "Primary CTA in the reset-password modal."
+            },
+            "reset_password_sent": {
+              "type": "string",
+              "description": "Confirmation toast shown after the reset link has been emailed."
+            },
+            "reset_password_error": {
+              "type": "string",
+              "description": "Error shown when sending the reset link fails."
+            },
+            "email_edit_unavailable": {
+              "type": "string",
+              "description": "Toast shown when email editing is not yet available."
+            },
+            "email_unavailable": {
+              "type": "string",
+              "description": "Inline placeholder shown when no email is available for the account."
+            },
+            "create_account": {
+              "type": "string",
+              "description": "CTA shown for guest users prompting them to create an account."
+            },
+            "delete_account_title": {
+              "type": "string",
+              "description": "Title of the delete-account confirmation."
+            },
+            "delete_account_description": {
+              "type": "string",
+              "description": "Body copy of the delete-account confirmation."
+            },
+            "delete_account_error": {
+              "type": "string",
+              "description": "Error shown when delete-account fails."
+            },
+            "delete_account_requires_recent_login": {
+              "type": "string",
+              "description": "Error shown when delete-account requires the user to log in again first."
+            },
+            "reauthenticate_title": {
+              "type": "string",
+              "description": "Title of the password re-entry modal used before destructive actions."
+            },
+            "reauthenticate_description": {
+              "type": "string",
+              "description": "Body copy of the password re-entry modal."
+            },
+            "reauthenticate_required": {
+              "type": "string",
+              "description": "Validation error shown when the password field is empty in the re-entry modal."
+            },
+            "reauthenticate_invalid": {
+              "type": "string",
+              "description": "Error shown when the re-entered password is incorrect."
+            },
+            "continue_action": {
+              "type": "string",
+              "description": "Primary CTA on the password re-entry modal."
+            },
+            "guest_email_prompt": {
+              "type": "string",
+              "description": "Inline prompt shown on the email row for guest users."
+            },
+            "guest_password_prompt": {
+              "type": "string",
+              "description": "Inline prompt shown on the password row for guest users."
+            },
+            "login": {
+              "type": "string",
+              "description": "Login CTA used in the guest prompts."
+            },
+            "logout": {
+              "type": "string",
+              "description": "Logout CTA in the account screen."
+            },
+            "privacy_policy": {
+              "type": "string",
+              "description": "Inline link opening the Privacy Policy webview from the account screen."
+            },
+            "delete_account": {
+              "type": "string",
+              "description": "Destructive CTA opening the delete-account flow."
+            }
+          },
+          "additionalProperties": false
         },
-        "send": {
-          "type": "string",
-          "description": "Submit CTA on the form."
-        },
-        "sending": {
-          "type": "string",
-          "description": "Loading-state label shown on the Submit CTA while sending."
-        },
-        "sent": {
-          "type": "string",
-          "description": "Confirmation toast shown after the feedback is sent."
-        },
-        "empty_error": {
-          "type": "string",
-          "description": "Validation error shown when the feedback field is empty."
-        },
-        "min_length_error": {
-          "type": "string",
-          "description": "Validation error shown when the feedback is shorter than the minimum length (50 characters)."
-        },
-        "send_error": {
-          "type": "string",
-          "description": "Error shown when sending the feedback fails."
+        "contact": {
+          "type": "object",
+          "description": "Profile → Contact us screen — free-text feedback form. The text itself is first-party only — it never reaches the ad path.",
+          "properties": {
+            "title": {
+              "type": "string",
+              "description": "Screen title (typically uppercase)."
+            },
+            "header": {
+              "type": "string",
+              "description": "Hero copy above the form."
+            },
+            "subtitle": {
+              "type": "string",
+              "description": "Subtitle below the hero copy."
+            },
+            "placeholder": {
+              "type": "string",
+              "description": "Input field placeholder hint for the feedback text area."
+            },
+            "send": {
+              "type": "string",
+              "description": "Submit CTA on the form."
+            },
+            "sending": {
+              "type": "string",
+              "description": "Loading-state label shown on the Submit CTA while sending."
+            },
+            "sent": {
+              "type": "string",
+              "description": "Confirmation toast shown after the feedback is sent."
+            },
+            "empty_error": {
+              "type": "string",
+              "description": "Validation error shown when the feedback field is empty."
+            },
+            "min_length_error": {
+              "type": "string",
+              "description": "Validation error shown when the feedback is shorter than the minimum length (50 characters)."
+            },
+            "send_error": {
+              "type": "string",
+              "description": "Error shown when sending the feedback fails."
+            }
+          },
+          "additionalProperties": false
         }
       },
       "additionalProperties": false
     },
-    "consent_ad_modal": {
+    "consent": {
       "type": "object",
-      "description": "Post-first-meditation ‘Help spread the word’ ad-measurement consent modal. Shown in the onboarding chain after the first-meditation Vibes Interpretation + Shri Mataji talk and before Account Creation. Approval flips adsMarketingConsent = true (see .kiro/specs/analytics-simplified/01-strategy.md §3 and §9). Figma: node-id 11564-91404.",
+      "description": "Ad-measurement consent surfaces — the post-first-meditation modal and the Profile → Privacy & advertising settings screen. See .kiro/specs/analytics-simplified/01-strategy.md §3 and §9.",
       "properties": {
-        "title": {
-          "type": "string",
-          "description": "Modal title (e.g. 'Help spread the word')."
+        "ad_modal": {
+          "type": "object",
+          "description": "Post-first-meditation ‘Help spread the word’ ad-measurement consent modal. Shown in the onboarding chain after the first-meditation Vibes Interpretation + Shri Mataji talk and before Account Creation. Approval flips adsMarketingConsent = true. Figma: node-id 11564-91404.",
+          "properties": {
+            "title": {
+              "type": "string",
+              "description": "Modal title (e.g. 'Help spread the word')."
+            },
+            "body_intro_prefix": {
+              "type": "string",
+              "description": "First paragraph prefix; combined inline with body_intro_link and body_intro_suffix to form a single sentence. Include any trailing space."
+            },
+            "body_intro_link": {
+              "type": "string",
+              "description": "Inline link text inside the first paragraph (e.g. 'what we share'). Tapping opens a detail sheet listing exactly which fields are sent to Meta, Apple and Google Ads."
+            },
+            "body_intro_suffix": {
+              "type": "string",
+              "description": "First paragraph suffix completing the sentence after the inline link. Include the leading separator if needed (e.g. ') with Meta, Apple and Google Ads to understand which outreach helps people discover meditation.')."
+            },
+            "body_benefits": {
+              "type": "string",
+              "description": "Second paragraph explaining the benefits of granting consent (improving campaigns, using donations responsibly, suppressing ads to existing users, reaching similar people)."
+            },
+            "body_never_share": {
+              "type": "string",
+              "description": "Third paragraph listing categories that are never sent for advertising (mood, goals, hand sensations, reflections, class location, spiritual-practice details). Must remain consistent with the privacy filter in analytics-simplified/03-marketing-event-taxonomy.md §2."
+            },
+            "body_never_sell": {
+              "type": "string",
+              "description": "Fourth paragraph: short statement that the app never sells user data."
+            },
+            "body_settings_hint": {
+              "type": "string",
+              "description": "Fifth paragraph telling the user they can change this anytime via Settings → Privacy & advertising. Preserve the arrow character (→) or substitute the locale equivalent."
+            },
+            "allow": {
+              "type": "string",
+              "description": "Primary CTA granting consent (sets adsMarketingConsent = true)."
+            },
+            "reject": {
+              "type": "string",
+              "description": "Decline CTA. Decline is a single tap and must not block account creation (see analytics-simplified/05-flutter-implementation.md §9)."
+            }
+          },
+          "additionalProperties": false
         },
-        "body_intro_prefix": {
-          "type": "string",
-          "description": "First paragraph prefix; combined inline with body_intro_link and body_intro_suffix to form a single sentence. Include any trailing space."
-        },
-        "body_intro_link": {
-          "type": "string",
-          "description": "Inline link text inside the first paragraph (e.g. 'what we share'). Tapping opens a detail sheet listing exactly which fields are sent to Meta, Apple and Google Ads."
-        },
-        "body_intro_suffix": {
-          "type": "string",
-          "description": "First paragraph suffix completing the sentence after the inline link. Include the leading separator if needed (e.g. ') with Meta, Apple and Google Ads to understand which outreach helps people discover meditation.')."
-        },
-        "body_benefits": {
-          "type": "string",
-          "description": "Second paragraph explaining the benefits of granting consent (improving campaigns, using donations responsibly, suppressing ads to existing users, reaching similar people)."
-        },
-        "body_never_share": {
-          "type": "string",
-          "description": "Third paragraph listing categories that are never sent for advertising (mood, goals, hand sensations, reflections, class location, spiritual-practice details). Must remain consistent with the privacy filter in analytics-simplified/03-marketing-event-taxonomy.md §2."
-        },
-        "body_never_sell": {
-          "type": "string",
-          "description": "Fourth paragraph: short statement that the app never sells user data."
-        },
-        "body_settings_hint": {
-          "type": "string",
-          "description": "Fifth paragraph telling the user they can change this anytime via Settings → Privacy & advertising. Preserve the arrow character (→) or substitute the locale equivalent."
-        },
-        "allow": {
-          "type": "string",
-          "description": "Primary CTA granting consent (sets adsMarketingConsent = true)."
-        },
-        "reject": {
-          "type": "string",
-          "description": "Decline CTA. Decline is a single tap and must not block account creation (see analytics-simplified/05-flutter-implementation.md §9)."
-        }
-      },
-      "additionalProperties": false
-    },
-    "consent_settings": {
-      "type": "object",
-      "description": "Profile → Privacy & advertising settings screen — two toggle sections (anonymous product analytics, advertising measurement). Drives the productAnalyticsOptOut and adsMarketingConsent flags respectively (see .kiro/specs/analytics-simplified/05-flutter-implementation.md §2 and §8). Figma: node-id 11571-40337.",
-      "properties": {
-        "screen_title": {
-          "type": "string",
-          "description": "Screen title (e.g. 'Help spread the word and make the app better')."
-        },
-        "status_allowed": {
-          "type": "string",
-          "description": "Status label shown next to a toggle that is currently allowed. MUST preserve the {date} placeholder — it is replaced at runtime with the localized date of the most recent consent decision (e.g. '16 May 2026')."
-        },
-        "status_not_allowed": {
-          "type": "string",
-          "description": "Status label shown next to a toggle that is currently disallowed."
-        },
-        "product_analytics_title": {
-          "type": "string",
-          "description": "Section title for the anonymous product analytics toggle (e.g. 'Anonymous product analytics'). Drives productAnalyticsOptOut."
-        },
-        "product_analytics_description": {
-          "type": "string",
-          "description": "Section body explaining anonymous product analytics: we log aggregated usage data to fix bugs and improve We Meditate, no individual data, no advertisers, no user profile. Must remain consistent with the TelemetryDeck posture in analytics-simplified/01-strategy.md §4."
-        },
-        "advertising_title": {
-          "type": "string",
-          "description": "Section title for the advertising-measurement toggle (e.g. 'Advertising measurement and improvement'). Drives adsMarketingConsent."
-        },
-        "advertising_body_intro_prefix": {
-          "type": "string",
-          "description": "First paragraph prefix of the advertising section; combined inline with advertising_body_intro_link and advertising_body_intro_suffix. Include any trailing space."
-        },
-        "advertising_body_intro_link": {
-          "type": "string",
-          "description": "Inline link text inside the first paragraph (e.g. 'what we share'). Tapping opens the same 'what we share' detail used by the ad consent modal."
-        },
-        "advertising_body_intro_suffix": {
-          "type": "string",
-          "description": "First paragraph suffix completing the sentence after the inline link. Include the leading separator if needed."
-        },
-        "advertising_body_benefits": {
-          "type": "string",
-          "description": "Second paragraph of the advertising section: how granting consent helps WeMeditate use donations responsibly, improve campaigns, suppress ads to existing users, and reach similar people."
-        },
-        "advertising_body_never_share": {
-          "type": "string",
-          "description": "Third paragraph of the advertising section reiterating the never-shared categories (mood, goals, hand sensations, reflections, class location, spiritual-practice details). Must remain consistent with analytics-simplified/03-marketing-event-taxonomy.md §2."
-        },
-        "advertising_body_change_hint": {
-          "type": "string",
-          "description": "Fourth paragraph of the advertising section explaining that the user can change their choice anytime using the toggle at the top of this screen."
-        },
-        "advertising_platforms_header": {
-          "type": "string",
-          "description": "Sub-section header listing current advertising platforms (e.g. 'Current advertising platforms')."
-        },
-        "advertising_platform_meta": {
-          "type": "string",
-          "description": "Bullet item for Meta (Facebook + Instagram + Audience Network). Brand name — usually kept as 'Meta'."
-        },
-        "advertising_platform_google_ads": {
-          "type": "string",
-          "description": "Bullet item for Google Ads. Brand name — usually kept as 'Google Ads'."
-        },
-        "advertising_platform_apple_search_ads": {
-          "type": "string",
-          "description": "Bullet item for Apple Search Ads. Brand name — usually kept as 'Apple Search Ads'."
+        "settings": {
+          "type": "object",
+          "description": "Profile → Privacy & advertising settings screen — two toggle sections (anonymous product analytics, advertising measurement). Drives the productAnalyticsOptOut and adsMarketingConsent flags respectively (see analytics-simplified/05-flutter-implementation.md §2 and §8). Figma: node-id 11571-40337.",
+          "properties": {
+            "screen_title": {
+              "type": "string",
+              "description": "Screen title (e.g. 'Help spread the word and make the app better')."
+            },
+            "status_allowed": {
+              "type": "string",
+              "description": "Status label shown next to a toggle that is currently allowed. MUST preserve the {date} placeholder — it is replaced at runtime with the localized date of the most recent consent decision (e.g. '16 May 2026')."
+            },
+            "status_not_allowed": {
+              "type": "string",
+              "description": "Status label shown next to a toggle that is currently disallowed."
+            },
+            "product_analytics_title": {
+              "type": "string",
+              "description": "Section title for the anonymous product analytics toggle (e.g. 'Anonymous product analytics'). Drives productAnalyticsOptOut."
+            },
+            "product_analytics_description": {
+              "type": "string",
+              "description": "Section body explaining anonymous product analytics: we log aggregated usage data to fix bugs and improve We Meditate, no individual data, no advertisers, no user profile. Must remain consistent with the TelemetryDeck posture in analytics-simplified/01-strategy.md §4."
+            },
+            "advertising_title": {
+              "type": "string",
+              "description": "Section title for the advertising-measurement toggle (e.g. 'Advertising measurement and improvement'). Drives adsMarketingConsent."
+            },
+            "advertising_body_intro_prefix": {
+              "type": "string",
+              "description": "First paragraph prefix of the advertising section; combined inline with advertising_body_intro_link and advertising_body_intro_suffix. Include any trailing space."
+            },
+            "advertising_body_intro_link": {
+              "type": "string",
+              "description": "Inline link text inside the first paragraph (e.g. 'what we share'). Tapping opens the same 'what we share' detail used by the ad consent modal."
+            },
+            "advertising_body_intro_suffix": {
+              "type": "string",
+              "description": "First paragraph suffix completing the sentence after the inline link. Include the leading separator if needed."
+            },
+            "advertising_body_benefits": {
+              "type": "string",
+              "description": "Second paragraph of the advertising section: how granting consent helps WeMeditate use donations responsibly, improve campaigns, suppress ads to existing users, and reach similar people."
+            },
+            "advertising_body_never_share": {
+              "type": "string",
+              "description": "Third paragraph of the advertising section reiterating the never-shared categories (mood, goals, hand sensations, reflections, class location, spiritual-practice details). Must remain consistent with analytics-simplified/03-marketing-event-taxonomy.md §2."
+            },
+            "advertising_body_change_hint": {
+              "type": "string",
+              "description": "Fourth paragraph of the advertising section explaining that the user can change their choice anytime using the toggle at the top of this screen."
+            },
+            "advertising_platforms_header": {
+              "type": "string",
+              "description": "Sub-section header listing current advertising platforms (e.g. 'Current advertising platforms')."
+            },
+            "advertising_platform_meta": {
+              "type": "string",
+              "description": "Bullet item for Meta (Facebook + Instagram + Audience Network). Brand name — usually kept as 'Meta'."
+            },
+            "advertising_platform_google_ads": {
+              "type": "string",
+              "description": "Bullet item for Google Ads. Brand name — usually kept as 'Google Ads'."
+            },
+            "advertising_platform_apple_search_ads": {
+              "type": "string",
+              "description": "Bullet item for Apple Search Ads. Brand name — usually kept as 'Apple Search Ads'."
+            }
+          },
+          "additionalProperties": false
         }
       },
       "additionalProperties": false

--- a/src/globals/wemeditate-app/translationsSchema.json
+++ b/src/globals/wemeditate-app/translationsSchema.json
@@ -3,7 +3,7 @@
   "properties": {
     "onboarding": {
       "type": "object",
-      "description": "Onboarding flow — name entry, greeting, user-type classification, and the intro carousel. Drives downstream personalisation and the analytics yogi-exclusion gate.",
+      "description": "First-run onboarding flow plus the post-first-meditation ad-consent modal that closes the flow. See .kiro/specs/onboarding-flow/requirements.md.",
       "properties": {
         "welcome": {
           "type": "object",
@@ -168,87 +168,65 @@
           },
           "additionalProperties": false,
           "screenshot": "https://www.figma.com/design/JkJK5lBTjB3oSwATMGqfUt/We-Meditate-App?node-id=5390-7673"
+        },
+        "consent_modal": {
+          "type": "object",
+          "description": "Post-first-meditation ‘Help spread the word’ ad-measurement consent modal. Shown in the onboarding chain after the first-meditation Vibes Interpretation + Shri Mataji talk and before Account Creation. Approval flips adsMarketingConsent = true. Figma: node-id 11564-91404.",
+          "properties": {
+            "title": {
+              "type": "string",
+              "description": "Modal title (e.g. 'Help spread the word')."
+            },
+            "body_intro_prefix": {
+              "type": "string",
+              "description": "First paragraph prefix; combined inline with body_intro_link and body_intro_suffix to form a single sentence. Include any trailing space."
+            },
+            "body_intro_link": {
+              "type": "string",
+              "description": "Inline link text inside the first paragraph (e.g. 'what we share'). Tapping opens a detail sheet listing exactly which fields are sent to Meta, Apple and Google Ads."
+            },
+            "body_intro_suffix": {
+              "type": "string",
+              "description": "First paragraph suffix completing the sentence after the inline link. Include the leading separator if needed (e.g. ') with Meta, Apple and Google Ads to understand which outreach helps people discover meditation.')."
+            },
+            "body_benefits": {
+              "type": "string",
+              "description": "Second paragraph explaining the benefits of granting consent (improving campaigns, using donations responsibly, suppressing ads to existing users, reaching similar people)."
+            },
+            "body_never_share": {
+              "type": "string",
+              "description": "Third paragraph listing categories that are never sent for advertising (mood, goals, hand sensations, reflections, class location, spiritual-practice details). Must remain consistent with the privacy filter in analytics-simplified/03-marketing-event-taxonomy.md §2."
+            },
+            "body_never_sell": {
+              "type": "string",
+              "description": "Fourth paragraph: short statement that the app never sells user data."
+            },
+            "body_settings_hint": {
+              "type": "string",
+              "description": "Fifth paragraph telling the user they can change this anytime via Settings → Privacy & advertising. Preserve the arrow character (→) or substitute the locale equivalent."
+            },
+            "allow": {
+              "type": "string",
+              "description": "Primary CTA granting consent (sets adsMarketingConsent = true)."
+            },
+            "reject": {
+              "type": "string",
+              "description": "Decline CTA. Decline is a single tap and must not block account creation (see analytics-simplified/05-flutter-implementation.md §9)."
+            }
+          },
+          "additionalProperties": false,
+          "screenshot": "https://www.figma.com/design/JkJK5lBTjB3oSwATMGqfUt/We-Meditate-App?node-id=11564-91404"
         }
       },
       "additionalProperties": false
     },
-    "home": {
+    "daily": {
       "type": "object",
-      "description": "Home (Daily) tab — hero, daily/quick/personalised cards, time-of-day variants, plus the curated Explore-style grid embedded on Home.",
+      "description": "Daily tab — bottom-nav index 0. Two snap super slides (Daily hero + Path promo) plus a long-panel below with hero, intent capture, classes invitation, and highlights. See .kiro/specs/home-page/requirements.md.",
       "properties": {
-        "common": {
+        "main": {
           "type": "object",
-          "description": "Shared messages and error toasts on the Home (Daily) tab.",
-          "properties": {
-            "unlock_after_first_meditation": {
-              "type": "string",
-              "description": "Locked-state message shown on Home cards that are gated behind completing the first meditation."
-            },
-            "path_coming_soon": {
-              "type": "string",
-              "description": "Placeholder shown when the Path tile on Home is not yet available for the current user/locale."
-            },
-            "something_went_wrong": {
-              "type": "string",
-              "description": "Generic error message shown on Home when a section fails to load."
-            },
-            "retry": {
-              "type": "string",
-              "description": "Retry CTA used on Home error states."
-            },
-            "external_link_coming_soon": {
-              "type": "string",
-              "description": "Toast shown when an external link card on Home is not yet wired up."
-            },
-            "card_action_not_available": {
-              "type": "string",
-              "description": "Toast shown when tapping a Home card whose action is not yet implemented."
-            },
-            "map_coming_soon": {
-              "type": "string",
-              "description": "Placeholder shown for the in-person class finder on Home before the feature ships."
-            },
-            "music_coming_soon": {
-              "type": "string",
-              "description": "Placeholder shown for the music section on Home before the feature ships."
-            }
-          },
-          "additionalProperties": false
-        },
-        "load_info": {
-          "type": "object",
-          "description": "Inline info banners on Home that explain why a section is showing fallback content (network or content failure).",
-          "properties": {
-            "top_daily_unavailable": {
-              "type": "string",
-              "description": "Banner shown when the hero Daily meditation could not be resolved at all."
-            },
-            "top_daily_failed": {
-              "type": "string",
-              "description": "Banner shown when the hero Daily meditation failed to load due to a network or content error."
-            },
-            "top_daily_random": {
-              "type": "string",
-              "description": "Banner shown when the hero Daily meditation has been replaced by a random meditation fallback."
-            },
-            "quick_daily_unavailable": {
-              "type": "string",
-              "description": "Banner shown when the Quick meditations row could not be resolved."
-            },
-            "quick_daily_failed": {
-              "type": "string",
-              "description": "Banner shown when the Quick meditations row failed to load."
-            },
-            "quick_daily_random": {
-              "type": "string",
-              "description": "Banner shown when the Quick meditations row has been replaced by random fallbacks."
-            }
-          },
-          "additionalProperties": false
-        },
-        "daily": {
-          "type": "object",
-          "description": "Hero, cards, and CTAs on the Daily tab. Includes the time-of-day hero variants (morning/afternoon/evening) and Path / Talks / Live / In-person promo blocks.",
+          "description": "Main Daily tab content — super slide 1 (greeting + your-X-meditation hero), super slide 2 (Path promo), and the long-panel sections (hero, intent capture priority chooser, classes invitation, relevant highlights). Excludes the standalone Explore tab cards.",
           "properties": {
             "start_meditation": {
               "type": "string",
@@ -485,787 +463,73 @@
           },
           "additionalProperties": false,
           "screenshot": "https://www.figma.com/design/JkJK5lBTjB3oSwATMGqfUt/We-Meditate-App?node-id=7064-81297"
-        }
-      },
-      "additionalProperties": false
-    },
-    "explore": {
-      "type": "object",
-      "description": "Standalone Explore tab — curated grid of Meditate / Learn / Join cards linking into the rest of the app. Reached via the Explore entry in the bottom navigation bar.",
-      "properties": {
-        "section_label": {
-          "type": "string",
-          "description": "Eyebrow label for the embedded Explore block."
         },
-        "section_meditate_title": {
-          "type": "string",
-          "description": "Section header for the Meditate column."
-        },
-        "section_learn_title": {
-          "type": "string",
-          "description": "Section header for the Learn column."
-        },
-        "section_join_title": {
-          "type": "string",
-          "description": "Section header for the Join Free Classes column."
-        },
-        "card_daily_title": {
-          "type": "string",
-          "description": "Card title for the Daily entry in the Explore block."
-        },
-        "card_daily_subtitle": {
-          "type": "string",
-          "description": "Card subtitle for the Daily entry in the Explore block."
-        },
-        "card_path_title": {
-          "type": "string",
-          "description": "Card title for the Path entry in the Explore block."
-        },
-        "card_path_subtitle": {
-          "type": "string",
-          "description": "Card subtitle for the Path entry in the Explore block."
-        },
-        "card_techniques_title": {
-          "type": "string",
-          "description": "Card title for the Techniques entry in the Explore block."
-        },
-        "card_techniques_subtitle": {
-          "type": "string",
-          "description": "Card subtitle for the Techniques entry in the Explore block."
-        },
-        "card_vibes_check_title": {
-          "type": "string",
-          "description": "Card title for the Vibes Check entry in the Explore block."
-        },
-        "card_vibes_check_subtitle": {
-          "type": "string",
-          "description": "Card subtitle for the Vibes Check entry in the Explore block."
-        },
-        "card_music_title": {
-          "type": "string",
-          "description": "Card title for the Music for Meditation entry in the Explore block."
-        },
-        "card_challenges_title": {
-          "type": "string",
-          "description": "Card title for the Challenges entry in the Explore block."
-        },
-        "card_talks_title": {
-          "type": "string",
-          "description": "Card title for the Shri Mataji Talks entry in the Explore block. Preserve the embedded line break (\\n)."
-        },
-        "card_subtle_system_title": {
-          "type": "string",
-          "description": "Card title for the Subtle System entry in the Explore block."
-        },
-        "card_who_is_title": {
-          "type": "string",
-          "description": "Card title for the 'Who is Shri Mataji' entry in the Explore block. Preserve the embedded line break (\\n)."
-        },
-        "card_what_is_title": {
-          "type": "string",
-          "description": "Card title for the 'What is Sahaja Yoga?' entry in the Explore block."
-        },
-        "card_live_online_title": {
-          "type": "string",
-          "description": "Card title for the Live Online Classes entry in the Explore block. Preserve the embedded line break (\\n)."
-        },
-        "card_find_classes_title": {
-          "type": "string",
-          "description": "Card title for the in-person class finder entry in the Explore block. Preserve the embedded line break (\\n)."
-        },
-        "card_coming_soon": {
-          "type": "string",
-          "description": "Generic 'Coming soon' badge used on locked Explore-block cards."
-        }
-      },
-      "additionalProperties": false,
-      "screenshot": "https://www.figma.com/design/JkJK5lBTjB3oSwATMGqfUt/We-Meditate-App?node-id=5878-10306"
-    },
-    "general": {
-      "type": "object",
-      "description": "Generic UI strings shared across the app (overlays, error states, simple actions).",
-      "properties": {
-        "back": {
-          "type": "string",
-          "description": "Generic back action label (used as accessibility text and as a back button label)."
-        },
-        "retry": {
-          "type": "string",
-          "description": "Generic retry action label used on error states across the app."
-        },
-        "undo": {
-          "type": "string",
-          "description": "Generic undo action label used on snackbars and other transient confirmations."
-        }
-      },
-      "additionalProperties": false
-    },
-    "navigation": {
-      "type": "object",
-      "description": "Bottom navigation bar tab labels.",
-      "properties": {
-        "daily": {
-          "type": "string",
-          "description": "Bottom-nav label for the Daily tab (home / today’s meditations)."
-        },
-        "path": {
-          "type": "string",
-          "description": "Bottom-nav label for the Path tab (guided learning course)."
-        },
-        "explore": {
-          "type": "string",
-          "description": "Bottom-nav label for the Explore tab (library of meditations, talks, techniques)."
-        },
-        "profile": {
-          "type": "string",
-          "description": "Bottom-nav label for the Profile tab (account, history, favourites, settings)."
-        }
-      },
-      "additionalProperties": false
-    },
-    "meditation": {
-      "type": "object",
-      "description": "Meditation player and the surrounding intro flow (pre-meditation intent, footsoak, Vibes Check, subtle-system diagram).",
-      "properties": {
-        "intent": {
+        "common": {
           "type": "object",
-          "description": "Pre-meditation intent / set-up flow: time-of-day picker, quick vs. personalised selection, reminder prompts, and notification-permission rationale screens.",
+          "description": "Shared messages and error toasts on the Home (Daily) tab.",
           "properties": {
-            "carousel_continue": {
+            "unlock_after_first_meditation": {
               "type": "string",
-              "description": "Continue CTA on the intent carousel."
+              "description": "Locked-state message shown on Home cards that are gated behind completing the first meditation."
             },
-            "skip_video_and_continue": {
+            "path_coming_soon": {
               "type": "string",
-              "description": "Skip-link shown over the intent video that lets the user proceed without watching."
+              "description": "Placeholder shown when the Path tile on Home is not yet available for the current user/locale."
             },
-            "repeat_video": {
+            "something_went_wrong": {
               "type": "string",
-              "description": "Replay-link shown after the intent video ends."
+              "description": "Generic error message shown on Home when a section fails to load."
             },
-            "start_meditation": {
+            "retry": {
               "type": "string",
-              "description": "Primary CTA that starts the actual meditation after the intent flow."
+              "description": "Retry CTA used on Home error states."
             },
-            "skip_and_explore_the_app": {
+            "external_link_coming_soon": {
               "type": "string",
-              "description": "Tertiary CTA letting a new user skip the first meditation and just browse the app. Tied to the onboarding_ready_action / skip_and_explore_app_press analytics event."
+              "description": "Toast shown when an external link card on Home is not yet wired up."
             },
-            "step_label": {
+            "card_action_not_available": {
               "type": "string",
-              "description": "Step indicator (e.g. 'Step 1 of 3') at the top of the intent flow."
+              "description": "Toast shown when tapping a Home card whose action is not yet implemented."
             },
-            "title_today": {
+            "map_coming_soon": {
               "type": "string",
-              "description": "Intent screen title shown during the day. Preserve the embedded line break (\\n)."
+              "description": "Placeholder shown for the in-person class finder on Home before the feature ships."
             },
-            "title_tonight": {
+            "music_coming_soon": {
               "type": "string",
-              "description": "Intent screen title shown in the evening. Preserve the embedded line break (\\n)."
-            },
-            "first_meditation_title": {
-              "type": "string",
-              "description": "Title of the locked first-meditation card before activation."
-            },
-            "first_meditation_subtitle": {
-              "type": "string",
-              "description": "Subtitle of the locked first-meditation card."
-            },
-            "repeat_first_meditation_title": {
-              "type": "string",
-              "description": "Title shown when a returning user is invited to repeat the first meditation."
-            },
-            "repeat_first_meditation_subtitle": {
-              "type": "string",
-              "description": "Subtitle shown when a returning user is invited to repeat the first meditation."
-            },
-            "ready_to_try_title": {
-              "type": "string",
-              "description": "Title shown on the 'ready to try?' confirmation step before starting the first meditation."
-            },
-            "ready_to_try_subtitle_beginner": {
-              "type": "string",
-              "description": "Subtitle for the 'ready to try?' step, beginner variant."
-            },
-            "ready_to_try_subtitle_repeat": {
-              "type": "string",
-              "description": "Subtitle for the 'ready to try?' step, repeat variant."
-            },
-            "quick_morning_title": {
-              "type": "string",
-              "description": "Title of the morning quick-meditation card in the intent flow."
-            },
-            "quick_afternoon_title": {
-              "type": "string",
-              "description": "Title of the afternoon quick-meditation card in the intent flow."
-            },
-            "quick_evening_title": {
-              "type": "string",
-              "description": "Title of the evening quick-meditation card in the intent flow."
-            },
-            "quick_morning_subtitle": {
-              "type": "string",
-              "description": "Subtitle of the morning quick-meditation card."
-            },
-            "quick_afternoon_subtitle": {
-              "type": "string",
-              "description": "Subtitle of the afternoon quick-meditation card. Preserve the embedded line break (\\n)."
-            },
-            "quick_evening_subtitle": {
-              "type": "string",
-              "description": "Subtitle of the evening quick-meditation card."
-            },
-            "personalized_title": {
-              "type": "string",
-              "description": "Title of the personalised long-session card in the intent flow."
-            },
-            "personalized_subtitle": {
-              "type": "string",
-              "description": "Subtitle of the personalised long-session card."
-            },
-            "locked_subtitle": {
-              "type": "string",
-              "description": "Subtitle shown on cards that are locked until the user completes their first meditation."
-            },
-            "learn_more": {
-              "type": "string",
-              "description": "Inline link/CTA used on intent-flow cards to view more detail."
-            },
-            "go_to_first_meditation": {
-              "type": "string",
-              "description": "CTA on a locked card that takes the user back to the first meditation flow."
-            },
-            "set_reminder_for_later": {
-              "type": "string",
-              "description": "CTA opening the 'schedule for later' bottom sheet."
-            },
-            "reminder_prompt_title": {
-              "type": "string",
-              "description": "Title of the prompt that suggests scheduling the first meditation for later. Preserve the embedded line break (\\n)."
-            },
-            "reminder_prompt_subtitle": {
-              "type": "string",
-              "description": "Subtitle of the same scheduling prompt. Preserve the embedded line break (\\n)."
-            },
-            "reminder_prompt_set_reminder": {
-              "type": "string",
-              "description": "Primary CTA on the scheduling prompt."
-            },
-            "reminder_prompt_no_thanks": {
-              "type": "string",
-              "description": "Decline CTA on the scheduling prompt."
-            },
-            "reminder_prompt_allow_notifications_title": {
-              "type": "string",
-              "description": "Title of the rationale screen explaining why notification permission is needed before showing the OS prompt."
-            },
-            "reminder_prompt_allow_notifications_subtitle": {
-              "type": "string",
-              "description": "Subtitle of the same rationale screen. References the wording on the next (OS) screen — keep 'Allow' consistent with the OS prompt translation if locale-specific."
-            },
-            "reminder_prompt_allow_notifications_primary": {
-              "type": "string",
-              "description": "Primary CTA on the notification-rationale screen that triggers the OS permission prompt."
-            },
-            "reminder_prompt_not_now": {
-              "type": "string",
-              "description": "Decline CTA on the notification-rationale screen."
-            },
-            "reminder_prompt_turn_on_notifications_title": {
-              "type": "string",
-              "description": "Title shown when notifications were previously denied and need to be re-enabled from OS Settings."
-            },
-            "reminder_prompt_turn_on_notifications_subtitle": {
-              "type": "string",
-              "description": "Subtitle of the same 'open Settings' prompt."
-            },
-            "reminder_prompt_open_settings": {
-              "type": "string",
-              "description": "CTA that deep-links to the app’s OS notification settings."
-            },
-            "reminder_sheet_title": {
-              "type": "string",
-              "description": "Title of the bottom sheet where the user picks a reminder time. Preserve the embedded line break (\\n)."
-            },
-            "reminder_sheet_dont_set": {
-              "type": "string",
-              "description": "Dismiss action on the reminder bottom sheet."
-            },
-            "reminder_sheet_done": {
-              "type": "string",
-              "description": "Confirm CTA on the reminder bottom sheet."
-            },
-            "reminder_sheet_return_to_meditation": {
-              "type": "string",
-              "description": "CTA letting the user return to the meditation flow from the reminder sheet."
-            },
-            "reminder_sheet_leave_meditation": {
-              "type": "string",
-              "description": "CTA letting the user exit the meditation flow from the reminder sheet."
-            },
-            "reminder_sheet_success_title": {
-              "type": "string",
-              "description": "Title of the success confirmation after a reminder is scheduled."
-            },
-            "reminder_sheet_success_subtitle": {
-              "type": "string",
-              "description": "Subtitle of the success confirmation after a reminder is scheduled."
-            },
-            "reminder_sheet_explore_app": {
-              "type": "string",
-              "description": "CTA on the success confirmation suggesting the user explores the app while waiting."
-            },
-            "reminder_sheet_start_first_meditation": {
-              "type": "string",
-              "description": "CTA on the success confirmation suggesting the user starts the first meditation immediately instead."
-            },
-            "reminder_sheet_error": {
-              "type": "string",
-              "description": "Error toast shown when scheduling the reminder fails."
-            },
-            "reminder_preset_unwind_later_today": {
-              "type": "string",
-              "description": "Preset chip label suggesting a reminder later the same day."
-            },
-            "reminder_preset_start_your_week_calm": {
-              "type": "string",
-              "description": "Preset chip label suggesting a reminder at the start of the week."
-            },
-            "reminder_preset_find_your_midweek_balance": {
-              "type": "string",
-              "description": "Preset chip label suggesting a reminder midweek."
-            },
-            "reminder_preset_pause_and_recharge": {
-              "type": "string",
-              "description": "Preset chip label suggesting a recharge break."
-            },
-            "reminder_preset_mindful_break_before_weekend": {
-              "type": "string",
-              "description": "Preset chip label suggesting a reminder before the weekend."
-            },
-            "reminder_preset_end_your_week_with_peace": {
-              "type": "string",
-              "description": "Preset chip label suggesting a reminder at the end of the work week."
-            },
-            "reminder_preset_slow_down_weekend": {
-              "type": "string",
-              "description": "Preset chip label suggesting a weekend slow-down reminder."
-            },
-            "reminder_preset_reset_for_week_ahead": {
-              "type": "string",
-              "description": "Preset chip label suggesting a Sunday reset reminder."
-            },
-            "reminder_notification_title": {
-              "type": "string",
-              "description": "Title of the scheduled local notification used by the generic meditation reminder."
-            },
-            "reminder_notification_body_locked": {
-              "type": "string",
-              "description": "Notification body used when the meditation is still locked at the time the reminder fires."
-            },
-            "reminder_notification_body_exit": {
-              "type": "string",
-              "description": "Notification body used when the reminder is for a previously exited meditation."
-            },
-            "reminder_allow_notifications_screen_title": {
-              "type": "string",
-              "description": "Title of the dedicated full-screen rationale used when reminder scheduling requires notification permission."
-            },
-            "reminder_allow_notifications_screen_subtitle": {
-              "type": "string",
-              "description": "Subtitle of the same full-screen rationale. Preserve the embedded line break (\\n) and the trailing sparkle emoji (✨) if used in copy."
-            },
-            "locked_quick_start_title": {
-              "type": "string",
-              "description": "Title shown in the locked-preview card for Quick meditations (‘Start right away’)."
-            },
-            "locked_quick_start_description_morning": {
-              "type": "string",
-              "description": "Locked-preview description for morning Quick meditations."
-            },
-            "locked_quick_start_description_afternoon": {
-              "type": "string",
-              "description": "Locked-preview description for afternoon Quick meditations."
-            },
-            "locked_quick_start_description_evening": {
-              "type": "string",
-              "description": "Locked-preview description for evening Quick meditations."
-            },
-            "locked_quick_custom_time_title": {
-              "type": "string",
-              "description": "Title of the custom-time row in the Quick locked preview."
-            },
-            "locked_quick_custom_time_description": {
-              "type": "string",
-              "description": "Description of the custom-time row in the Quick locked preview."
-            },
-            "locked_personalized_feeling_title": {
-              "type": "string",
-              "description": "Title of the feeling-picker row in the Personalised locked preview."
-            },
-            "locked_personalized_feeling_description": {
-              "type": "string",
-              "description": "Description of the feeling-picker row in the Personalised locked preview."
-            },
-            "locked_personalized_custom_time_title": {
-              "type": "string",
-              "description": "Title of the custom-time row in the Personalised locked preview."
-            },
-            "locked_personalized_custom_time_description": {
-              "type": "string",
-              "description": "Description of the custom-time row in the Personalised locked preview."
+              "description": "Placeholder shown for the music section on Home before the feature ships."
             }
           },
           "additionalProperties": false
         },
-        "player": {
+        "load_info": {
           "type": "object",
-          "description": "Meditation audio player (voice + background music). v1 only carries an error title; controls are pictographic.",
+          "description": "Inline info banners on Home that explain why a section is showing fallback content (network or content failure).",
           "properties": {
-            "load_error_title": {
+            "top_daily_unavailable": {
               "type": "string",
-              "description": "Error title shown when the meditation track fails to load in the player."
-            }
-          },
-          "additionalProperties": false,
-          "screenshot": "https://www.figma.com/design/JkJK5lBTjB3oSwATMGqfUt/We-Meditate-App?node-id=7461-1119009"
-        },
-        "footsoak": {
-          "type": "object",
-          "description": "Step 3 of 3 in the meditation intro: invites the user to do an optional foot-soak before meditating.",
-          "properties": {
-            "step_label": {
-              "type": "string",
-              "description": "Step indicator (e.g. 'Step 3 of 3') at the top of the foot-soak screen."
-            },
-            "title": {
-              "type": "string",
-              "description": "Screen title asking whether the user wants to foot-soak with this meditation."
-            },
-            "description_prefix": {
-              "type": "string",
-              "description": "Body-copy prefix; combined inline with description_emphasis and description_suffix to form a single sentence. Include trailing space if the locale needs one."
-            },
-            "description_emphasis": {
-              "type": "string",
-              "description": "Emphasised word in the foot-soak body copy, typically rendered in italic or bold (e.g. 'really')."
-            },
-            "description_suffix": {
-              "type": "string",
-              "description": "Body-copy suffix completing the foot-soak description sentence. Include the leading space."
-            },
-            "tutorial_cta": {
-              "type": "string",
-              "description": "Inline link/CTA opening the foot-soak tutorial."
-            },
-            "start_with_footsoak": {
-              "type": "string",
-              "description": "Primary CTA that starts the meditation with a foot-soak."
-            },
-            "start_meditation": {
-              "type": "string",
-              "description": "Secondary CTA that starts the meditation without a foot-soak."
-            }
-          },
-          "additionalProperties": false
-        },
-        "vibes_check": {
-          "type": "object",
-          "description": "Vibes Check post-meditation flow: asks what the user felt on each hand. Strictly first-party copy — the raw selections never ship in analytics (see analytics-simplified/02-product-event-taxonomy.md).",
-          "properties": {
-            "intro_question": {
-              "type": "string",
-              "description": "Initial Vibes Check question shown before the per-hand prompt. Preserve the embedded line break (\\n)."
-            },
-            "question_prefix": {
-              "type": "string",
-              "description": "Per-hand question prefix; combined with left_hand or right_hand and question_suffix to form the full prompt (e.g. 'What do you feel on your left hand?'). Preserve the trailing line break (\\n)."
-            },
-            "question_suffix": {
-              "type": "string",
-              "description": "Per-hand question suffix (typically ' hand?'). Include the leading space."
-            },
-            "left_hand": {
-              "type": "string",
-              "description": "Inline noun for the left hand, plugged into the per-hand question template."
-            },
-            "right_hand": {
-              "type": "string",
-              "description": "Inline noun for the right hand, plugged into the per-hand question template."
-            },
-            "cool": {
-              "type": "string",
-              "description": "Selectable sensation: cool. Maps to raw selection 'cool' (first-party storage only)."
-            },
-            "warm": {
-              "type": "string",
-              "description": "Selectable sensation: warm."
-            },
-            "fingers_tingling": {
-              "type": "string",
-              "description": "Selectable sensation: fingers tingling."
-            },
-            "nothing": {
-              "type": "string",
-              "description": "Selectable sensation: nothing felt."
-            },
-            "continue_action": {
-              "type": "string",
-              "description": "Primary CTA to confirm the current Vibes Check answer and continue."
-            },
-            "not_sure": {
-              "type": "string",
-              "description": "Skip-like CTA used when the user is unsure what they felt. Maps to derived firstMedExperience = not_sure."
-            },
-            "got_it": {
-              "type": "string",
-              "description": "Acknowledge CTA at the end of the Vibes Check explanation."
-            },
-            "interpretation_nothing": {
-              "type": "string",
-              "description": "Reassurance shown when the user selects 'nothing' for both hands."
-            },
-            "interpretation_intro": {
-              "type": "string",
-              "description": "Intro line of the Vibes Check interpretation screen."
-            },
-            "interpretation_detail": {
-              "type": "string",
-              "description": "Per-hand detail copy in the Vibes Check interpretation screen."
-            },
-            "skip_vibes_check": {
-              "type": "string",
-              "description": "Inline action that opens the skip-confirmation prompt."
-            },
-            "skip_prompt_title": {
-              "type": "string",
-              "description": "Title of the skip-confirmation prompt."
-            },
-            "skip_prompt_description": {
-              "type": "string",
-              "description": "Body copy of the skip-confirmation prompt."
-            },
-            "back_to_explanation": {
-              "type": "string",
-              "description": "CTA returning the user from the skip prompt to the Vibes Check explanation."
-            },
-            "return_to_meditation_prompt_title": {
-              "type": "string",
-              "description": "Title of the prompt offering to restart the first meditation from the beginning."
-            },
-            "return_to_meditation_prompt_description": {
-              "type": "string",
-              "description": "Body copy of the same restart prompt."
-            },
-            "return_to_meditation_action": {
-              "type": "string",
-              "description": "Primary CTA on the restart prompt."
-            },
-            "skip_it": {
-              "type": "string",
-              "description": "Decline CTA on the restart prompt."
-            }
-          },
-          "additionalProperties": false,
-          "screenshot": "https://www.figma.com/design/JkJK5lBTjB3oSwATMGqfUt/We-Meditate-App?node-id=5390-8159"
-        },
-        "subtle_system": {
-          "type": "object",
-          "description": "Subtle-system intro diagram shown during the meditation intro (chakras / channels diagram).",
-          "properties": {
-            "screen_label": {
-              "type": "string",
-              "description": "Eyebrow / route label for the subtle-system screen."
-            },
-            "diagram_title": {
-              "type": "string",
-              "description": "Diagram title."
-            },
-            "diagram_subtitle": {
-              "type": "string",
-              "description": "Diagram subtitle prompting the user to tap to learn more."
-            },
-            "mode_chakras": {
-              "type": "string",
-              "description": "Tab label switching the diagram to chakra view."
-            },
-            "mode_channels": {
-              "type": "string",
-              "description": "Tab label switching the diagram to channel view."
-            },
-            "front_view_mirrored": {
-              "type": "string",
-              "description": "Caption clarifying that the diagram shows a front view (left/right are mirrored relative to the viewer)."
-            },
-            "chip_right": {
-              "type": "string",
-              "description": "Filter chip label for the Right channel."
-            },
-            "chip_center": {
-              "type": "string",
-              "description": "Filter chip label for the Center channel."
-            },
-            "chip_left": {
-              "type": "string",
-              "description": "Filter chip label for the Left channel."
-            },
-            "aspect_right": {
-              "type": "string",
-              "description": "Detail label for the Right Aspect of a chakra."
-            },
-            "aspect_center": {
-              "type": "string",
-              "description": "Detail label for the Center Aspect of a chakra."
-            },
-            "aspect_left": {
-              "type": "string",
-              "description": "Detail label for the Left Aspect of a chakra."
-            }
-          },
-          "additionalProperties": false,
-          "screenshot": "https://www.figma.com/design/JkJK5lBTjB3oSwATMGqfUt/We-Meditate-App?node-id=7307-83858"
-        }
-      },
-      "additionalProperties": false
-    },
-    "talks": {
-      "type": "object",
-      "description": "Shri Mataji talks — intro/placement, list screen, and player.",
-      "properties": {
-        "intro": {
-          "type": "object",
-          "description": "Intro / placement copy used when a Shri Mataji talk is surfaced, including the post-first-meditation intro and inline placement cards.",
-          "properties": {
-            "unavailable": {
-              "type": "string",
-              "description": "Inline message when a talk is temporarily unavailable to play."
-            },
-            "title": {
-              "type": "string",
-              "description": "Title of the talks intro screen."
-            },
-            "generic_description": {
-              "type": "string",
-              "description": "Long-form description of Shri Mataji and Sahaja Yoga used as fallback intro copy when a specific talk-clip description is unavailable."
-            },
-            "clip_description": {
-              "type": "string",
-              "description": "Short clip-level description shown before a specific talk clip starts."
-            },
-            "post_first_meditation_name": {
-              "type": "string",
-              "description": "Speaker name shown on the talk card placed after the first meditation (e.g. 'Shri Mataji,'). The trailing comma is intentional — it precedes the role line."
-            },
-            "post_first_meditation_subtitle": {
-              "type": "string",
-              "description": "Speaker role/subtitle on the post-first-meditation talk card (e.g. 'The founder of Sahaja Yoga')."
-            },
-            "post_first_meditation_description": {
-              "type": "string",
-              "description": "Body copy on the post-first-meditation talk card."
-            },
-            "start": {
-              "type": "string",
-              "description": "Primary CTA that begins the talk."
-            },
-            "maybe_later": {
-              "type": "string",
-              "description": "Decline CTA on the post-first-meditation talk card."
-            },
-            "watch_now": {
-              "type": "string",
-              "description": "Alternative CTA used on inline talk placements."
-            }
-          },
-          "additionalProperties": false
-        },
-        "list": {
-          "type": "object",
-          "description": "Standalone Shri Mataji talks list screen.",
-          "properties": {
-            "screen_title": {
-              "type": "string",
-              "description": "Eyebrow / route title for the talks list screen (typically uppercase)."
-            },
-            "section_title": {
-              "type": "string",
-              "description": "Section title above the list."
-            },
-            "description": {
-              "type": "string",
-              "description": "Section description above the list."
-            },
-            "all_tags": {
-              "type": "string",
-              "description": "Default filter chip label ('All tags')."
-            },
-            "learn_more": {
-              "type": "string",
-              "description": "Inline link/CTA opening more information about a talk."
-            },
-            "start": {
-              "type": "string",
-              "description": "Card CTA that begins a talk."
-            },
-            "watched": {
-              "type": "string",
-              "description": "Status label shown on talks that the user has already watched."
-            }
-          },
-          "additionalProperties": false,
-          "screenshot": "https://www.figma.com/design/JkJK5lBTjB3oSwATMGqfUt/We-Meditate-App?node-id=2359-6059"
-        },
-        "player": {
-          "type": "object",
-          "description": "Shri Mataji talks player controls and subtitle picker.",
-          "properties": {
-            "unavailable": {
-              "type": "string",
-              "description": "Error message shown when the player cannot load the requested talk."
-            },
-            "play": {
-              "type": "string",
-              "description": "Player play-control label."
-            },
-            "pause": {
-              "type": "string",
-              "description": "Player pause-control label."
-            },
-            "replay": {
-              "type": "string",
-              "description": "Player replay-control label."
-            },
-            "subtitles_title": {
-              "type": "string",
-              "description": "Title of the subtitles bottom sheet."
-            },
-            "subtitles_off": {
-              "type": "string",
-              "description": "Subtitles option label disabling captions."
-            },
-            "subtitles_english": {
-              "type": "string",
-              "description": "Subtitles language label — English."
+              "description": "Banner shown when the hero Daily meditation could not be resolved at all."
             },
-            "subtitles_turkish": {
+            "top_daily_failed": {
               "type": "string",
-              "description": "Subtitles language label — Turkish."
+              "description": "Banner shown when the hero Daily meditation failed to load due to a network or content error."
             },
-            "subtitles_bulgarian": {
+            "top_daily_random": {
               "type": "string",
-              "description": "Subtitles language label — Bulgarian."
+              "description": "Banner shown when the hero Daily meditation has been replaced by a random meditation fallback."
             },
-            "subtitles_portuguese_brazil": {
+            "quick_daily_unavailable": {
               "type": "string",
-              "description": "Subtitles language label — Brazilian Portuguese."
+              "description": "Banner shown when the Quick meditations row could not be resolved."
             },
-            "subtitles_french": {
+            "quick_daily_failed": {
               "type": "string",
-              "description": "Subtitles language label — French."
+              "description": "Banner shown when the Quick meditations row failed to load."
             },
-            "subtitles_spanish": {
+            "quick_daily_random": {
               "type": "string",
-              "description": "Subtitles language label — Spanish."
+              "description": "Banner shown when the Quick meditations row has been replaced by random fallbacks."
             }
           },
           "additionalProperties": false
@@ -1275,7 +539,7 @@
     },
     "path": {
       "type": "object",
-      "description": "Path tab — guided 4-step learning course, intro carousel, step completion, and post-meditation feedback.",
+      "description": "Path tab — bottom-nav index 1. Guided lesson course (units > lessons > phases). Lessons have phases Lesson Intro -> Story Panels -> Audio Intro -> Article. See .kiro/specs/path-tab/requirements.md.",
       "properties": {
         "overview": {
           "type": "object",
@@ -1468,10 +732,1170 @@
           },
           "additionalProperties": false,
           "screenshot": "https://www.figma.com/design/JkJK5lBTjB3oSwATMGqfUt/We-Meditate-App?node-id=7846-27656"
-        },
-        "meditation_feedback": {
+        }
+      },
+      "additionalProperties": false
+    },
+    "explore": {
+      "type": "object",
+      "description": "Explore tab — bottom-nav index 2. Three-section discovery surface (Meditate / Learn / Join free classes) leading into Techniques, Subtle System, Shri Mataji Talks, in-person classes, and live online classes. See .kiro/specs/explore-tab/requirements.md.",
+      "properties": {
+        "overview": {
           "type": "object",
-          "description": "Free-text feedback form shown after a Path meditation. The text itself is first-party only — it never reaches the ad path.",
+          "description": "Explore tab card grid — section headers (Meditate / Learn / Join free classes) and tile labels for the cards that lead into the subscreens. The actual subscreen copy lives in the other groups under Explore.",
+          "properties": {
+            "section_label": {
+              "type": "string",
+              "description": "Eyebrow label for the embedded Explore block."
+            },
+            "section_meditate_title": {
+              "type": "string",
+              "description": "Section header for the Meditate column."
+            },
+            "section_learn_title": {
+              "type": "string",
+              "description": "Section header for the Learn column."
+            },
+            "section_join_title": {
+              "type": "string",
+              "description": "Section header for the Join Free Classes column."
+            },
+            "card_daily_title": {
+              "type": "string",
+              "description": "Card title for the Daily entry in the Explore block."
+            },
+            "card_daily_subtitle": {
+              "type": "string",
+              "description": "Card subtitle for the Daily entry in the Explore block."
+            },
+            "card_path_title": {
+              "type": "string",
+              "description": "Card title for the Path entry in the Explore block."
+            },
+            "card_path_subtitle": {
+              "type": "string",
+              "description": "Card subtitle for the Path entry in the Explore block."
+            },
+            "card_techniques_title": {
+              "type": "string",
+              "description": "Card title for the Techniques entry in the Explore block."
+            },
+            "card_techniques_subtitle": {
+              "type": "string",
+              "description": "Card subtitle for the Techniques entry in the Explore block."
+            },
+            "card_vibes_check_title": {
+              "type": "string",
+              "description": "Card title for the Vibes Check entry in the Explore block."
+            },
+            "card_vibes_check_subtitle": {
+              "type": "string",
+              "description": "Card subtitle for the Vibes Check entry in the Explore block."
+            },
+            "card_music_title": {
+              "type": "string",
+              "description": "Card title for the Music for Meditation entry in the Explore block."
+            },
+            "card_challenges_title": {
+              "type": "string",
+              "description": "Card title for the Challenges entry in the Explore block."
+            },
+            "card_talks_title": {
+              "type": "string",
+              "description": "Card title for the Shri Mataji Talks entry in the Explore block. Preserve the embedded line break (\\n)."
+            },
+            "card_subtle_system_title": {
+              "type": "string",
+              "description": "Card title for the Subtle System entry in the Explore block."
+            },
+            "card_who_is_title": {
+              "type": "string",
+              "description": "Card title for the 'Who is Shri Mataji' entry in the Explore block. Preserve the embedded line break (\\n)."
+            },
+            "card_what_is_title": {
+              "type": "string",
+              "description": "Card title for the 'What is Sahaja Yoga?' entry in the Explore block."
+            },
+            "card_live_online_title": {
+              "type": "string",
+              "description": "Card title for the Live Online Classes entry in the Explore block. Preserve the embedded line break (\\n)."
+            },
+            "card_find_classes_title": {
+              "type": "string",
+              "description": "Card title for the in-person class finder entry in the Explore block. Preserve the embedded line break (\\n)."
+            },
+            "card_coming_soon": {
+              "type": "string",
+              "description": "Generic 'Coming soon' badge used on locked Explore-block cards."
+            }
+          },
+          "additionalProperties": false,
+          "screenshot": "https://www.figma.com/design/JkJK5lBTjB3oSwATMGqfUt/We-Meditate-App?node-id=5878-10306"
+        },
+        "subtle_system": {
+          "type": "object",
+          "description": "Subtle System screen — interactive chakras/channels diagram. Primarily the standalone Explore subscreen (Learn section); the same strings also serve the meditation intro overlay variant. See .kiro/specs/explore-tab/subtle-system/requirements.md.",
+          "properties": {
+            "screen_label": {
+              "type": "string",
+              "description": "Eyebrow / route label for the subtle-system screen."
+            },
+            "diagram_title": {
+              "type": "string",
+              "description": "Diagram title."
+            },
+            "diagram_subtitle": {
+              "type": "string",
+              "description": "Diagram subtitle prompting the user to tap to learn more."
+            },
+            "mode_chakras": {
+              "type": "string",
+              "description": "Tab label switching the diagram to chakra view."
+            },
+            "mode_channels": {
+              "type": "string",
+              "description": "Tab label switching the diagram to channel view."
+            },
+            "front_view_mirrored": {
+              "type": "string",
+              "description": "Caption clarifying that the diagram shows a front view (left/right are mirrored relative to the viewer)."
+            },
+            "chip_right": {
+              "type": "string",
+              "description": "Filter chip label for the Right channel."
+            },
+            "chip_center": {
+              "type": "string",
+              "description": "Filter chip label for the Center channel."
+            },
+            "chip_left": {
+              "type": "string",
+              "description": "Filter chip label for the Left channel."
+            },
+            "aspect_right": {
+              "type": "string",
+              "description": "Detail label for the Right Aspect of a chakra."
+            },
+            "aspect_center": {
+              "type": "string",
+              "description": "Detail label for the Center Aspect of a chakra."
+            },
+            "aspect_left": {
+              "type": "string",
+              "description": "Detail label for the Left Aspect of a chakra."
+            }
+          },
+          "additionalProperties": false,
+          "screenshot": "https://www.figma.com/design/JkJK5lBTjB3oSwATMGqfUt/We-Meditate-App?node-id=7307-83858"
+        },
+        "talks_intro": {
+          "type": "object",
+          "description": "Shri Mataji talks intro / inline placement copy — used on the standalone talks screen intro AND on the post-first-meditation talk card during onboarding (see post_first_meditation_* keys).",
+          "properties": {
+            "unavailable": {
+              "type": "string",
+              "description": "Inline message when a talk is temporarily unavailable to play."
+            },
+            "title": {
+              "type": "string",
+              "description": "Title of the talks intro screen."
+            },
+            "generic_description": {
+              "type": "string",
+              "description": "Long-form description of Shri Mataji and Sahaja Yoga used as fallback intro copy when a specific talk-clip description is unavailable."
+            },
+            "clip_description": {
+              "type": "string",
+              "description": "Short clip-level description shown before a specific talk clip starts."
+            },
+            "post_first_meditation_name": {
+              "type": "string",
+              "description": "Speaker name shown on the talk card placed after the first meditation (e.g. 'Shri Mataji,'). The trailing comma is intentional — it precedes the role line."
+            },
+            "post_first_meditation_subtitle": {
+              "type": "string",
+              "description": "Speaker role/subtitle on the post-first-meditation talk card (e.g. 'The founder of Sahaja Yoga')."
+            },
+            "post_first_meditation_description": {
+              "type": "string",
+              "description": "Body copy on the post-first-meditation talk card."
+            },
+            "start": {
+              "type": "string",
+              "description": "Primary CTA that begins the talk."
+            },
+            "maybe_later": {
+              "type": "string",
+              "description": "Decline CTA on the post-first-meditation talk card."
+            },
+            "watch_now": {
+              "type": "string",
+              "description": "Alternative CTA used on inline talk placements."
+            }
+          },
+          "additionalProperties": false
+        },
+        "talks_list": {
+          "type": "object",
+          "description": "Standalone Shri Mataji talks list screen (Explore -> Talks of Shri Mataji). See .kiro/specs/explore-tab/shri-mataji-talks/requirements.md.",
+          "properties": {
+            "screen_title": {
+              "type": "string",
+              "description": "Eyebrow / route title for the talks list screen (typically uppercase)."
+            },
+            "section_title": {
+              "type": "string",
+              "description": "Section title above the list."
+            },
+            "description": {
+              "type": "string",
+              "description": "Section description above the list."
+            },
+            "all_tags": {
+              "type": "string",
+              "description": "Default filter chip label ('All tags')."
+            },
+            "learn_more": {
+              "type": "string",
+              "description": "Inline link/CTA opening more information about a talk."
+            },
+            "start": {
+              "type": "string",
+              "description": "Card CTA that begins a talk."
+            },
+            "watched": {
+              "type": "string",
+              "description": "Status label shown on talks that the user has already watched."
+            }
+          },
+          "additionalProperties": false,
+          "screenshot": "https://www.figma.com/design/JkJK5lBTjB3oSwATMGqfUt/We-Meditate-App?node-id=2359-6059"
+        },
+        "talks_player": {
+          "type": "object",
+          "description": "Shri Mataji talks player controls and subtitle picker — shared across all talk playback surfaces.",
+          "properties": {
+            "unavailable": {
+              "type": "string",
+              "description": "Error message shown when the player cannot load the requested talk."
+            },
+            "play": {
+              "type": "string",
+              "description": "Player play-control label."
+            },
+            "pause": {
+              "type": "string",
+              "description": "Player pause-control label."
+            },
+            "replay": {
+              "type": "string",
+              "description": "Player replay-control label."
+            },
+            "subtitles_title": {
+              "type": "string",
+              "description": "Title of the subtitles bottom sheet."
+            },
+            "subtitles_off": {
+              "type": "string",
+              "description": "Subtitles option label disabling captions."
+            },
+            "subtitles_english": {
+              "type": "string",
+              "description": "Subtitles language label — English."
+            },
+            "subtitles_turkish": {
+              "type": "string",
+              "description": "Subtitles language label — Turkish."
+            },
+            "subtitles_bulgarian": {
+              "type": "string",
+              "description": "Subtitles language label — Bulgarian."
+            },
+            "subtitles_portuguese_brazil": {
+              "type": "string",
+              "description": "Subtitles language label — Brazilian Portuguese."
+            },
+            "subtitles_french": {
+              "type": "string",
+              "description": "Subtitles language label — French."
+            },
+            "subtitles_spanish": {
+              "type": "string",
+              "description": "Subtitles language label — Spanish."
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    "profile": {
+      "type": "object",
+      "description": "Profile tab — bottom-nav index 3. Personal area: identity summary, favourites/history activity lists, account settings (with edit/reset/delete bottom sheets), Privacy & advertising settings, and the contact-us feedback form. See .kiro/specs/profile-tab/requirements.md.",
+      "properties": {
+        "main": {
+          "type": "object",
+          "description": "Profile tab main screen — settings entries, favourites preview, joined-date copy, and the Privacy & advertising entry.",
+          "properties": {
+            "favourites_header": {
+              "type": "string",
+              "description": "Eyebrow above the favourites preview block on Profile (typically uppercase)."
+            },
+            "see_all": {
+              "type": "string",
+              "description": "Inline link expanding a preview block to its full screen."
+            },
+            "no_favourites_title": {
+              "type": "string",
+              "description": "Empty-state title in the favourites preview block."
+            },
+            "no_favourites_subtitle": {
+              "type": "string",
+              "description": "Empty-state subtitle in the favourites preview block."
+            },
+            "history_title": {
+              "type": "string",
+              "description": "Title of the History entry in the Profile menu."
+            },
+            "history_subtitle": {
+              "type": "string",
+              "description": "Subtitle of the History entry in the Profile menu."
+            },
+            "account_title": {
+              "type": "string",
+              "description": "Title of the Account entry in the Profile menu."
+            },
+            "account_subtitle": {
+              "type": "string",
+              "description": "Subtitle of the Account entry in the Profile menu."
+            },
+            "privacy_and_advertising_title": {
+              "type": "string",
+              "description": "Title of the Privacy & advertising entry in the Profile menu — opens the consent settings screen (see consent.settings)."
+            },
+            "privacy_and_advertising_subtitle": {
+              "type": "string",
+              "description": "Subtitle of the Privacy & advertising entry in the Profile menu."
+            },
+            "feedback_header": {
+              "type": "string",
+              "description": "Eyebrow above the feedback block on Profile (typically uppercase)."
+            },
+            "contact_title": {
+              "type": "string",
+              "description": "Title of the Contact us entry in the Profile menu."
+            },
+            "contact_subtitle": {
+              "type": "string",
+              "description": "Subtitle of the Contact us entry in the Profile menu."
+            },
+            "joined_fallback": {
+              "type": "string",
+              "description": "Fallback joined-date string when no usable creation timestamp is available."
+            },
+            "joined_one_month": {
+              "type": "string",
+              "description": "Joined-date string for exactly one month ago (singular)."
+            },
+            "joined_months": {
+              "type": "string",
+              "description": "Joined-date string for the multi-month range. MUST preserve the {months} placeholder — it is replaced at runtime with the month count."
+            },
+            "joined_less_than_year": {
+              "type": "string",
+              "description": "Joined-date string for less than a year ago (fallback before the months-since helper)."
+            },
+            "joined_one_year": {
+              "type": "string",
+              "description": "Joined-date string for exactly one year ago (singular)."
+            },
+            "joined_years": {
+              "type": "string",
+              "description": "Joined-date string for multiple years ago. MUST preserve the {years} placeholder — it is replaced at runtime with the year count."
+            }
+          },
+          "additionalProperties": false,
+          "screenshot": "https://www.figma.com/design/JkJK5lBTjB3oSwATMGqfUt/We-Meditate-App?node-id=7611-1453777"
+        },
+        "favourites": {
+          "type": "object",
+          "description": "Profile → Favourites screen.",
+          "properties": {
+            "title": {
+              "type": "string",
+              "description": "Screen title (typically uppercase)."
+            },
+            "removed_from_favourites": {
+              "type": "string",
+              "description": "Snackbar shown after a favourite is removed (paired with the global Undo action from the general group)."
+            }
+          },
+          "additionalProperties": false,
+          "screenshot": "https://www.figma.com/design/JkJK5lBTjB3oSwATMGqfUt/We-Meditate-App?node-id=9150-87479"
+        },
+        "history": {
+          "type": "object",
+          "description": "Profile → History screen.",
+          "properties": {
+            "title": {
+              "type": "string",
+              "description": "Screen title (typically uppercase)."
+            },
+            "empty_title": {
+              "type": "string",
+              "description": "Empty-state title when the user has no history entries."
+            },
+            "empty_subtitle": {
+              "type": "string",
+              "description": "Empty-state subtitle when the user has no history entries."
+            }
+          },
+          "additionalProperties": false,
+          "screenshot": "https://www.figma.com/design/JkJK5lBTjB3oSwATMGqfUt/We-Meditate-App?node-id=7615-1623198"
+        },
+        "account": {
+          "type": "object",
+          "description": "Profile → Account settings screen — edit name/email, change password, delete account.",
+          "properties": {
+            "title": {
+              "type": "string",
+              "description": "Screen title."
+            },
+            "details_header": {
+              "type": "string",
+              "description": "Eyebrow above the details block (typically uppercase)."
+            },
+            "name_label": {
+              "type": "string",
+              "description": "Label for the name input."
+            },
+            "name_hint": {
+              "type": "string",
+              "description": "Placeholder hint for the name input."
+            },
+            "save": {
+              "type": "string",
+              "description": "Save CTA used on inline forms."
+            },
+            "saving": {
+              "type": "string",
+              "description": "Loading-state label shown on the Save CTA while saving."
+            },
+            "saved": {
+              "type": "string",
+              "description": "Confirmation toast shown after settings are saved."
+            },
+            "first_name_label": {
+              "type": "string",
+              "description": "Label used by the dedicated first-name edit row."
+            },
+            "email_label": {
+              "type": "string",
+              "description": "Label used by the email row."
+            },
+            "password_label": {
+              "type": "string",
+              "description": "Label used by the password row."
+            },
+            "edit_action": {
+              "type": "string",
+              "description": "Edit CTA used on read-only rows that open an edit modal."
+            },
+            "edit_first_name_title": {
+              "type": "string",
+              "description": "Title of the edit-first-name modal."
+            },
+            "edit_email_title": {
+              "type": "string",
+              "description": "Title of the edit-email modal."
+            },
+            "cancel": {
+              "type": "string",
+              "description": "Cancel CTA used in edit modals."
+            },
+            "save_changes": {
+              "type": "string",
+              "description": "Primary CTA in edit modals."
+            },
+            "save_failed": {
+              "type": "string",
+              "description": "Error shown when saving account settings fails."
+            },
+            "reset_password_title": {
+              "type": "string",
+              "description": "Title of the reset-password modal."
+            },
+            "reset_password_description": {
+              "type": "string",
+              "description": "Body copy of the reset-password modal."
+            },
+            "reset_password_action": {
+              "type": "string",
+              "description": "Primary CTA in the reset-password modal."
+            },
+            "reset_password_sent": {
+              "type": "string",
+              "description": "Confirmation toast shown after the reset link has been emailed."
+            },
+            "reset_password_error": {
+              "type": "string",
+              "description": "Error shown when sending the reset link fails."
+            },
+            "email_edit_unavailable": {
+              "type": "string",
+              "description": "Toast shown when email editing is not yet available."
+            },
+            "email_unavailable": {
+              "type": "string",
+              "description": "Inline placeholder shown when no email is available for the account."
+            },
+            "create_account": {
+              "type": "string",
+              "description": "CTA shown for guest users prompting them to create an account."
+            },
+            "delete_account_title": {
+              "type": "string",
+              "description": "Title of the delete-account confirmation."
+            },
+            "delete_account_description": {
+              "type": "string",
+              "description": "Body copy of the delete-account confirmation."
+            },
+            "delete_account_error": {
+              "type": "string",
+              "description": "Error shown when delete-account fails."
+            },
+            "delete_account_requires_recent_login": {
+              "type": "string",
+              "description": "Error shown when delete-account requires the user to log in again first."
+            },
+            "reauthenticate_title": {
+              "type": "string",
+              "description": "Title of the password re-entry modal used before destructive actions."
+            },
+            "reauthenticate_description": {
+              "type": "string",
+              "description": "Body copy of the password re-entry modal."
+            },
+            "reauthenticate_required": {
+              "type": "string",
+              "description": "Validation error shown when the password field is empty in the re-entry modal."
+            },
+            "reauthenticate_invalid": {
+              "type": "string",
+              "description": "Error shown when the re-entered password is incorrect."
+            },
+            "continue_action": {
+              "type": "string",
+              "description": "Primary CTA on the password re-entry modal."
+            },
+            "guest_email_prompt": {
+              "type": "string",
+              "description": "Inline prompt shown on the email row for guest users."
+            },
+            "guest_password_prompt": {
+              "type": "string",
+              "description": "Inline prompt shown on the password row for guest users."
+            },
+            "login": {
+              "type": "string",
+              "description": "Login CTA used in the guest prompts."
+            },
+            "logout": {
+              "type": "string",
+              "description": "Logout CTA in the account screen."
+            },
+            "privacy_policy": {
+              "type": "string",
+              "description": "Inline link opening the Privacy Policy webview from the account screen."
+            },
+            "delete_account": {
+              "type": "string",
+              "description": "Destructive CTA opening the delete-account flow."
+            }
+          },
+          "additionalProperties": false,
+          "screenshot": "https://www.figma.com/design/JkJK5lBTjB3oSwATMGqfUt/We-Meditate-App?node-id=9159-89387"
+        },
+        "privacy_advertising": {
+          "type": "object",
+          "description": "Profile -> Privacy & advertising settings screen — two toggle sections (anonymous product analytics, advertising measurement). Drives productAnalyticsOptOut and adsMarketingConsent. Reached from the Privacy & advertising row on profile.main. See .kiro/specs/analytics-simplified/05-flutter-implementation.md §2 and §8. Figma: node-id 11571-40337.",
+          "properties": {
+            "screen_title": {
+              "type": "string",
+              "description": "Screen title (e.g. 'Help spread the word and make the app better')."
+            },
+            "status_allowed": {
+              "type": "string",
+              "description": "Status label shown next to a toggle that is currently allowed. MUST preserve the {date} placeholder — it is replaced at runtime with the localized date of the most recent consent decision (e.g. '16 May 2026')."
+            },
+            "status_not_allowed": {
+              "type": "string",
+              "description": "Status label shown next to a toggle that is currently disallowed."
+            },
+            "product_analytics_title": {
+              "type": "string",
+              "description": "Section title for the anonymous product analytics toggle (e.g. 'Anonymous product analytics'). Drives productAnalyticsOptOut."
+            },
+            "product_analytics_description": {
+              "type": "string",
+              "description": "Section body explaining anonymous product analytics: we log aggregated usage data to fix bugs and improve We Meditate, no individual data, no advertisers, no user profile. Must remain consistent with the TelemetryDeck posture in analytics-simplified/01-strategy.md §4."
+            },
+            "advertising_title": {
+              "type": "string",
+              "description": "Section title for the advertising-measurement toggle (e.g. 'Advertising measurement and improvement'). Drives adsMarketingConsent."
+            },
+            "advertising_body_intro_prefix": {
+              "type": "string",
+              "description": "First paragraph prefix of the advertising section; combined inline with advertising_body_intro_link and advertising_body_intro_suffix. Include any trailing space."
+            },
+            "advertising_body_intro_link": {
+              "type": "string",
+              "description": "Inline link text inside the first paragraph (e.g. 'what we share'). Tapping opens the same 'what we share' detail used by the ad consent modal."
+            },
+            "advertising_body_intro_suffix": {
+              "type": "string",
+              "description": "First paragraph suffix completing the sentence after the inline link. Include the leading separator if needed."
+            },
+            "advertising_body_benefits": {
+              "type": "string",
+              "description": "Second paragraph of the advertising section: how granting consent helps WeMeditate use donations responsibly, improve campaigns, suppress ads to existing users, and reach similar people."
+            },
+            "advertising_body_never_share": {
+              "type": "string",
+              "description": "Third paragraph of the advertising section reiterating the never-shared categories (mood, goals, hand sensations, reflections, class location, spiritual-practice details). Must remain consistent with analytics-simplified/03-marketing-event-taxonomy.md §2."
+            },
+            "advertising_body_change_hint": {
+              "type": "string",
+              "description": "Fourth paragraph of the advertising section explaining that the user can change their choice anytime using the toggle at the top of this screen."
+            },
+            "advertising_platforms_header": {
+              "type": "string",
+              "description": "Sub-section header listing current advertising platforms (e.g. 'Current advertising platforms')."
+            },
+            "advertising_platform_meta": {
+              "type": "string",
+              "description": "Bullet item for Meta (Facebook + Instagram + Audience Network). Brand name — usually kept as 'Meta'."
+            },
+            "advertising_platform_google_ads": {
+              "type": "string",
+              "description": "Bullet item for Google Ads. Brand name — usually kept as 'Google Ads'."
+            },
+            "advertising_platform_apple_search_ads": {
+              "type": "string",
+              "description": "Bullet item for Apple Search Ads. Brand name — usually kept as 'Apple Search Ads'."
+            }
+          },
+          "additionalProperties": false,
+          "screenshot": "https://www.figma.com/design/JkJK5lBTjB3oSwATMGqfUt/We-Meditate-App?node-id=11571-40337"
+        },
+        "contact": {
+          "type": "object",
+          "description": "Profile → Contact us screen — free-text feedback form. The text itself is first-party only — it never reaches the ad path.",
+          "properties": {
+            "title": {
+              "type": "string",
+              "description": "Screen title (typically uppercase)."
+            },
+            "header": {
+              "type": "string",
+              "description": "Hero copy above the form."
+            },
+            "subtitle": {
+              "type": "string",
+              "description": "Subtitle below the hero copy."
+            },
+            "placeholder": {
+              "type": "string",
+              "description": "Input field placeholder hint for the feedback text area."
+            },
+            "send": {
+              "type": "string",
+              "description": "Submit CTA on the form."
+            },
+            "sending": {
+              "type": "string",
+              "description": "Loading-state label shown on the Submit CTA while sending."
+            },
+            "sent": {
+              "type": "string",
+              "description": "Confirmation toast shown after the feedback is sent."
+            },
+            "empty_error": {
+              "type": "string",
+              "description": "Validation error shown when the feedback field is empty."
+            },
+            "min_length_error": {
+              "type": "string",
+              "description": "Validation error shown when the feedback is shorter than the minimum length (50 characters)."
+            },
+            "send_error": {
+              "type": "string",
+              "description": "Error shown when sending the feedback fails."
+            }
+          },
+          "additionalProperties": false,
+          "screenshot": "https://www.figma.com/design/JkJK5lBTjB3oSwATMGqfUt/We-Meditate-App?node-id=9159-89388"
+        }
+      },
+      "additionalProperties": false
+    },
+    "meditation": {
+      "type": "object",
+      "description": "Cross-cutting meditation flow — pre-meditation intent chooser, reminder system, the optional footsoak step, the player itself, Vibes Check (post-first-meditation), and the post-meditation feedback form. Reached from Daily / Path / Explore / Profile / Home cards. See .kiro/specs/meditation-player/requirements.md.",
+      "properties": {
+        "intent": {
+          "type": "object",
+          "description": "Pre-meditation intent flow — time-of-day chooser, quick vs. personalised cards, first-meditation cards, locked-state previews, and the entry CTA for the reminder flow. Reached when the user taps Start meditation on Daily or selects the Daily card from Explore.",
+          "properties": {
+            "carousel_continue": {
+              "type": "string",
+              "description": "Continue CTA on the intent carousel."
+            },
+            "skip_video_and_continue": {
+              "type": "string",
+              "description": "Skip-link shown over the intent video that lets the user proceed without watching."
+            },
+            "repeat_video": {
+              "type": "string",
+              "description": "Replay-link shown after the intent video ends."
+            },
+            "start_meditation": {
+              "type": "string",
+              "description": "Primary CTA that starts the actual meditation after the intent flow."
+            },
+            "skip_and_explore_the_app": {
+              "type": "string",
+              "description": "Tertiary CTA letting a new user skip the first meditation and just browse the app. Tied to the onboarding_ready_action / skip_and_explore_app_press analytics event."
+            },
+            "step_label": {
+              "type": "string",
+              "description": "Step indicator (e.g. 'Step 1 of 3') at the top of the intent flow."
+            },
+            "title_today": {
+              "type": "string",
+              "description": "Intent screen title shown during the day. Preserve the embedded line break (\\n)."
+            },
+            "title_tonight": {
+              "type": "string",
+              "description": "Intent screen title shown in the evening. Preserve the embedded line break (\\n)."
+            },
+            "first_meditation_title": {
+              "type": "string",
+              "description": "Title of the locked first-meditation card before activation."
+            },
+            "first_meditation_subtitle": {
+              "type": "string",
+              "description": "Subtitle of the locked first-meditation card."
+            },
+            "repeat_first_meditation_title": {
+              "type": "string",
+              "description": "Title shown when a returning user is invited to repeat the first meditation."
+            },
+            "repeat_first_meditation_subtitle": {
+              "type": "string",
+              "description": "Subtitle shown when a returning user is invited to repeat the first meditation."
+            },
+            "ready_to_try_title": {
+              "type": "string",
+              "description": "Title shown on the 'ready to try?' confirmation step before starting the first meditation."
+            },
+            "ready_to_try_subtitle_beginner": {
+              "type": "string",
+              "description": "Subtitle for the 'ready to try?' step, beginner variant."
+            },
+            "ready_to_try_subtitle_repeat": {
+              "type": "string",
+              "description": "Subtitle for the 'ready to try?' step, repeat variant."
+            },
+            "quick_morning_title": {
+              "type": "string",
+              "description": "Title of the morning quick-meditation card in the intent flow."
+            },
+            "quick_afternoon_title": {
+              "type": "string",
+              "description": "Title of the afternoon quick-meditation card in the intent flow."
+            },
+            "quick_evening_title": {
+              "type": "string",
+              "description": "Title of the evening quick-meditation card in the intent flow."
+            },
+            "quick_morning_subtitle": {
+              "type": "string",
+              "description": "Subtitle of the morning quick-meditation card."
+            },
+            "quick_afternoon_subtitle": {
+              "type": "string",
+              "description": "Subtitle of the afternoon quick-meditation card. Preserve the embedded line break (\\n)."
+            },
+            "quick_evening_subtitle": {
+              "type": "string",
+              "description": "Subtitle of the evening quick-meditation card."
+            },
+            "personalized_title": {
+              "type": "string",
+              "description": "Title of the personalised long-session card in the intent flow."
+            },
+            "personalized_subtitle": {
+              "type": "string",
+              "description": "Subtitle of the personalised long-session card."
+            },
+            "locked_subtitle": {
+              "type": "string",
+              "description": "Subtitle shown on cards that are locked until the user completes their first meditation."
+            },
+            "learn_more": {
+              "type": "string",
+              "description": "Inline link/CTA used on intent-flow cards to view more detail."
+            },
+            "go_to_first_meditation": {
+              "type": "string",
+              "description": "CTA on a locked card that takes the user back to the first meditation flow."
+            },
+            "set_reminder_for_later": {
+              "type": "string",
+              "description": "CTA opening the 'schedule for later' bottom sheet."
+            },
+            "locked_quick_start_title": {
+              "type": "string",
+              "description": "Title shown in the locked-preview card for Quick meditations (‘Start right away’)."
+            },
+            "locked_quick_start_description_morning": {
+              "type": "string",
+              "description": "Locked-preview description for morning Quick meditations."
+            },
+            "locked_quick_start_description_afternoon": {
+              "type": "string",
+              "description": "Locked-preview description for afternoon Quick meditations."
+            },
+            "locked_quick_start_description_evening": {
+              "type": "string",
+              "description": "Locked-preview description for evening Quick meditations."
+            },
+            "locked_quick_custom_time_title": {
+              "type": "string",
+              "description": "Title of the custom-time row in the Quick locked preview."
+            },
+            "locked_quick_custom_time_description": {
+              "type": "string",
+              "description": "Description of the custom-time row in the Quick locked preview."
+            },
+            "locked_personalized_feeling_title": {
+              "type": "string",
+              "description": "Title of the feeling-picker row in the Personalised locked preview."
+            },
+            "locked_personalized_feeling_description": {
+              "type": "string",
+              "description": "Description of the feeling-picker row in the Personalised locked preview."
+            },
+            "locked_personalized_custom_time_title": {
+              "type": "string",
+              "description": "Title of the custom-time row in the Personalised locked preview."
+            },
+            "locked_personalized_custom_time_description": {
+              "type": "string",
+              "description": "Description of the custom-time row in the Personalised locked preview."
+            }
+          },
+          "additionalProperties": false
+        },
+        "reminder": {
+          "type": "object",
+          "description": "Meditation reminder system — prompt that suggests scheduling the meditation for later, time presets, the bottom sheet flow, the OS notification-permission rationale, and the local notification copy itself. Triggered from the intent screen via set_reminder_for_later.",
+          "properties": {
+            "prompt_title": {
+              "type": "string",
+              "description": "Title of the prompt that suggests scheduling the first meditation for later. Preserve the embedded line break (\\n)."
+            },
+            "prompt_subtitle": {
+              "type": "string",
+              "description": "Subtitle of the same scheduling prompt. Preserve the embedded line break (\\n)."
+            },
+            "prompt_set_reminder": {
+              "type": "string",
+              "description": "Primary CTA on the scheduling prompt."
+            },
+            "prompt_no_thanks": {
+              "type": "string",
+              "description": "Decline CTA on the scheduling prompt."
+            },
+            "prompt_allow_notifications_title": {
+              "type": "string",
+              "description": "Title of the rationale screen explaining why notification permission is needed before showing the OS prompt."
+            },
+            "prompt_allow_notifications_subtitle": {
+              "type": "string",
+              "description": "Subtitle of the same rationale screen. References the wording on the next (OS) screen — keep 'Allow' consistent with the OS prompt translation if locale-specific."
+            },
+            "prompt_allow_notifications_primary": {
+              "type": "string",
+              "description": "Primary CTA on the notification-rationale screen that triggers the OS permission prompt."
+            },
+            "prompt_not_now": {
+              "type": "string",
+              "description": "Decline CTA on the notification-rationale screen."
+            },
+            "prompt_turn_on_notifications_title": {
+              "type": "string",
+              "description": "Title shown when notifications were previously denied and need to be re-enabled from OS Settings."
+            },
+            "prompt_turn_on_notifications_subtitle": {
+              "type": "string",
+              "description": "Subtitle of the same 'open Settings' prompt."
+            },
+            "prompt_open_settings": {
+              "type": "string",
+              "description": "CTA that deep-links to the app’s OS notification settings."
+            },
+            "sheet_title": {
+              "type": "string",
+              "description": "Title of the bottom sheet where the user picks a reminder time. Preserve the embedded line break (\\n)."
+            },
+            "sheet_dont_set": {
+              "type": "string",
+              "description": "Dismiss action on the reminder bottom sheet."
+            },
+            "sheet_done": {
+              "type": "string",
+              "description": "Confirm CTA on the reminder bottom sheet."
+            },
+            "sheet_return_to_meditation": {
+              "type": "string",
+              "description": "CTA letting the user return to the meditation flow from the reminder sheet."
+            },
+            "sheet_leave_meditation": {
+              "type": "string",
+              "description": "CTA letting the user exit the meditation flow from the reminder sheet."
+            },
+            "sheet_success_title": {
+              "type": "string",
+              "description": "Title of the success confirmation after a reminder is scheduled."
+            },
+            "sheet_success_subtitle": {
+              "type": "string",
+              "description": "Subtitle of the success confirmation after a reminder is scheduled."
+            },
+            "sheet_explore_app": {
+              "type": "string",
+              "description": "CTA on the success confirmation suggesting the user explores the app while waiting."
+            },
+            "sheet_start_first_meditation": {
+              "type": "string",
+              "description": "CTA on the success confirmation suggesting the user starts the first meditation immediately instead."
+            },
+            "sheet_error": {
+              "type": "string",
+              "description": "Error toast shown when scheduling the reminder fails."
+            },
+            "preset_unwind_later_today": {
+              "type": "string",
+              "description": "Preset chip label suggesting a reminder later the same day."
+            },
+            "preset_start_your_week_calm": {
+              "type": "string",
+              "description": "Preset chip label suggesting a reminder at the start of the week."
+            },
+            "preset_find_your_midweek_balance": {
+              "type": "string",
+              "description": "Preset chip label suggesting a reminder midweek."
+            },
+            "preset_pause_and_recharge": {
+              "type": "string",
+              "description": "Preset chip label suggesting a recharge break."
+            },
+            "preset_mindful_break_before_weekend": {
+              "type": "string",
+              "description": "Preset chip label suggesting a reminder before the weekend."
+            },
+            "preset_end_your_week_with_peace": {
+              "type": "string",
+              "description": "Preset chip label suggesting a reminder at the end of the work week."
+            },
+            "preset_slow_down_weekend": {
+              "type": "string",
+              "description": "Preset chip label suggesting a weekend slow-down reminder."
+            },
+            "preset_reset_for_week_ahead": {
+              "type": "string",
+              "description": "Preset chip label suggesting a Sunday reset reminder."
+            },
+            "notification_title": {
+              "type": "string",
+              "description": "Title of the scheduled local notification used by the generic meditation reminder."
+            },
+            "notification_body_locked": {
+              "type": "string",
+              "description": "Notification body used when the meditation is still locked at the time the reminder fires."
+            },
+            "notification_body_exit": {
+              "type": "string",
+              "description": "Notification body used when the reminder is for a previously exited meditation."
+            },
+            "allow_notifications_screen_title": {
+              "type": "string",
+              "description": "Title of the dedicated full-screen rationale used when reminder scheduling requires notification permission."
+            },
+            "allow_notifications_screen_subtitle": {
+              "type": "string",
+              "description": "Subtitle of the same full-screen rationale. Preserve the embedded line break (\\n) and the trailing sparkle emoji (✨) if used in copy."
+            }
+          },
+          "additionalProperties": false
+        },
+        "footsoak": {
+          "type": "object",
+          "description": "Step 3 of 3 in the meditation intro: invites the user to do an optional foot-soak before meditating.",
+          "properties": {
+            "step_label": {
+              "type": "string",
+              "description": "Step indicator (e.g. 'Step 3 of 3') at the top of the foot-soak screen."
+            },
+            "title": {
+              "type": "string",
+              "description": "Screen title asking whether the user wants to foot-soak with this meditation."
+            },
+            "description_prefix": {
+              "type": "string",
+              "description": "Body-copy prefix; combined inline with description_emphasis and description_suffix to form a single sentence. Include trailing space if the locale needs one."
+            },
+            "description_emphasis": {
+              "type": "string",
+              "description": "Emphasised word in the foot-soak body copy, typically rendered in italic or bold (e.g. 'really')."
+            },
+            "description_suffix": {
+              "type": "string",
+              "description": "Body-copy suffix completing the foot-soak description sentence. Include the leading space."
+            },
+            "tutorial_cta": {
+              "type": "string",
+              "description": "Inline link/CTA opening the foot-soak tutorial."
+            },
+            "start_with_footsoak": {
+              "type": "string",
+              "description": "Primary CTA that starts the meditation with a foot-soak."
+            },
+            "start_meditation": {
+              "type": "string",
+              "description": "Secondary CTA that starts the meditation without a foot-soak."
+            }
+          },
+          "additionalProperties": false
+        },
+        "player": {
+          "type": "object",
+          "description": "Meditation audio player (voice + background music). v1 only carries an error title; controls are pictographic.",
+          "properties": {
+            "load_error_title": {
+              "type": "string",
+              "description": "Error title shown when the meditation track fails to load in the player."
+            }
+          },
+          "additionalProperties": false,
+          "screenshot": "https://www.figma.com/design/JkJK5lBTjB3oSwATMGqfUt/We-Meditate-App?node-id=7461-1119009"
+        },
+        "vibes_check": {
+          "type": "object",
+          "description": "Vibes Check post-meditation flow: asks what the user felt on each hand. Strictly first-party copy — the raw selections never ship in analytics (see analytics-simplified/02-product-event-taxonomy.md).",
+          "properties": {
+            "intro_question": {
+              "type": "string",
+              "description": "Initial Vibes Check question shown before the per-hand prompt. Preserve the embedded line break (\\n)."
+            },
+            "question_prefix": {
+              "type": "string",
+              "description": "Per-hand question prefix; combined with left_hand or right_hand and question_suffix to form the full prompt (e.g. 'What do you feel on your left hand?'). Preserve the trailing line break (\\n)."
+            },
+            "question_suffix": {
+              "type": "string",
+              "description": "Per-hand question suffix (typically ' hand?'). Include the leading space."
+            },
+            "left_hand": {
+              "type": "string",
+              "description": "Inline noun for the left hand, plugged into the per-hand question template."
+            },
+            "right_hand": {
+              "type": "string",
+              "description": "Inline noun for the right hand, plugged into the per-hand question template."
+            },
+            "cool": {
+              "type": "string",
+              "description": "Selectable sensation: cool. Maps to raw selection 'cool' (first-party storage only)."
+            },
+            "warm": {
+              "type": "string",
+              "description": "Selectable sensation: warm."
+            },
+            "fingers_tingling": {
+              "type": "string",
+              "description": "Selectable sensation: fingers tingling."
+            },
+            "nothing": {
+              "type": "string",
+              "description": "Selectable sensation: nothing felt."
+            },
+            "continue_action": {
+              "type": "string",
+              "description": "Primary CTA to confirm the current Vibes Check answer and continue."
+            },
+            "not_sure": {
+              "type": "string",
+              "description": "Skip-like CTA used when the user is unsure what they felt. Maps to derived firstMedExperience = not_sure."
+            },
+            "got_it": {
+              "type": "string",
+              "description": "Acknowledge CTA at the end of the Vibes Check explanation."
+            },
+            "interpretation_nothing": {
+              "type": "string",
+              "description": "Reassurance shown when the user selects 'nothing' for both hands."
+            },
+            "interpretation_intro": {
+              "type": "string",
+              "description": "Intro line of the Vibes Check interpretation screen."
+            },
+            "interpretation_detail": {
+              "type": "string",
+              "description": "Per-hand detail copy in the Vibes Check interpretation screen."
+            },
+            "skip_vibes_check": {
+              "type": "string",
+              "description": "Inline action that opens the skip-confirmation prompt."
+            },
+            "skip_prompt_title": {
+              "type": "string",
+              "description": "Title of the skip-confirmation prompt."
+            },
+            "skip_prompt_description": {
+              "type": "string",
+              "description": "Body copy of the skip-confirmation prompt."
+            },
+            "back_to_explanation": {
+              "type": "string",
+              "description": "CTA returning the user from the skip prompt to the Vibes Check explanation."
+            },
+            "return_to_meditation_prompt_title": {
+              "type": "string",
+              "description": "Title of the prompt offering to restart the first meditation from the beginning."
+            },
+            "return_to_meditation_prompt_description": {
+              "type": "string",
+              "description": "Body copy of the same restart prompt."
+            },
+            "return_to_meditation_action": {
+              "type": "string",
+              "description": "Primary CTA on the restart prompt."
+            },
+            "skip_it": {
+              "type": "string",
+              "description": "Decline CTA on the restart prompt."
+            }
+          },
+          "additionalProperties": false,
+          "screenshot": "https://www.figma.com/design/JkJK5lBTjB3oSwATMGqfUt/We-Meditate-App?node-id=5390-8159"
+        },
+        "feedback": {
+          "type": "object",
+          "description": "Generic post-meditation free-text feedback form. Currently dormant in code per the meditation-player spec but kept for the planned reinstatement. The text is first-party only — it never reaches the ad path.",
           "properties": {
             "title": {
               "type": "string",
@@ -1821,468 +2245,44 @@
       },
       "additionalProperties": false
     },
-    "profile": {
+    "navigation": {
       "type": "object",
-      "description": "Profile tab — main menu (with the Privacy & advertising entry point), history, favourites, account settings, and contact us.",
+      "description": "Bottom navigation bar tab labels.",
       "properties": {
-        "main": {
-          "type": "object",
-          "description": "Profile tab main screen — settings entries, favourites preview, joined-date copy, and the Privacy & advertising entry.",
-          "properties": {
-            "favourites_header": {
-              "type": "string",
-              "description": "Eyebrow above the favourites preview block on Profile (typically uppercase)."
-            },
-            "see_all": {
-              "type": "string",
-              "description": "Inline link expanding a preview block to its full screen."
-            },
-            "no_favourites_title": {
-              "type": "string",
-              "description": "Empty-state title in the favourites preview block."
-            },
-            "no_favourites_subtitle": {
-              "type": "string",
-              "description": "Empty-state subtitle in the favourites preview block."
-            },
-            "history_title": {
-              "type": "string",
-              "description": "Title of the History entry in the Profile menu."
-            },
-            "history_subtitle": {
-              "type": "string",
-              "description": "Subtitle of the History entry in the Profile menu."
-            },
-            "account_title": {
-              "type": "string",
-              "description": "Title of the Account entry in the Profile menu."
-            },
-            "account_subtitle": {
-              "type": "string",
-              "description": "Subtitle of the Account entry in the Profile menu."
-            },
-            "privacy_and_advertising_title": {
-              "type": "string",
-              "description": "Title of the Privacy & advertising entry in the Profile menu — opens the consent settings screen (see consent.settings)."
-            },
-            "privacy_and_advertising_subtitle": {
-              "type": "string",
-              "description": "Subtitle of the Privacy & advertising entry in the Profile menu."
-            },
-            "feedback_header": {
-              "type": "string",
-              "description": "Eyebrow above the feedback block on Profile (typically uppercase)."
-            },
-            "contact_title": {
-              "type": "string",
-              "description": "Title of the Contact us entry in the Profile menu."
-            },
-            "contact_subtitle": {
-              "type": "string",
-              "description": "Subtitle of the Contact us entry in the Profile menu."
-            },
-            "joined_fallback": {
-              "type": "string",
-              "description": "Fallback joined-date string when no usable creation timestamp is available."
-            },
-            "joined_one_month": {
-              "type": "string",
-              "description": "Joined-date string for exactly one month ago (singular)."
-            },
-            "joined_months": {
-              "type": "string",
-              "description": "Joined-date string for the multi-month range. MUST preserve the {months} placeholder — it is replaced at runtime with the month count."
-            },
-            "joined_less_than_year": {
-              "type": "string",
-              "description": "Joined-date string for less than a year ago (fallback before the months-since helper)."
-            },
-            "joined_one_year": {
-              "type": "string",
-              "description": "Joined-date string for exactly one year ago (singular)."
-            },
-            "joined_years": {
-              "type": "string",
-              "description": "Joined-date string for multiple years ago. MUST preserve the {years} placeholder — it is replaced at runtime with the year count."
-            }
-          },
-          "additionalProperties": false,
-          "screenshot": "https://www.figma.com/design/JkJK5lBTjB3oSwATMGqfUt/We-Meditate-App?node-id=7611-1453777"
+        "daily": {
+          "type": "string",
+          "description": "Bottom-nav label for the Daily tab (home / today’s meditations)."
         },
-        "history": {
-          "type": "object",
-          "description": "Profile → History screen.",
-          "properties": {
-            "title": {
-              "type": "string",
-              "description": "Screen title (typically uppercase)."
-            },
-            "empty_title": {
-              "type": "string",
-              "description": "Empty-state title when the user has no history entries."
-            },
-            "empty_subtitle": {
-              "type": "string",
-              "description": "Empty-state subtitle when the user has no history entries."
-            }
-          },
-          "additionalProperties": false,
-          "screenshot": "https://www.figma.com/design/JkJK5lBTjB3oSwATMGqfUt/We-Meditate-App?node-id=7615-1623198"
+        "path": {
+          "type": "string",
+          "description": "Bottom-nav label for the Path tab (guided learning course)."
         },
-        "favourites": {
-          "type": "object",
-          "description": "Profile → Favourites screen.",
-          "properties": {
-            "title": {
-              "type": "string",
-              "description": "Screen title (typically uppercase)."
-            },
-            "removed_from_favourites": {
-              "type": "string",
-              "description": "Snackbar shown after a favourite is removed (paired with the global Undo action from the general group)."
-            }
-          },
-          "additionalProperties": false,
-          "screenshot": "https://www.figma.com/design/JkJK5lBTjB3oSwATMGqfUt/We-Meditate-App?node-id=9150-87479"
+        "explore": {
+          "type": "string",
+          "description": "Bottom-nav label for the Explore tab (library of meditations, talks, techniques)."
         },
-        "account": {
-          "type": "object",
-          "description": "Profile → Account settings screen — edit name/email, change password, delete account.",
-          "properties": {
-            "title": {
-              "type": "string",
-              "description": "Screen title."
-            },
-            "details_header": {
-              "type": "string",
-              "description": "Eyebrow above the details block (typically uppercase)."
-            },
-            "name_label": {
-              "type": "string",
-              "description": "Label for the name input."
-            },
-            "name_hint": {
-              "type": "string",
-              "description": "Placeholder hint for the name input."
-            },
-            "save": {
-              "type": "string",
-              "description": "Save CTA used on inline forms."
-            },
-            "saving": {
-              "type": "string",
-              "description": "Loading-state label shown on the Save CTA while saving."
-            },
-            "saved": {
-              "type": "string",
-              "description": "Confirmation toast shown after settings are saved."
-            },
-            "first_name_label": {
-              "type": "string",
-              "description": "Label used by the dedicated first-name edit row."
-            },
-            "email_label": {
-              "type": "string",
-              "description": "Label used by the email row."
-            },
-            "password_label": {
-              "type": "string",
-              "description": "Label used by the password row."
-            },
-            "edit_action": {
-              "type": "string",
-              "description": "Edit CTA used on read-only rows that open an edit modal."
-            },
-            "edit_first_name_title": {
-              "type": "string",
-              "description": "Title of the edit-first-name modal."
-            },
-            "edit_email_title": {
-              "type": "string",
-              "description": "Title of the edit-email modal."
-            },
-            "cancel": {
-              "type": "string",
-              "description": "Cancel CTA used in edit modals."
-            },
-            "save_changes": {
-              "type": "string",
-              "description": "Primary CTA in edit modals."
-            },
-            "save_failed": {
-              "type": "string",
-              "description": "Error shown when saving account settings fails."
-            },
-            "reset_password_title": {
-              "type": "string",
-              "description": "Title of the reset-password modal."
-            },
-            "reset_password_description": {
-              "type": "string",
-              "description": "Body copy of the reset-password modal."
-            },
-            "reset_password_action": {
-              "type": "string",
-              "description": "Primary CTA in the reset-password modal."
-            },
-            "reset_password_sent": {
-              "type": "string",
-              "description": "Confirmation toast shown after the reset link has been emailed."
-            },
-            "reset_password_error": {
-              "type": "string",
-              "description": "Error shown when sending the reset link fails."
-            },
-            "email_edit_unavailable": {
-              "type": "string",
-              "description": "Toast shown when email editing is not yet available."
-            },
-            "email_unavailable": {
-              "type": "string",
-              "description": "Inline placeholder shown when no email is available for the account."
-            },
-            "create_account": {
-              "type": "string",
-              "description": "CTA shown for guest users prompting them to create an account."
-            },
-            "delete_account_title": {
-              "type": "string",
-              "description": "Title of the delete-account confirmation."
-            },
-            "delete_account_description": {
-              "type": "string",
-              "description": "Body copy of the delete-account confirmation."
-            },
-            "delete_account_error": {
-              "type": "string",
-              "description": "Error shown when delete-account fails."
-            },
-            "delete_account_requires_recent_login": {
-              "type": "string",
-              "description": "Error shown when delete-account requires the user to log in again first."
-            },
-            "reauthenticate_title": {
-              "type": "string",
-              "description": "Title of the password re-entry modal used before destructive actions."
-            },
-            "reauthenticate_description": {
-              "type": "string",
-              "description": "Body copy of the password re-entry modal."
-            },
-            "reauthenticate_required": {
-              "type": "string",
-              "description": "Validation error shown when the password field is empty in the re-entry modal."
-            },
-            "reauthenticate_invalid": {
-              "type": "string",
-              "description": "Error shown when the re-entered password is incorrect."
-            },
-            "continue_action": {
-              "type": "string",
-              "description": "Primary CTA on the password re-entry modal."
-            },
-            "guest_email_prompt": {
-              "type": "string",
-              "description": "Inline prompt shown on the email row for guest users."
-            },
-            "guest_password_prompt": {
-              "type": "string",
-              "description": "Inline prompt shown on the password row for guest users."
-            },
-            "login": {
-              "type": "string",
-              "description": "Login CTA used in the guest prompts."
-            },
-            "logout": {
-              "type": "string",
-              "description": "Logout CTA in the account screen."
-            },
-            "privacy_policy": {
-              "type": "string",
-              "description": "Inline link opening the Privacy Policy webview from the account screen."
-            },
-            "delete_account": {
-              "type": "string",
-              "description": "Destructive CTA opening the delete-account flow."
-            }
-          },
-          "additionalProperties": false,
-          "screenshot": "https://www.figma.com/design/JkJK5lBTjB3oSwATMGqfUt/We-Meditate-App?node-id=9159-89387"
-        },
-        "contact": {
-          "type": "object",
-          "description": "Profile → Contact us screen — free-text feedback form. The text itself is first-party only — it never reaches the ad path.",
-          "properties": {
-            "title": {
-              "type": "string",
-              "description": "Screen title (typically uppercase)."
-            },
-            "header": {
-              "type": "string",
-              "description": "Hero copy above the form."
-            },
-            "subtitle": {
-              "type": "string",
-              "description": "Subtitle below the hero copy."
-            },
-            "placeholder": {
-              "type": "string",
-              "description": "Input field placeholder hint for the feedback text area."
-            },
-            "send": {
-              "type": "string",
-              "description": "Submit CTA on the form."
-            },
-            "sending": {
-              "type": "string",
-              "description": "Loading-state label shown on the Submit CTA while sending."
-            },
-            "sent": {
-              "type": "string",
-              "description": "Confirmation toast shown after the feedback is sent."
-            },
-            "empty_error": {
-              "type": "string",
-              "description": "Validation error shown when the feedback field is empty."
-            },
-            "min_length_error": {
-              "type": "string",
-              "description": "Validation error shown when the feedback is shorter than the minimum length (50 characters)."
-            },
-            "send_error": {
-              "type": "string",
-              "description": "Error shown when sending the feedback fails."
-            }
-          },
-          "additionalProperties": false,
-          "screenshot": "https://www.figma.com/design/JkJK5lBTjB3oSwATMGqfUt/We-Meditate-App?node-id=9159-89388"
+        "profile": {
+          "type": "string",
+          "description": "Bottom-nav label for the Profile tab (account, history, favourites, settings)."
         }
       },
       "additionalProperties": false
     },
-    "consent": {
+    "general": {
       "type": "object",
-      "description": "Ad-measurement consent surfaces — the post-first-meditation modal and the Profile → Privacy & advertising settings screen. See .kiro/specs/analytics-simplified/01-strategy.md §3 and §9.",
+      "description": "Generic UI strings shared across the app (overlays, error states, simple actions).",
       "properties": {
-        "ad_modal": {
-          "type": "object",
-          "description": "Post-first-meditation ‘Help spread the word’ ad-measurement consent modal. Shown in the onboarding chain after the first-meditation Vibes Interpretation + Shri Mataji talk and before Account Creation. Approval flips adsMarketingConsent = true. Figma: node-id 11564-91404.",
-          "properties": {
-            "title": {
-              "type": "string",
-              "description": "Modal title (e.g. 'Help spread the word')."
-            },
-            "body_intro_prefix": {
-              "type": "string",
-              "description": "First paragraph prefix; combined inline with body_intro_link and body_intro_suffix to form a single sentence. Include any trailing space."
-            },
-            "body_intro_link": {
-              "type": "string",
-              "description": "Inline link text inside the first paragraph (e.g. 'what we share'). Tapping opens a detail sheet listing exactly which fields are sent to Meta, Apple and Google Ads."
-            },
-            "body_intro_suffix": {
-              "type": "string",
-              "description": "First paragraph suffix completing the sentence after the inline link. Include the leading separator if needed (e.g. ') with Meta, Apple and Google Ads to understand which outreach helps people discover meditation.')."
-            },
-            "body_benefits": {
-              "type": "string",
-              "description": "Second paragraph explaining the benefits of granting consent (improving campaigns, using donations responsibly, suppressing ads to existing users, reaching similar people)."
-            },
-            "body_never_share": {
-              "type": "string",
-              "description": "Third paragraph listing categories that are never sent for advertising (mood, goals, hand sensations, reflections, class location, spiritual-practice details). Must remain consistent with the privacy filter in analytics-simplified/03-marketing-event-taxonomy.md §2."
-            },
-            "body_never_sell": {
-              "type": "string",
-              "description": "Fourth paragraph: short statement that the app never sells user data."
-            },
-            "body_settings_hint": {
-              "type": "string",
-              "description": "Fifth paragraph telling the user they can change this anytime via Settings → Privacy & advertising. Preserve the arrow character (→) or substitute the locale equivalent."
-            },
-            "allow": {
-              "type": "string",
-              "description": "Primary CTA granting consent (sets adsMarketingConsent = true)."
-            },
-            "reject": {
-              "type": "string",
-              "description": "Decline CTA. Decline is a single tap and must not block account creation (see analytics-simplified/05-flutter-implementation.md §9)."
-            }
-          },
-          "additionalProperties": false,
-          "screenshot": "https://www.figma.com/design/JkJK5lBTjB3oSwATMGqfUt/We-Meditate-App?node-id=11564-91404"
+        "back": {
+          "type": "string",
+          "description": "Generic back action label (used as accessibility text and as a back button label)."
         },
-        "settings": {
-          "type": "object",
-          "description": "Profile → Privacy & advertising settings screen — two toggle sections (anonymous product analytics, advertising measurement). Drives the productAnalyticsOptOut and adsMarketingConsent flags respectively (see analytics-simplified/05-flutter-implementation.md §2 and §8). Figma: node-id 11571-40337.",
-          "properties": {
-            "screen_title": {
-              "type": "string",
-              "description": "Screen title (e.g. 'Help spread the word and make the app better')."
-            },
-            "status_allowed": {
-              "type": "string",
-              "description": "Status label shown next to a toggle that is currently allowed. MUST preserve the {date} placeholder — it is replaced at runtime with the localized date of the most recent consent decision (e.g. '16 May 2026')."
-            },
-            "status_not_allowed": {
-              "type": "string",
-              "description": "Status label shown next to a toggle that is currently disallowed."
-            },
-            "product_analytics_title": {
-              "type": "string",
-              "description": "Section title for the anonymous product analytics toggle (e.g. 'Anonymous product analytics'). Drives productAnalyticsOptOut."
-            },
-            "product_analytics_description": {
-              "type": "string",
-              "description": "Section body explaining anonymous product analytics: we log aggregated usage data to fix bugs and improve We Meditate, no individual data, no advertisers, no user profile. Must remain consistent with the TelemetryDeck posture in analytics-simplified/01-strategy.md §4."
-            },
-            "advertising_title": {
-              "type": "string",
-              "description": "Section title for the advertising-measurement toggle (e.g. 'Advertising measurement and improvement'). Drives adsMarketingConsent."
-            },
-            "advertising_body_intro_prefix": {
-              "type": "string",
-              "description": "First paragraph prefix of the advertising section; combined inline with advertising_body_intro_link and advertising_body_intro_suffix. Include any trailing space."
-            },
-            "advertising_body_intro_link": {
-              "type": "string",
-              "description": "Inline link text inside the first paragraph (e.g. 'what we share'). Tapping opens the same 'what we share' detail used by the ad consent modal."
-            },
-            "advertising_body_intro_suffix": {
-              "type": "string",
-              "description": "First paragraph suffix completing the sentence after the inline link. Include the leading separator if needed."
-            },
-            "advertising_body_benefits": {
-              "type": "string",
-              "description": "Second paragraph of the advertising section: how granting consent helps WeMeditate use donations responsibly, improve campaigns, suppress ads to existing users, and reach similar people."
-            },
-            "advertising_body_never_share": {
-              "type": "string",
-              "description": "Third paragraph of the advertising section reiterating the never-shared categories (mood, goals, hand sensations, reflections, class location, spiritual-practice details). Must remain consistent with analytics-simplified/03-marketing-event-taxonomy.md §2."
-            },
-            "advertising_body_change_hint": {
-              "type": "string",
-              "description": "Fourth paragraph of the advertising section explaining that the user can change their choice anytime using the toggle at the top of this screen."
-            },
-            "advertising_platforms_header": {
-              "type": "string",
-              "description": "Sub-section header listing current advertising platforms (e.g. 'Current advertising platforms')."
-            },
-            "advertising_platform_meta": {
-              "type": "string",
-              "description": "Bullet item for Meta (Facebook + Instagram + Audience Network). Brand name — usually kept as 'Meta'."
-            },
-            "advertising_platform_google_ads": {
-              "type": "string",
-              "description": "Bullet item for Google Ads. Brand name — usually kept as 'Google Ads'."
-            },
-            "advertising_platform_apple_search_ads": {
-              "type": "string",
-              "description": "Bullet item for Apple Search Ads. Brand name — usually kept as 'Apple Search Ads'."
-            }
-          },
-          "additionalProperties": false,
-          "screenshot": "https://www.figma.com/design/JkJK5lBTjB3oSwATMGqfUt/We-Meditate-App?node-id=11571-40337"
+        "retry": {
+          "type": "string",
+          "description": "Generic retry action label used on error states across the app."
+        },
+        "undo": {
+          "type": "string",
+          "description": "Generic undo action label used on snackbars and other transient confirmations."
         }
       },
       "additionalProperties": false

--- a/src/globals/wemeditate-app/translationsSchema.json
+++ b/src/globals/wemeditate-app/translationsSchema.json
@@ -54,7 +54,8 @@
           "description": "Generic error toast shown when an inline link on the welcome screen fails to open."
         }
       },
-      "additionalProperties": false
+      "additionalProperties": false,
+      "screenshot": "https://www.figma.com/design/JkJK5lBTjB3oSwATMGqfUt/We-Meditate-App?node-id=5390-8945"
     },
     "onboarding": {
       "type": "object",
@@ -77,7 +78,8 @@
               "description": "Primary CTA to confirm the entered name and continue onboarding."
             }
           },
-          "additionalProperties": false
+          "additionalProperties": false,
+          "screenshot": "https://www.figma.com/design/JkJK5lBTjB3oSwATMGqfUt/We-Meditate-App?node-id=5390-7392"
         },
         "greeting": {
           "type": "object",
@@ -88,7 +90,8 @@
               "description": "Multi-line greeting prefix shown above the user’s name. Preserve the embedded line breaks (\\n) — they control where the text wraps in the hero layout."
             }
           },
-          "additionalProperties": false
+          "additionalProperties": false,
+          "screenshot": "https://www.figma.com/design/JkJK5lBTjB3oSwATMGqfUt/We-Meditate-App?node-id=5390-7596"
         },
         "user_type": {
           "type": "object",
@@ -127,7 +130,8 @@
               "description": "Selectable option for long-time Sahaja Yoga practitioners. Maps to userType = yogi (excluded from the ad-measurement path)."
             }
           },
-          "additionalProperties": false
+          "additionalProperties": false,
+          "screenshot": "https://www.figma.com/design/JkJK5lBTjB3oSwATMGqfUt/We-Meditate-App?node-id=10253-86746"
         },
         "carousel": {
           "type": "object",
@@ -162,7 +166,8 @@
               "description": "Slide 3 supporting copy."
             }
           },
-          "additionalProperties": false
+          "additionalProperties": false,
+          "screenshot": "https://www.figma.com/design/JkJK5lBTjB3oSwATMGqfUt/We-Meditate-App?node-id=5390-7673"
         }
       },
       "additionalProperties": false
@@ -478,7 +483,8 @@
               "description": "Inline message asking the user to enable notifications in OS Settings to receive live-meditation reminders."
             }
           },
-          "additionalProperties": false
+          "additionalProperties": false,
+          "screenshot": "https://www.figma.com/design/JkJK5lBTjB3oSwATMGqfUt/We-Meditate-App?node-id=7064-81297"
         },
         "explore": {
           "type": "object",
@@ -569,7 +575,8 @@
               "description": "Generic 'Coming soon' badge used on locked Explore-block cards."
             }
           },
-          "additionalProperties": false
+          "additionalProperties": false,
+          "screenshot": "https://www.figma.com/design/JkJK5lBTjB3oSwATMGqfUt/We-Meditate-App?node-id=5878-10306"
         }
       },
       "additionalProperties": false
@@ -920,7 +927,8 @@
               "description": "Error title shown when the meditation track fails to load in the player."
             }
           },
-          "additionalProperties": false
+          "additionalProperties": false,
+          "screenshot": "https://www.figma.com/design/JkJK5lBTjB3oSwATMGqfUt/We-Meditate-App?node-id=7461-1119009"
         },
         "footsoak": {
           "type": "object",
@@ -1058,7 +1066,8 @@
               "description": "Decline CTA on the restart prompt."
             }
           },
-          "additionalProperties": false
+          "additionalProperties": false,
+          "screenshot": "https://www.figma.com/design/JkJK5lBTjB3oSwATMGqfUt/We-Meditate-App?node-id=5390-8159"
         },
         "subtle_system": {
           "type": "object",
@@ -1113,7 +1122,8 @@
               "description": "Detail label for the Left Aspect of a chakra."
             }
           },
-          "additionalProperties": false
+          "additionalProperties": false,
+          "screenshot": "https://www.figma.com/design/JkJK5lBTjB3oSwATMGqfUt/We-Meditate-App?node-id=7307-83858"
         }
       },
       "additionalProperties": false
@@ -1202,7 +1212,8 @@
               "description": "Status label shown on talks that the user has already watched."
             }
           },
-          "additionalProperties": false
+          "additionalProperties": false,
+          "screenshot": "https://www.figma.com/design/JkJK5lBTjB3oSwATMGqfUt/We-Meditate-App?node-id=2359-6059"
         },
         "player": {
           "type": "object",
@@ -1287,7 +1298,8 @@
               "description": "Placeholder shown at the bottom of the Path when no further steps are released yet (typically uppercase)."
             }
           },
-          "additionalProperties": false
+          "additionalProperties": false,
+          "screenshot": "https://www.figma.com/design/JkJK5lBTjB3oSwATMGqfUt/We-Meditate-App?node-id=7846-27543"
         },
         "info": {
           "type": "object",
@@ -1399,7 +1411,8 @@
               "description": "Back CTA returning the user to the step overview."
             }
           },
-          "additionalProperties": false
+          "additionalProperties": false,
+          "screenshot": "https://www.figma.com/design/JkJK5lBTjB3oSwATMGqfUt/We-Meditate-App?node-id=7846-27579"
         },
         "step_4": {
           "type": "object",
@@ -1453,7 +1466,8 @@
               "description": "CTA returning the user to the Path overview after completing a step."
             }
           },
-          "additionalProperties": false
+          "additionalProperties": false,
+          "screenshot": "https://www.figma.com/design/JkJK5lBTjB3oSwATMGqfUt/We-Meditate-App?node-id=7846-27656"
         },
         "meditation_feedback": {
           "type": "object",
@@ -1641,7 +1655,8 @@
               "description": "Generic sign-in failure error."
             }
           },
-          "additionalProperties": false
+          "additionalProperties": false,
+          "screenshot": "https://www.figma.com/design/JkJK5lBTjB3oSwATMGqfUt/We-Meditate-App?node-id=5502-18583"
         },
         "restore_password": {
           "type": "object",
@@ -1672,7 +1687,8 @@
               "description": "Validation error on the recovery form for an invalid email."
             }
           },
-          "additionalProperties": false
+          "additionalProperties": false,
+          "screenshot": "https://www.figma.com/design/JkJK5lBTjB3oSwATMGqfUt/We-Meditate-App?node-id=5502-19240"
         },
         "restore_password_email_sent": {
           "type": "object",
@@ -1687,7 +1703,8 @@
               "description": "Acknowledge CTA on the confirmation."
             }
           },
-          "additionalProperties": false
+          "additionalProperties": false,
+          "screenshot": "https://www.figma.com/design/JkJK5lBTjB3oSwATMGqfUt/We-Meditate-App?node-id=5901-23072"
         },
         "create_account": {
           "type": "object",
@@ -1798,7 +1815,8 @@
               "description": "Message shown when the user cancels the social-auth flow."
             }
           },
-          "additionalProperties": false
+          "additionalProperties": false,
+          "screenshot": "https://www.figma.com/design/JkJK5lBTjB3oSwATMGqfUt/We-Meditate-App?node-id=5390-8755"
         }
       },
       "additionalProperties": false
@@ -1888,7 +1906,8 @@
               "description": "Joined-date string for multiple years ago. MUST preserve the {years} placeholder — it is replaced at runtime with the year count."
             }
           },
-          "additionalProperties": false
+          "additionalProperties": false,
+          "screenshot": "https://www.figma.com/design/JkJK5lBTjB3oSwATMGqfUt/We-Meditate-App?node-id=7611-1453777"
         },
         "history": {
           "type": "object",
@@ -1907,7 +1926,8 @@
               "description": "Empty-state subtitle when the user has no history entries."
             }
           },
-          "additionalProperties": false
+          "additionalProperties": false,
+          "screenshot": "https://www.figma.com/design/JkJK5lBTjB3oSwATMGqfUt/We-Meditate-App?node-id=7615-1623198"
         },
         "favourites": {
           "type": "object",
@@ -1922,7 +1942,8 @@
               "description": "Snackbar shown after a favourite is removed (paired with the global Undo action from the general group)."
             }
           },
-          "additionalProperties": false
+          "additionalProperties": false,
+          "screenshot": "https://www.figma.com/design/JkJK5lBTjB3oSwATMGqfUt/We-Meditate-App?node-id=9150-87479"
         },
         "account": {
           "type": "object",
@@ -2085,7 +2106,8 @@
               "description": "Destructive CTA opening the delete-account flow."
             }
           },
-          "additionalProperties": false
+          "additionalProperties": false,
+          "screenshot": "https://www.figma.com/design/JkJK5lBTjB3oSwATMGqfUt/We-Meditate-App?node-id=9159-89387"
         },
         "contact": {
           "type": "object",
@@ -2132,7 +2154,8 @@
               "description": "Error shown when sending the feedback fails."
             }
           },
-          "additionalProperties": false
+          "additionalProperties": false,
+          "screenshot": "https://www.figma.com/design/JkJK5lBTjB3oSwATMGqfUt/We-Meditate-App?node-id=9159-89388"
         }
       },
       "additionalProperties": false
@@ -2186,7 +2209,8 @@
               "description": "Decline CTA. Decline is a single tap and must not block account creation (see analytics-simplified/05-flutter-implementation.md §9)."
             }
           },
-          "additionalProperties": false
+          "additionalProperties": false,
+          "screenshot": "https://www.figma.com/design/JkJK5lBTjB3oSwATMGqfUt/We-Meditate-App?node-id=11564-91404"
         },
         "settings": {
           "type": "object",
@@ -2257,7 +2281,8 @@
               "description": "Bullet item for Apple Search Ads. Brand name — usually kept as 'Apple Search Ads'."
             }
           },
-          "additionalProperties": false
+          "additionalProperties": false,
+          "screenshot": "https://www.figma.com/design/JkJK5lBTjB3oSwATMGqfUt/We-Meditate-App?node-id=11571-40337"
         }
       },
       "additionalProperties": false


### PR DESCRIPTION
## Summary

Follow-up to #386. The schema that shipped in #386 had **39 flat top-level tabs** and groupings that didn't line up with the real app structure — \"Home\" wasn't a tab (the bottom-nav tab is **Daily**), Subtle System and Talks sat under Meditation/Talks despite being Explore subscreens, and Consent had its own top-level despite living inside the onboarding chain (modal) and inside Profile (settings).

This PR re-grounds the schema in the actual app structure (verified by reading every non-analytics spec under \`.kiro/specs/\`) and adds editor orientation aids on top.

## Changes

### 1. Nested groups (the helper now recurses one level)

\`buildTranslationTabs\` extended to support parent groups whose properties are themselves \`GroupSchema\` values. Parent groups render as an outer tab containing inner sub-tabs (Payload nested \`tabs\`); leaf groups still render as a single tab. JSON field names for leaf groups remain flat \`parent_child\` so the global's data shape stays predictable.

Backward compatible: \`wm-web-translations\` and \`sahaj-atlas\` are flat-only schemas, so they go down the unchanged leaf path of the helper.

### 2. Re-grouped around real app structure

After reading \`home-page\`, \`path-tab\`, \`explore-tab/*\`, \`profile-tab\`, \`meditation-player\`, \`onboarding-flow\`, \`vibes-check-realisation\`, \`daily-meditations-flow\`, \`find-a-class-near-you\`, and \`live-online-classes\` specs:

\`\`\`
Onboarding   — first-run + post-first-meditation consent modal
  ├ Welcome, Name, Greeting, User Type, Carousel, Consent Modal

Daily        — bottom-nav index 0 (Daily tab)
  ├ Main, Common, Load Info

Path         — bottom-nav index 1
  ├ Overview, Info, Step 1, Step 2, Step 3, Step 4, Step Complete

Explore      — bottom-nav index 2 + subscreens
  ├ Overview, Subtle System, Talks Intro, Talks List, Talks Player

Profile      — bottom-nav index 3 + sub-screens
  ├ Main, Favourites, History, Account, Privacy Advertising, Contact

Meditation   — cross-cutting meditation flow
  ├ Intent, Reminder, Footsoak, Player, Vibes Check, Feedback

Auth         — auth overlay flows
  ├ Common, Login, Restore Password, Restore Password Email Sent, Create Account

Navigation   — flat, bottom-nav tab labels
General      — flat, generic shared utility strings
\`\`\`

What this fixes vs. #386:
- \"Home\" → **Daily** (the real bottom-nav tab name; \"Home Page\" is the 4-tab shell, not a tab)
- **Welcome** is now nested under Onboarding (first screen of the first-run flow)
- **Subtle System** moved from Meditation → Explore (primary surface is the Explore → Learn subscreen; meditation intro overlay reuses the strings)
- **Talks** moved from a top-level group → Explore (Shri Mataji's Talks is an Explore → Learn subscreen)
- **Consent** dissolved: ad modal → Onboarding (it's part of the onboarding chain), settings → Profile (reached from Profile menu)
- **\`path.meditation_feedback\`** → \`meditation.feedback\` (generic post-meditation form per the meditation-player spec, not Path-specific)
- **\`meditation.intent\`** at 71 keys split into Intent (37 chooser/cards keys) + Reminder (34 reminder-system keys, with the redundant \`reminder_\` prefix dropped on the way)

### 3. Per-tab screenshot / Figma-link previews

New optional \`screenshot\` field on each leaf group in the JSON Schema. The helper emits a small UI-only field above the TranslationsTable when set — either an inline image (when the value points at a repo asset like \`/admin-screenshots/.../foo.png\`) or a \"🎨 View this screen in Figma ↗\" button (when the value is a Figma design URL).

New client component: \`src/components/admin/TabScreenshot/TabScreenshot.tsx\`. Renders a small bordered preview block, no data wiring.

Populated 25 of 40 leaf groups with Figma URLs sourced from \`Figma:\` annotations in \`.kiro/specs/\`. The remaining 15 groups left empty are either:
- shared utility copy with no anchor screen (\`general\`, \`navigation\`, \`auth.common\`, \`daily.common\`, \`daily.load_info\`),
- multi-screen flows that don't map to one Figma node (\`meditation.intent\`, \`meditation.reminder\`),
- or groups without a confirmed Figma reference yet (\`explore.talks_intro\`, \`explore.talks_player\`, \`path.info\`, \`path.step_1/2/4\`, \`meditation.footsoak\`, \`meditation.feedback\`).

Tabs without a screenshot render no preview block — degrades cleanly. Eventually intended to be replaced by a live in-CMS Flutter preview.

## Backward compatibility

- **\`TranslationsTableField.tsx\` is not touched.** JSON field names stay flat (\`parent_child\`), so the component still reads top-level fields by name and the API/data shape stays the same flat key set.
- **\`wm-web-translations\` and \`sahaj-atlas\` are not touched.** Their schemas are flat top-level groups only, so they go down the unchanged leaf path of the helper.
- **Field renames within \`wm-app-translations\`** are all no-cost — no translation data exists in this global yet (#386 was just merged). Renames:

| Old (post-#386) | New |
| --- | --- |
| \`welcome\` | \`onboarding_welcome\` |
| \`home_common\` | \`daily_common\` |
| \`home_load_info\` | \`daily_load_info\` |
| \`home_daily\` | \`daily_main\` |
| \`explore\` (was \`home_explore\` before #386) | \`explore_overview\` |
| \`talks_intro\` | \`explore_talks_intro\` |
| \`talks_list\` | \`explore_talks_list\` |
| \`talks_player\` | \`explore_talks_player\` |
| \`meditation_subtle_system\` | \`explore_subtle_system\` |
| \`path_meditation_feedback\` | \`meditation_feedback\` |
| \`consent_ad_modal\` | \`onboarding_consent_modal\` |
| \`consent_settings\` | \`profile_privacy_advertising\` |
| \`meditation_intent\` (71 keys) | split into \`meditation_intent\` (37) + \`meditation_reminder\` (34) |

\`path\` (4 keys for the path-tab chrome) became \`path_overview\` earlier in this branch — also no-cost.

## Numbers

- Outer tabs: **39 → 9**
- Leaf JSON fields: 39 → **40** (+1 from the intent/reminder split)
- Total leaf keys: **483 → 483** (preserved)
- en.yaml coverage: **455 / 455** (verified, 0 missing, 0 extra)
- Screenshots wired up: **25 of 40** leaf groups
- \`tsc --noEmit\`: clean

## Commits

- \`0b54480\` — initial nesting (11 outer tabs)
- \`63ab7ec\` — per-tab screenshot / Figma-link previews (helper + new component + populate from \`.kiro/specs/\`)
- \`266ab9b\` — Welcome nested under Onboarding
- \`c679dc5\` — Explore promoted to top-level
- \`fbfe7f5\` — re-grouped around real app structure (final 9-group layout)

## Test plan

- [x] \`tsc --noEmit\` clean
- [x] Programmatic call to \`buildTranslationTabs(schema, 'wm-app-translations')\` returns 9 outer tabs and 40 leaf JSON fields with expected names
- [x] en.yaml coverage check: 455 / 455
- [x] All 25 screenshot Figma URLs preserved across the restructure
- [ ] Reviewer to load the Translations admin in Payload and confirm nested-tab UI renders correctly and screenshots show
- [ ] Reviewer to confirm \`wm-web-translations\` and \`sahaj-atlas\` editors still render unchanged

## Follow-up (separate change in WeMeditateApp)

When the consent screens get built in Flutter, \`assets/l10n/en.yaml\` needs matching keys for \`consent_ad_modal.*\`, \`consent_settings.*\` (now under their new homes), and \`profile.main.privacy_and_advertising_*\` — otherwise \`easiest_localization\` codegen has nothing to seed the new strings from.

Also: the YAML structure in WeMeditateApp still uses the old flat \`path_step_1\`, \`path_info\`, \`talks.*\`, \`home.*\` etc. naming. Re-syncing the YAML to match this schema's grouping is a separate Flutter-side task.