### PR TITLE
fix(meditations): harden frame publish cache writes

### DIFF
--- a/src/collections/content/Meditations.ts
+++ b/src/collections/content/Meditations.ts
@@ -5,12 +5,19 @@ import { mediaField, slugField } from '@/fields'
 import {
   extractAudioDuration,
   filterMeditationsByLocale,
+  invalidateMeditationNodeWeights,
   recomputeMeditationNodeWeights,
 } from '@/hooks/meditationHooks'
 import { LOCALES } from '@/lib/locales'
+import {
+  getFrameDiagnosticsLogContext,
+  hasFrameNormalizationIssues,
+  normalizeMeditationFrames,
+  normalizeMeditationFramesForStorage,
+} from '@/lib/meditations/frames'
 import { getR2Url } from '@/lib/storage/r2NativeAdapter'
 import { virtualUrlField } from '@/lib/storage/urlFields'
-import { KeyframeData, KeyframeDefinition } from '@/types/frames'
+import { KeyframeData } from '@/types/frames'
 
 /**
  * afterRead hook for the randomSongUrl virtual field.
@@ -108,7 +115,7 @@ export const Meditations: CollectionConfig = {
   endpoints: [meditationLectures],
   hooks: {
     beforeOperation: [filterMeditationsByLocale],
-    beforeChange: [extractAudioDuration],
+    beforeChange: [extractAudioDuration, invalidateMeditationNodeWeights],
     afterChange: [recomputeMeditationNodeWeights],
   },
   defaultPopulate: {
@@ -378,39 +385,37 @@ export const Meditations: CollectionConfig = {
                       validate: ((value, options) => {
                         // Only required during update (not on create)
                         const isUpdate = options.operation === 'update' || !!options.id
-                        if (isUpdate && (!value || !Array.isArray(value) || value.length === 0)) {
+                        const previousValue = (options as { previousValue?: unknown }).previousValue
+                        const valueToValidate = value === undefined ? previousValue : value
+                        const { frames } = normalizeMeditationFrames(valueToValidate)
+                        if (isUpdate && frames.length === 0) {
                           return 'At least one frame is required'
                         }
                         return true
                       }) as Validate,
                       hooks: {
                         beforeChange: [
-                          async ({ value }) => {
-                            if (!value || !Array.isArray(value)) return []
+                          async ({ data, operation, req, value }) => {
+                            if (value === undefined) return undefined
 
-                            return value
-                              .filter((v) => {
-                                // Drop malformed frames silently
-                                if (!v || typeof v !== 'object') return false
-                                if (!v.id) return false
-                                if (
-                                  typeof v.timestamp !== 'number' ||
-                                  v.timestamp < 0 ||
-                                  isNaN(v.timestamp)
-                                )
-                                  return false
-                                return true
+                            const normalized = normalizeMeditationFrames(value)
+                            if (hasFrameNormalizationIssues(normalized.diagnostics)) {
+                              req.payload.logger.warn({
+                                msg: 'Dropped malformed meditation frames before save',
+                                issue: '390',
+                                meditationId: data?.id,
+                                operation,
+                                status: data?._status,
+                                ...getFrameDiagnosticsLogContext(normalized.diagnostics),
                               })
-                              .map(
-                                (v) => ({ id: v.id, timestamp: v.timestamp }) as KeyframeDefinition,
-                              )
-                              .sort((a, b) => a.timestamp - b.timestamp)
+                            }
+
+                            return normalizeMeditationFramesForStorage(value)
                           },
                         ],
                         afterRead: [
                           async ({ value, req }) => {
-                            if (!value || !Array.isArray(value)) return []
-                            const frames = value as KeyframeData[]
+                            const { frames } = normalizeMeditationFrames(value)
 
                             const frameIds = frames.map((f) => f.id)
                             if (frameIds.length === 0) return []

--- a/src/collections/content/Meditations.ts
+++ b/src/collections/content/Meditations.ts
@@ -385,8 +385,7 @@ export const Meditations: CollectionConfig = {
                       validate: ((value, options) => {
                         // Only required during update (not on create)
                         const isUpdate = options.operation === 'update' || !!options.id
-                        const previousValue = (options as { previousValue?: unknown }).previousValue
-                        const valueToValidate = value === undefined ? previousValue : value
+                        const valueToValidate = value === undefined ? options.previousValue : value
                         const { frames } = normalizeMeditationFrames(valueToValidate)
                         if (isUpdate && frames.length === 0) {
                           return 'At least one frame is required'
@@ -406,7 +405,7 @@ export const Meditations: CollectionConfig = {
                                 meditationId: data?.id,
                                 operation,
                                 status: data?._status,
-                                ...getFrameDiagnosticsLogContext(normalized.diagnostics),
+                                ...getFrameDiagnosticsLogContext(normalized),
                               })
                             }
 

--- a/src/hooks/frameHooks.ts
+++ b/src/hooks/frameHooks.ts
@@ -3,6 +3,12 @@ import type { CollectionAfterChangeHook } from 'payload'
 import { extractID } from 'payload/shared'
 
 import { recomputeWeightsForMeditation } from '@/hooks/meditationHooks'
+import {
+  getFrameDiagnosticsLogContext,
+  normalizeMeditationFrames,
+  persistMeditationNodeWeightsCache,
+  reportMeditationNodeWeightsCacheError,
+} from '@/lib/meditations/frames'
 import type { Meditation } from '@/payload-types'
 
 /**
@@ -33,6 +39,9 @@ export const cascadeFrameNodeChange: CollectionAfterChangeHook = async ({
   const after = doc?.subtleSystemNode ? extractID(doc.subtleSystemNode) : null
   if (before === after) return doc
 
+  const changedFrameId = typeof doc.id === 'number' ? doc.id : Number(doc.id)
+  if (!Number.isSafeInteger(changedFrameId)) return doc
+
   const { docs } = await req.payload.find({
     collection: 'meditations',
     limit: 0,
@@ -42,27 +51,46 @@ export const cascadeFrameNodeChange: CollectionAfterChangeHook = async ({
     req,
   })
 
-  const affected = (docs as Meditation[]).filter(
-    (m) =>
-      Array.isArray(m.frames) &&
-      m.frames.some((f) => {
-        if (!f || typeof f !== 'object') return false
-        const fid = (f as { id?: unknown }).id
-        return fid === doc.id
-      }),
-  )
+  const affected = (docs as Meditation[])
+    .map((meditation) => ({
+      meditation,
+      normalized: normalizeMeditationFrames(meditation.frames),
+    }))
+    .filter(({ normalized }) => normalized.frames.some((f) => f.id === changedFrameId))
 
   if (affected.length === 0) return doc
 
-  for (const m of affected) {
-    const weights = await recomputeWeightsForMeditation(req.payload, m, req)
-    await req.payload.update({
-      collection: 'meditations',
-      id: m.id,
-      data: { subtleSystemNodeWeights: weights },
-      context: { skipRecomputeNodeWeights: true },
+  for (const { meditation, normalized } of affected) {
+    const diagnostics = {
+      frameId: doc.id,
+      operation,
+      status: meditation._status,
+      ...getFrameDiagnosticsLogContext(normalized.diagnostics),
+    }
+
+    let weights: Record<string, number>
+    try {
+      weights = await recomputeWeightsForMeditation(req.payload, meditation, req)
+    } catch (error) {
+      reportMeditationNodeWeightsCacheError({
+        payload: req.payload,
+        req,
+        meditationId: meditation.id,
+        reason: 'frame-cascade-recompute',
+        diagnostics,
+        error,
+      })
+      continue
+    }
+
+    await persistMeditationNodeWeightsCache({
+      payload: req.payload,
+      meditationId: meditation.id,
+      weights,
+      reason: 'frame-cascade',
+      diagnostics,
       req,
-      locale: m.locale ?? undefined,
+      locale: meditation.locale ?? undefined,
     })
   }
 

--- a/src/hooks/frameHooks.ts
+++ b/src/hooks/frameHooks.ts
@@ -65,7 +65,7 @@ export const cascadeFrameNodeChange: CollectionAfterChangeHook = async ({
       frameId: doc.id,
       operation,
       status: meditation._status,
-      ...getFrameDiagnosticsLogContext(normalized.diagnostics),
+      ...getFrameDiagnosticsLogContext(normalized),
     }
 
     let weights: Record<string, number>

--- a/src/hooks/meditationHooks.ts
+++ b/src/hooks/meditationHooks.ts
@@ -9,6 +9,13 @@ import type {
 
 import { parseBuffer } from 'music-metadata'
 
+import {
+  getFrameDiagnosticsLogContext,
+  meditationFramesChanged,
+  normalizeMeditationFrames,
+  persistMeditationNodeWeightsCache,
+  reportMeditationNodeWeightsCacheError,
+} from '@/lib/meditations/frames'
 import type { Frame, Meditation } from '@/payload-types'
 
 const MAX_DURATION_MINUTES = 50
@@ -153,6 +160,21 @@ export const extractAudioDuration: CollectionBeforeChangeHook = async ({ data, r
   return data
 }
 
+export const invalidateMeditationNodeWeights: CollectionBeforeChangeHook = ({
+  data,
+  originalDoc,
+}) => {
+  const hasOwn = (key: string) => Object.prototype.hasOwnProperty.call(data, key)
+  const framesChanged = hasOwn('frames') && meditationFramesChanged(originalDoc?.frames, data.frames)
+  const durationChanged = hasOwn('duration') && data.duration !== originalDoc?.duration
+
+  if (framesChanged || durationChanged) {
+    data.subtleSystemNodeWeights = null
+  }
+
+  return data
+}
+
 /**
  * Read the cached subtle-system-node weights for `meditation` by re-computing
  * from its current `frames` JSON + `duration`. Bulk-fetches Frame docs at
@@ -165,12 +187,11 @@ export async function recomputeWeightsForMeditation(
   req?: PayloadRequest,
 ): Promise<Record<string, number>> {
   const rawFrames = meditation.frames
-  if (!Array.isArray(rawFrames) || rawFrames.length === 0) return {}
+  const { frames } = normalizeMeditationFrames(rawFrames)
+  if (frames.length === 0) return {}
   if (typeof meditation.duration !== 'number' || meditation.duration <= 0) return {}
 
-  const frameIds = rawFrames
-    .map((f) => (f && typeof f === 'object' ? (f as { id?: unknown }).id : null))
-    .filter((id): id is number => typeof id === 'number')
+  const frameIds = [...new Set(frames.map((f) => f.id))]
 
   if (frameIds.length === 0) return {}
 
@@ -190,13 +211,10 @@ export async function recomputeWeightsForMeditation(
     subtleSystemNode: NonNullable<Frame['subtleSystemNode']> | null
   }
   const populated: PopulatedFrame[] = []
-  for (const f of rawFrames) {
-    const id = (f as { id?: unknown }).id
-    const timestamp = (f as { timestamp?: unknown }).timestamp
-    if (typeof id !== 'number' || typeof timestamp !== 'number') continue
-    const frameDoc = frameMap.get(id)
+  for (const f of frames) {
+    const frameDoc = frameMap.get(f.id)
     populated.push({
-      timestamp,
+      timestamp: f.timestamp,
       subtleSystemNode: frameDoc?.subtleSystemNode ?? null,
     })
   }
@@ -218,12 +236,12 @@ export const recomputeMeditationNodeWeights: CollectionAfterChangeHook = async (
   previousDoc,
   req,
   context,
+  operation,
 }) => {
   if (context?.skipRecomputeNodeWeights) return doc
 
-  const framesChanged =
-    JSON.stringify(extractFrameIds(doc.frames)) !==
-    JSON.stringify(extractFrameIds(previousDoc?.frames))
+  const normalizedFrames = normalizeMeditationFrames(doc.frames)
+  const framesChanged = meditationFramesChanged(previousDoc?.frames, doc.frames)
 
   const durationChanged = doc.duration !== previousDoc?.duration
 
@@ -233,25 +251,43 @@ export const recomputeMeditationNodeWeights: CollectionAfterChangeHook = async (
   // (typical fresh-create state) — the `frames` field is required on update,
   // so attempting to write back the (empty) weights would trip its validator.
   // Subsequent edits that introduce frames will fire the hook normally.
-  const frameIds = extractFrameIds(doc.frames)
-  if (frameIds.length === 0) return doc
+  if (normalizedFrames.frames.length === 0) return doc
 
-  const weights = await recomputeWeightsForMeditation(req.payload, doc as Meditation, req)
+  const diagnostics = {
+    operation,
+    status: doc._status,
+    ...getFrameDiagnosticsLogContext(normalizedFrames.diagnostics),
+  }
 
-  await req.payload.update({
-    collection: 'meditations',
-    id: doc.id,
-    data: { subtleSystemNodeWeights: weights },
-    context: { skipRecomputeNodeWeights: true },
+  let weights: Record<string, number>
+  try {
+    weights = await recomputeWeightsForMeditation(req.payload, doc as Meditation, req)
+  } catch (error) {
+    reportMeditationNodeWeightsCacheError({
+      payload: req.payload,
+      req,
+      meditationId: doc.id,
+      reason: 'meditation-after-change-recompute',
+      diagnostics,
+      error,
+    })
+    return doc
+  }
+
+  const persisted = await persistMeditationNodeWeightsCache({
+    payload: req.payload,
     req,
+    meditationId: doc.id,
+    locale: typeof doc.locale === 'string' ? doc.locale : undefined,
+    weights,
+    reason: 'meditation-after-change',
+    diagnostics,
   })
 
-  return doc
-}
+  if (!persisted) return doc
 
-function extractFrameIds(frames: unknown): number[] {
-  if (!Array.isArray(frames)) return []
-  return frames
-    .map((f) => (f && typeof f === 'object' ? (f as { id?: unknown }).id : null))
-    .filter((id): id is number => typeof id === 'number')
+  return {
+    ...doc,
+    subtleSystemNodeWeights: weights,
+  }
 }

--- a/src/hooks/meditationHooks.ts
+++ b/src/hooks/meditationHooks.ts
@@ -256,7 +256,7 @@ export const recomputeMeditationNodeWeights: CollectionAfterChangeHook = async (
   const diagnostics = {
     operation,
     status: doc._status,
-    ...getFrameDiagnosticsLogContext(normalizedFrames.diagnostics),
+    ...getFrameDiagnosticsLogContext(normalizedFrames),
   }
 
   let weights: Record<string, number>

--- a/src/lib/meditations/frames.ts
+++ b/src/lib/meditations/frames.ts
@@ -1,3 +1,20 @@
+/**
+ * Centralized frame normalization for the Meditations `frames` JSON field.
+ *
+ * Shared by:
+ *   - Meditations field hooks (validate / beforeChange / afterRead) — see
+ *     `src/collections/content/Meditations.ts`
+ *   - `invalidateMeditationNodeWeights` / `recomputeMeditationNodeWeights`
+ *     in `src/hooks/meditationHooks.ts`
+ *   - `cascadeFrameNodeChange` in `src/hooks/frameHooks.ts`
+ *
+ * `normalizeMeditationFrames` is idempotent: it drops malformed entries,
+ * coerces string IDs to numbers, and returns diagnostics suitable for
+ * `req.payload.logger.warn` and Sentry breadcrumbs. The persistence helper
+ * (`persistMeditationNodeWeightsCache`) writes the derived
+ * `subtleSystemNodeWeights` cache best-effort; failures must not propagate
+ * to the user-facing save (root cause of issue #390).
+ */
 import type { Payload, PayloadRequest } from 'payload'
 
 import * as Sentry from '@sentry/cloudflare'
@@ -18,7 +35,11 @@ export type FrameNormalizationDiagnostics = {
   frameCount: number
   invalidFrameReasons: Partial<Record<FrameNormalizationIssue, number>>
   normalizedFrameCount: number
-  normalizedPayloadBytes: number
+}
+
+export type NormalizedFramesResult = {
+  diagnostics: FrameNormalizationDiagnostics
+  frames: NormalizedKeyframe[]
 }
 
 export type NormalizedKeyframe = {
@@ -58,13 +79,9 @@ const buildDiagnostics = (
   frameCount,
   invalidFrameReasons,
   normalizedFrameCount: frames.length,
-  normalizedPayloadBytes: JSON.stringify(frames).length,
 })
 
-export function normalizeMeditationFrames(value: unknown): {
-  diagnostics: FrameNormalizationDiagnostics
-  frames: NormalizedKeyframe[]
-} {
+export function normalizeMeditationFrames(value: unknown): NormalizedFramesResult {
   const invalidFrameReasons: Partial<Record<FrameNormalizationIssue, number>> = {}
 
   if (!Array.isArray(value)) {
@@ -131,7 +148,12 @@ export function normalizeMeditationFramesForStorage(value: unknown): KeyframeDef
 export function meditationFramesChanged(previousFrames: unknown, nextFrames: unknown): boolean {
   const previous = normalizeMeditationFrames(previousFrames).frames
   const next = normalizeMeditationFrames(nextFrames).frames
-  return JSON.stringify(previous) !== JSON.stringify(next)
+  if (previous.length !== next.length) return true
+  for (let i = 0; i < previous.length; i++) {
+    if (previous[i].id !== next[i].id) return true
+    if (previous[i].timestamp !== next[i].timestamp) return true
+  }
+  return false
 }
 
 export function hasFrameNormalizationIssues(
@@ -140,13 +162,14 @@ export function hasFrameNormalizationIssues(
   return diagnostics.droppedCount > 0 || Object.keys(diagnostics.invalidFrameReasons).length > 0
 }
 
-export function getFrameDiagnosticsLogContext(diagnostics: FrameNormalizationDiagnostics) {
+export function getFrameDiagnosticsLogContext(result: NormalizedFramesResult) {
+  const { diagnostics, frames } = result
   return {
     droppedFrameCount: diagnostics.droppedCount,
     frameCount: diagnostics.frameCount,
     invalidFrameReasons: diagnostics.invalidFrameReasons,
     normalizedFrameCount: diagnostics.normalizedFrameCount,
-    normalizedPayloadBytes: diagnostics.normalizedPayloadBytes,
+    normalizedPayloadBytes: JSON.stringify(frames).length,
   }
 }
 
@@ -183,6 +206,17 @@ export function reportMeditationNodeWeightsCacheError(args: {
   })
 }
 
+/**
+ * Persist the derived `subtleSystemNodeWeights` cache directly via the DB
+ * adapter. Intentionally bypasses `payload.update` for two reasons:
+ *
+ * 1. It avoids re-entering the Meditations `afterChange` hook (no need
+ *    for a `skipRecomputeNodeWeights` context flag and no risk of an
+ *    infinite recompute loop).
+ * 2. The write is best-effort: on failure we report to logger + Sentry
+ *    and return `false`, but never throw. This is the fix for issue #390
+ *    — a cache-write error must never 500 the user-facing publish.
+ */
 export async function persistMeditationNodeWeightsCache(args: {
   diagnostics?: Record<string, unknown>
   locale?: string | null

--- a/src/lib/meditations/frames.ts
+++ b/src/lib/meditations/frames.ts
@@ -1,0 +1,219 @@
+import type { Payload, PayloadRequest } from 'payload'
+
+import * as Sentry from '@sentry/cloudflare'
+
+import type { KeyframeDefinition } from '@/types/frames'
+
+export type FrameNormalizationIssue =
+  | 'invalid-id'
+  | 'invalid-timestamp'
+  | 'missing-id'
+  | 'missing-timestamp'
+  | 'negative-timestamp'
+  | 'non-object'
+  | 'not-array'
+
+export type FrameNormalizationDiagnostics = {
+  droppedCount: number
+  frameCount: number
+  invalidFrameReasons: Partial<Record<FrameNormalizationIssue, number>>
+  normalizedFrameCount: number
+  normalizedPayloadBytes: number
+}
+
+export type NormalizedKeyframe = {
+  id: number
+  timestamp: number
+}
+
+const incrementIssue = (
+  issues: Partial<Record<FrameNormalizationIssue, number>>,
+  issue: FrameNormalizationIssue,
+) => {
+  issues[issue] = (issues[issue] ?? 0) + 1
+}
+
+const parseFrameID = (value: unknown): number | null => {
+  if (typeof value === 'number') {
+    return Number.isSafeInteger(value) && value > 0 ? value : null
+  }
+
+  if (typeof value === 'string') {
+    const trimmed = value.trim()
+    if (trimmed.length === 0) return null
+
+    const parsed = Number(trimmed)
+    return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : null
+  }
+
+  return null
+}
+
+const buildDiagnostics = (
+  frameCount: number,
+  frames: NormalizedKeyframe[],
+  invalidFrameReasons: Partial<Record<FrameNormalizationIssue, number>>,
+): FrameNormalizationDiagnostics => ({
+  droppedCount: frameCount - frames.length,
+  frameCount,
+  invalidFrameReasons,
+  normalizedFrameCount: frames.length,
+  normalizedPayloadBytes: JSON.stringify(frames).length,
+})
+
+export function normalizeMeditationFrames(value: unknown): {
+  diagnostics: FrameNormalizationDiagnostics
+  frames: NormalizedKeyframe[]
+} {
+  const invalidFrameReasons: Partial<Record<FrameNormalizationIssue, number>> = {}
+
+  if (!Array.isArray(value)) {
+    if (value !== undefined && value !== null) {
+      incrementIssue(invalidFrameReasons, 'not-array')
+    }
+
+    return {
+      diagnostics: buildDiagnostics(0, [], invalidFrameReasons),
+      frames: [],
+    }
+  }
+
+  const frames: NormalizedKeyframe[] = []
+
+  for (const item of value) {
+    if (!item || typeof item !== 'object') {
+      incrementIssue(invalidFrameReasons, 'non-object')
+      continue
+    }
+
+    const frame = item as { id?: unknown; timestamp?: unknown }
+    if (frame.id === undefined || frame.id === null || frame.id === '') {
+      incrementIssue(invalidFrameReasons, 'missing-id')
+      continue
+    }
+
+    const id = parseFrameID(frame.id)
+    if (id === null) {
+      incrementIssue(invalidFrameReasons, 'invalid-id')
+      continue
+    }
+
+    if (frame.timestamp === undefined || frame.timestamp === null) {
+      incrementIssue(invalidFrameReasons, 'missing-timestamp')
+      continue
+    }
+
+    if (typeof frame.timestamp !== 'number' || !Number.isFinite(frame.timestamp)) {
+      incrementIssue(invalidFrameReasons, 'invalid-timestamp')
+      continue
+    }
+
+    if (frame.timestamp < 0) {
+      incrementIssue(invalidFrameReasons, 'negative-timestamp')
+      continue
+    }
+
+    frames.push({ id, timestamp: frame.timestamp })
+  }
+
+  frames.sort((a, b) => a.timestamp - b.timestamp)
+
+  return {
+    diagnostics: buildDiagnostics(value.length, frames, invalidFrameReasons),
+    frames,
+  }
+}
+
+export function normalizeMeditationFramesForStorage(value: unknown): KeyframeDefinition[] {
+  return normalizeMeditationFrames(value).frames
+}
+
+export function meditationFramesChanged(previousFrames: unknown, nextFrames: unknown): boolean {
+  const previous = normalizeMeditationFrames(previousFrames).frames
+  const next = normalizeMeditationFrames(nextFrames).frames
+  return JSON.stringify(previous) !== JSON.stringify(next)
+}
+
+export function hasFrameNormalizationIssues(
+  diagnostics: FrameNormalizationDiagnostics,
+): boolean {
+  return diagnostics.droppedCount > 0 || Object.keys(diagnostics.invalidFrameReasons).length > 0
+}
+
+export function getFrameDiagnosticsLogContext(diagnostics: FrameNormalizationDiagnostics) {
+  return {
+    droppedFrameCount: diagnostics.droppedCount,
+    frameCount: diagnostics.frameCount,
+    invalidFrameReasons: diagnostics.invalidFrameReasons,
+    normalizedFrameCount: diagnostics.normalizedFrameCount,
+    normalizedPayloadBytes: diagnostics.normalizedPayloadBytes,
+  }
+}
+
+export function reportMeditationNodeWeightsCacheError(args: {
+  diagnostics?: Record<string, unknown>
+  error: unknown
+  meditationId: number | string
+  payload: Payload
+  reason: string
+  req?: PayloadRequest
+}) {
+  const { diagnostics, error, meditationId, payload, reason, req } = args
+  const logger = req?.payload.logger ?? payload.logger
+  const errorMessage = error instanceof Error ? error.message : String(error)
+  const issueContext = {
+    issue: '390',
+    meditationId,
+    reason,
+    ...diagnostics,
+  }
+
+  logger.error({
+    msg: 'Failed to update meditation node weights cache',
+    error: errorMessage,
+    ...issueContext,
+  })
+
+  Sentry.withScope((scope) => {
+    scope.setTag('issue', '390')
+    scope.setTag('collection', 'meditations')
+    scope.setTag('operation', reason)
+    scope.setExtra('meditationNodeWeightsCache', issueContext)
+    Sentry.captureException(error)
+  })
+}
+
+export async function persistMeditationNodeWeightsCache(args: {
+  diagnostics?: Record<string, unknown>
+  locale?: string | null
+  meditationId: number | string
+  payload: Payload
+  reason: string
+  req?: PayloadRequest
+  weights: Record<string, number> | null
+}): Promise<boolean> {
+  const { diagnostics, locale, meditationId, payload, reason, req, weights } = args
+
+  try {
+    await payload.db.updateOne({
+      collection: 'meditations',
+      id: meditationId,
+      data: { subtleSystemNodeWeights: weights },
+      locale: locale ?? undefined,
+      req,
+      returning: false,
+    })
+    return true
+  } catch (error) {
+    reportMeditationNodeWeightsCacheError({
+      diagnostics,
+      error,
+      meditationId,
+      payload,
+      reason,
+      req,
+    })
+
+    return false
+  }
+}

--- a/tests/int/meditation-lectures.int.spec.ts
+++ b/tests/int/meditation-lectures.int.spec.ts
@@ -216,6 +216,45 @@ describe('meditationLectures endpoint', () => {
     expect(weights!.anahat).toBeGreaterThan(weights!.mooladhara)
   })
 
+  it('recomputes cached weights when timestamps change but frame IDs do not', async () => {
+    try {
+      await payload.update({
+        collection: 'meditations',
+        id: meditation.id,
+        data: {
+          frames: [
+            { id: frameA.id, timestamp: 0 },
+            { id: frameB.id, timestamp: 5 },
+            { id: frameC.id, timestamp: 25 },
+          ] as unknown as Meditation['frames'],
+        },
+        locale: 'en',
+      })
+
+      const updated = (await payload.findByID({
+        collection: 'meditations',
+        id: meditation.id,
+        locale: 'en',
+      })) as Meditation
+      const weights = updated.subtleSystemNodeWeights as Record<string, number>
+      expect(weights.mooladhara).toBe(5)
+      expect(weights.anahat).toBe(20)
+    } finally {
+      await payload.update({
+        collection: 'meditations',
+        id: meditation.id,
+        data: {
+          frames: [
+            { id: frameA.id, timestamp: 0 },
+            { id: frameB.id, timestamp: 10 },
+            { id: frameC.id, timestamp: 25 },
+          ] as unknown as Meditation['frames'],
+        },
+        locale: 'en',
+      })
+    }
+  })
+
   it('returns lectures sorted by descending overlap weight', async () => {
     const { status, body } = await callEndpoint(payload, meditation.id, { limit: 10 }, {
       defaultAudiences: audienceFilter,

--- a/tests/int/meditationFrames.int.spec.ts
+++ b/tests/int/meditationFrames.int.spec.ts
@@ -1,6 +1,6 @@
 import type { Payload } from 'payload'
 
-import { describe, it, beforeAll, afterAll, expect } from 'vitest'
+import { describe, it, beforeAll, afterAll, expect, vi } from 'vitest'
 
 import type { Meditation, Narrator, Image, Frame } from '@/payload-types'
 import type { KeyframeDefinition } from '@/types/frames'
@@ -476,13 +476,12 @@ describe('Meditation Frames Field', () => {
         thumbnail: testImageMedia.id,
       })
 
-      const originalUpdateOne = payload.db.updateOne
+      const original = payload.db.updateOne.bind(payload.db)
       let cacheWriteAttempted = false
 
-      payload.db.updateOne = (async function updateOneWithCacheFailure(
-        this: typeof payload.db,
-        args: Parameters<typeof originalUpdateOne>[0],
-      ) {
+      const spy = vi.spyOn(payload.db, 'updateOne').mockImplementation((async (
+        args: Parameters<typeof payload.db.updateOne>[0],
+      ) => {
         const data = args.data as Record<string, unknown>
         if (
           args.collection === 'meditations' &&
@@ -494,8 +493,8 @@ describe('Meditation Frames Field', () => {
           throw new Error('forced cache persistence failure')
         }
 
-        return originalUpdateOne.call(this, args)
-      }) as typeof payload.db.updateOne
+        return original(args)
+      }) as typeof payload.db.updateOne)
 
       try {
         const updated = (await payload.update({
@@ -509,7 +508,7 @@ describe('Meditation Frames Field', () => {
         expect(cacheWriteAttempted).toBe(true)
         expect(updated.frames).toHaveLength(1)
       } finally {
-        payload.db.updateOne = originalUpdateOne
+        spy.mockRestore()
       }
     })
   })

--- a/tests/int/meditationFrames.int.spec.ts
+++ b/tests/int/meditationFrames.int.spec.ts
@@ -210,6 +210,26 @@ describe('Meditation Frames Field', () => {
       // Only valid frames remain
       expect(updated.frames).toHaveLength(2)
     })
+
+    it('rejects an explicit all-invalid frames payload', async () => {
+      await payload.update({
+        collection: 'meditations',
+        id: testMeditation.id,
+        data: {
+          frames: [{ id: testFrame1.id, timestamp: 0 }],
+        },
+      })
+
+      await expect(
+        payload.update({
+          collection: 'meditations',
+          id: testMeditation.id,
+          data: {
+            frames: [{ timestamp: 90 }] as unknown as KeyframeDefinition[],
+          },
+        }),
+      ).rejects.toThrow()
+    })
   })
 
   describe('Timestamp Handling', () => {
@@ -358,6 +378,29 @@ describe('Meditation Frames Field', () => {
         }),
       ).rejects.toThrow() // Required validation error - frames cannot be empty
     })
+
+    it('preserves existing frames when a partial update omits frames', async () => {
+      await payload.update({
+        collection: 'meditations',
+        id: testMeditation.id,
+        data: {
+          frames: [{ id: testFrame1.id, timestamp: 0 }],
+        },
+      })
+
+      const updated = (await payload.update({
+        collection: 'meditations',
+        id: testMeditation.id,
+        data: {
+          title: 'Updated without frames',
+        },
+      })) as Meditation
+
+      const resultFrames = updated.frames as KeyframeDefinition[]
+      expect(resultFrames).toHaveLength(1)
+      expect(resultFrames[0].id).toBe(testFrame1.id)
+      expect(resultFrames[0].timestamp).toBe(0)
+    })
   })
 
   describe('Publishing Validation with Frames', () => {
@@ -400,6 +443,74 @@ describe('Meditation Frames Field', () => {
 
       expect(published._status).toBe('published')
       expect(published.frames).toHaveLength(1)
+    })
+
+    it('publishes with numeric frame IDs and drops malformed frame entries', async () => {
+      const newMeditation = await testData.createMeditation(payload, {
+        narrator: testNarrator.id,
+        thumbnail: testImageMedia.id,
+      })
+
+      const published = (await payload.update({
+        collection: 'meditations',
+        id: newMeditation.id,
+        data: {
+          frames: [
+            { id: testFrame1.id, timestamp: 0 },
+            { timestamp: 514 },
+          ] as unknown as KeyframeDefinition[],
+          _status: 'published',
+        },
+      })) as Meditation
+
+      const resultFrames = published.frames as KeyframeDefinition[]
+      expect(published._status).toBe('published')
+      expect(resultFrames).toHaveLength(1)
+      expect(resultFrames[0].id).toBe(testFrame1.id)
+      expect(resultFrames[0].timestamp).toBe(0)
+    })
+
+    it('does not fail the save when node-weight cache persistence fails', async () => {
+      const newMeditation = await testData.createMeditation(payload, {
+        narrator: testNarrator.id,
+        thumbnail: testImageMedia.id,
+      })
+
+      const originalUpdateOne = payload.db.updateOne
+      let cacheWriteAttempted = false
+
+      payload.db.updateOne = (async function updateOneWithCacheFailure(
+        this: typeof payload.db,
+        args: Parameters<typeof originalUpdateOne>[0],
+      ) {
+        const data = args.data as Record<string, unknown>
+        if (
+          args.collection === 'meditations' &&
+          data &&
+          Object.keys(data).length === 1 &&
+          data.subtleSystemNodeWeights !== undefined
+        ) {
+          cacheWriteAttempted = true
+          throw new Error('forced cache persistence failure')
+        }
+
+        return originalUpdateOne.call(this, args)
+      }) as typeof payload.db.updateOne
+
+      try {
+        const updated = (await payload.update({
+          collection: 'meditations',
+          id: newMeditation.id,
+          data: {
+            frames: [{ id: testFrame1.id, timestamp: 0 }],
+          },
+        })) as Meditation
+
+        expect(cacheWriteAttempted).toBe(true)
+        expect(updated.frames).toHaveLength(1)
+      } finally {
+        payload.db.updateOne = originalUpdateOne
+      }
     })
   })
 })


### PR DESCRIPTION
## Summary
- normalize meditation frames before save/read and drop malformed entries with issue-390 diagnostics
- invalidate and recompute subtleSystemNodeWeights from the full frame timeline
- persist derived cache updates with low-level DB writes so cache failures do not 500 publishes

## Tests
- pnpm test:int tests/int/meditationFrames.int.spec.ts tests/int/meditation-lectures.int.spec.ts
- pnpm lint

## Notes
- Broader pnpm test:int still has unrelated existing/environment failures: translation global assertions, suite timeouts, and Wrangler EPERM bind/logging issues.