### PR TITLE
feat(wm-app-translations): rich-text leaf properties + schema delta + English seed import (closes #393)

### DIFF
--- a/seeds/lib/expectedCounts.ts
+++ b/seeds/lib/expectedCounts.ts
@@ -12,7 +12,12 @@ import type { CollectionMetadata, ScriptMetadata } from './pagination'
 
 import { getDefaultBatchSize, getEnvironment } from './pagination'
 
-export type ScriptName = 'tags' | 'wemeditate' | 'meditations' | 'storyblok'
+export type ScriptName =
+  | 'tags'
+  | 'wemeditate'
+  | 'meditations'
+  | 'storyblok'
+  | 'wm-app-translations'
 
 export interface ExpectedCounts {
   [collection: string]: number
@@ -53,6 +58,9 @@ export const EXPECTED_COUNTS: Record<ScriptName, ExpectedCounts> = {
   storyblok: {
     lessons: 17,
   },
+  // wm-app-translations updates a single PayloadCMS global, not collections.
+  // No collection counts apply — verification is intentionally a no-op.
+  'wm-app-translations': {},
 }
 
 /**
@@ -223,6 +231,10 @@ const COLLECTION_METADATA: Record<ScriptName, CollectionMetadata[]> = {
       naturalKey: 'nirmalVidyaVimeoUrl',
     },
   ],
+  // wm-app-translations targets the PayloadCMS global of the same slug, not
+  // a collection. The empty array tells the runner there are no per-collection
+  // pagination buckets or dependencies — the importer runs once, in bulk.
+  'wm-app-translations': [],
 }
 
 /**

--- a/seeds/wm-app-translations/data.en.json
+++ b/seeds/wm-app-translations/data.en.json
@@ -1,0 +1,734 @@
+{
+  "_meta": {
+    "global": "wm-app-translations",
+    "locale": "en",
+    "source": "Compiled from sydevs/WeMeditateApp@main:assets/l10n/en.yaml + Figma references for consent surfaces. See temp_scripts/import-wm-app-translations.ts for usage.",
+    "schema_version": "post-#388 (9 outer tabs, 40 leaf groups)",
+    "richtext_format": "{ \"_richText\": true, \"paragraphs\": [[{ text, bold?, italic? } | { type: 'link', text, href }, ...]] }",
+    "link_url_scheme": "wm-app-config:// — logical references that Flutter resolves through the wm-app-config global. wm-app-config://privacyPolicyPage and wm-app-config://termsAndConditionsPage resolve to the pages referenced by the corresponding wm-app-config fields (blocked on #384 — those fields don't exist on the config yet). Fragment (#what-we-share) is an anchor: Flutter scrolls to the matching h3 heading slug in the resolved page (32px top offset, per design). Convention is environment-agnostic — seed values do not bake in production page IDs (73/76) which would drift across dev/staging/prod.",
+    "todo_markers": "Keys/groups marked with _todo are intentional gaps the editor must fill in the CMS admin UI after the import runs."
+  },
+
+  "onboarding_welcome": {
+    "strings": {
+      "title": "Welcome, friend",
+      "subtitle": "Let's get you meditating",
+      "get_started": "Get started",
+      "use_existing_account": "Use existing account",
+      "privacy_policy_title": "Privacy Policy",
+      "terms_and_conditions_title": "Terms & Conditions",
+      "email_app_unavailable": "Couldn't open email app. Please install or set up a mail app.",
+      "link_open_failed": "Couldn't open the link. Please try again."
+    },
+    "legal_disclaimer": {
+      "_richText": true,
+      "_source": "Collapsed from yaml welcome.legal_disclaimer_prefix + .legal_terms + .legal_disclaimer_and + .legal_privacy_policy",
+      "paragraphs": [
+        [
+          { "text": "By continuing, you agree to our " },
+          { "type": "link", "text": "Terms", "href": "wm-app-config://termsAndConditionsPage" },
+          { "text": " & " },
+          { "type": "link", "text": "Privacy Policy", "href": "wm-app-config://privacyPolicyPage" }
+        ]
+      ]
+    }
+  },
+
+  "onboarding_name": {
+    "title": "What's your name?",
+    "placeholder": "Your first name",
+    "continue": "Continue"
+  },
+
+  "onboarding_greeting": {
+    "message_prefix": "We are happy\nyou are here,\n"
+  },
+
+  "onboarding_user_type": {
+    "strings": {
+      "get_started": "Get started",
+      "option_complete_beginner": "Never tried it, I'm completely new!",
+      "option_tried_before": "Tried it before, but didn't go deep into it",
+      "option_attending_classes": "Currently attending a newcomer class (in-person or online)",
+      "option_yogi": "Have been practicing for years"
+    },
+    "title": {
+      "_richText": true,
+      "_source": "Collapsed from yaml onboarding.user_type.title_prefix + .title_brand + .title_suffix. Brand rendered bold.",
+      "paragraphs": [
+        [
+          { "text": "Have you tried\n" },
+          { "text": "Sahaja Yoga", "bold": true },
+          { "text": " before?" }
+        ]
+      ]
+    }
+  },
+
+  "onboarding_carousel": {
+    "strings": {
+      "page_moment_title": "A moment of peace",
+      "page_moment_subtitle": "Let's switch off those worries and thoughts.",
+      "page_true_self_subtitle": "An ocean of pure joy and satisfaction lies within you.",
+      "page_unlock_potential_title": "Unlock your potential",
+      "page_unlock_potential_subtitle": "There's a lot more to you than you realise!"
+    },
+    "page_true_self_title": {
+      "_richText": true,
+      "_source": "Collapsed from yaml onboarding.carousel.page_true_self_prefix + .page_true_self_highlight. Highlight rendered bold (Flutter side may also apply accent colour).",
+      "paragraphs": [
+        [
+          { "text": "Get to know your " },
+          { "text": "true self", "bold": true }
+        ]
+      ]
+    }
+  },
+
+  "onboarding_consent_modal": {
+    "_source": "No yaml source — full content sourced from Figma node-id 11564-91404 (per PR #386). Cross-checked against the screenshots shared in the original design discussion.",
+    "strings": {
+      "title": "Help spread the word",
+      "body_benefits": "We are a non-profit with a modest budget, and this helps us spend it wisely: we see which outreach is useful, avoid bothering people who already use WeMeditate, and help ad platforms build lookalike audiences to find people with similar interests who may benefit from meditation.",
+      "body_settings_hint": "Help our outreach! You can change this anytime in Profile → Privacy & advertising.",
+      "allow": "Allow",
+      "reject": "Reject"
+    },
+    "body_intro": {
+      "_richText": true,
+      "_source": "Collapsed from schema's body_intro_prefix/_link/_suffix triple. Link target resolves through wm-app-config.privacyPolicyPage with anchor 'what-we-share' (h3 section 8.1 of the Privacy Policy).",
+      "paragraphs": [
+        [
+          { "text": "With your permission, we'll share a few basic app usage and device details with Meta, Apple Search Ads and Google Ads, like app installs or completed sessions. (" },
+          { "type": "link", "text": "what we share", "href": "wm-app-config://privacyPolicyPage#what-we-share" },
+          { "text": ")." }
+        ]
+      ]
+    },
+    "body_never_share": {
+      "_richText": true,
+      "_source": "Converted from plain string. Bold span on the lead phrase, matching Figma node-id 11564-91404.",
+      "paragraphs": [
+        [
+          { "text": "We'll never share", "bold": true },
+          { "text": " your mood, goals, hand sensations, reflections, location, or details about your practice." }
+        ]
+      ]
+    },
+    "body_never_sell": {
+      "_richText": true,
+      "_source": "Converted from plain string. Bold span on 'we never sell'.",
+      "paragraphs": [
+        [
+          { "text": "And " },
+          { "text": "we never sell", "bold": true },
+          { "text": " your data to anyone, ever." }
+        ]
+      ]
+    }
+  },
+
+  "daily_main": {
+    "start_meditation": "Start meditation",
+    "start_now": "Start now",
+    "start_course": "Start course",
+    "continue_course": "Continue course",
+    "start_the_course": "Start the course",
+    "continue_the_course": "Continue the course",
+    "scroll_to_the_path": "scroll to The Path",
+    "the_path_going_deeper": "THE PATH: GOING DEEPER",
+    "your_morning_meditation": "Your morning meditation",
+    "your_afternoon_meditation": "Your afternoon meditation",
+    "your_evening_meditation": "Your evening meditation",
+    "morning_meditation_subtitle": "Quick dose of joy, or a longer,\nmore personalised session",
+    "afternoon_meditation_subtitle": "Personalise, or\ndive right in",
+    "evening_meditation_subtitle": "Settle down, and unwind for the night ahead",
+    "path_going_deeper_title": "The Path:\ngoing deeper",
+    "path_going_deeper_subtitle": "Self-paced meditation course to learn deeper aspects:",
+    "learn_from_source": "LEARN FROM THE SOURCE",
+    "hero_label_get_started": "Get started",
+    "hero_label_try_something_new": "Try something new",
+    "hero_label_learn_from_source": "Learn from the source",
+    "hero_label_meditate_with_others": "Meditate with others",
+    "hero_label_discover": "Discover",
+    "shri_mataji_talks_title": "Shri Mataji's Talks",
+    "shri_mataji_talks_subtitle": "Learn from the source - watch talks by the founder of Sahaja Yoga",
+    "see_more": "See more",
+    "whats_your_priority_today": "WHAT'S YOUR PRIORITY TODAY?",
+    "whats_your_priority_tonight": "WHAT'S YOUR PRIORITY TONIGHT?",
+    "whats_your_priority_tag": "Priority",
+    "meditate_with_others_tag": "Community",
+    "improve_meditation_tag": "Improve",
+    "quick_morning": "Quick dose of joy\nand clarity",
+    "quick_afternoon": "Quick\n\"pick-me-up\"",
+    "quick_evening": "Quick detox to\nsleep better",
+    "longer_session": "Longer, more\ntailored session",
+    "help_me_deal": "Help me deal\nwith something",
+    "help_me_deal_custom_title": "Okay, let's start here.\nWhat are you feeling?",
+    "explore_deeper": "Explore the\npractice deeper",
+    "unlock_guided_meditations": "Unlock guided meditations",
+    "meditate_with_others": "MEDITATE WITH OTHERS",
+    "find_class_near_you": "Find a class\nnear you",
+    "join_live_online_class": "Join a live\nonline class",
+    "improve_your_meditation": "IMPROVE YOUR MEDITATION",
+    "improve_card_techniques_title": "Techniques",
+    "improve_card_techniques_subtitle": "Enhance your meditation with cleansing techniques",
+    "improve_card_subtle_system_title": "Subtle system",
+    "improve_card_subtle_system_subtitle": "Learn about chakras, channels, and Kundalini",
+    "highlights_title": "HIGHLIGHTS",
+    "get_back_in_the_flow": "Get back in\nthe flow",
+    "live_now": "Live now",
+    "minutes_short": "min",
+    "live_countdown_days": "days",
+    "live_countdown_hours": "hours",
+    "live_countdown_minutes": "minutes",
+    "live_reminder_button_active": "30m before",
+    "live_reminder_notification_title": "Live meditation starts soon",
+    "live_reminder_notification_body": "Your live meditation begins in 30 minutes.",
+    "live_reminder_permission_denied": "Allow notifications to get a reminder before live meditation.",
+    "live_reminder_permission_settings": "Enable notifications in Settings to get live meditation reminders."
+  },
+
+  "daily_common": {
+    "unlock_after_first_meditation": "Complete your first meditation to unlock more",
+    "path_coming_soon": "Path content is coming soon",
+    "something_went_wrong": "Something went wrong",
+    "retry": "Retry",
+    "external_link_coming_soon": "External links are coming soon",
+    "card_action_not_available": "This card action is not available yet",
+    "map_coming_soon": "In-person classes are coming soon",
+    "music_coming_soon": "Music section is coming soon"
+  },
+
+  "daily_load_info": {
+    "top_daily_unavailable": "Daily meditation is unavailable right now.",
+    "top_daily_failed": "Daily meditation failed to load.",
+    "top_daily_random": "Daily meditation did not load. Showing a random meditation.",
+    "quick_daily_unavailable": "Quick meditations are unavailable right now.",
+    "quick_daily_failed": "Quick meditations failed to load.",
+    "quick_daily_random": "Daily quick meditations did not load. Showing random meditations."
+  },
+
+  "path_overview": {
+    "error_message": "Failed to load the path. Please try again.",
+    "unit": "UNIT",
+    "retry": "Retry",
+    "more_steps_coming_soon": "MORE STEPS COMING SOON"
+  },
+
+  "path_info": {
+    "first_title": "Welcome to the Path!",
+    "first_text": "In this course you will learn some of the main aspects of Sahaja Yoga meditation.\\n\\nEach step of the path features a guided meditation, but also some nuggets of knowledge and new techniques to improve your meditation!",
+    "second_title": "Your course to learn Sahaja Yoga Meditation",
+    "second_text": "You will gradually learn how to use Sahaja Yoga meditation to help with life's challenges and grow as a person through it.\\n\\nThe meditations will get more advanced as you progress through the path and learn more about this amazing system within you.",
+    "third_title": "Ready to begin?",
+    "third_text": "A journey of a 1000 miles starts with one step.\\n\\nSimply select the first step and let your journey of self-discovery begin!"
+  },
+
+  "path_step_1": {
+    "default_intro_quote": "This Kundalini, when She passes through these six centers, She enlightens those centers, nourishes those centers and integrates them - so in totality you are all right.",
+    "author": "Shri Mataji Nirmala Devi",
+    "begin": "Begin",
+    "skip_title": "Are you sure you want to exit?",
+    "skip_continue": "Continue",
+    "back_to_path": "Back to path"
+  },
+
+  "path_step_2": {
+    "continue_button": "Continue"
+  },
+
+  "path_step_3": {
+    "meditation_intro": "MEDITATION INTRO",
+    "skip_intro": "Skip introduction",
+    "start_meditation": "Start Meditation",
+    "skip_title": "Skip introduction?",
+    "skip_continue": "Skip to meditation",
+    "back_to_intro": "Back to introduction",
+    "exit": "Exit",
+    "back_to_step": "Back to step"
+  },
+
+  "path_step_4": {
+    "delving_deeper": "DELVING DEEPER",
+    "lecture_prompt": "Continue to meditate as you listen to Shri Mataji speak about this subject",
+    "media_card_fallback_title": "“Within us lie all these powers, which can be easily awakened”",
+    "media_card_author": "Talk by Shri Mataji",
+    "media_card_author_subtitle": "The founder of Sahaja Yoga",
+    "media_card_watch_later": "Watch Later",
+    "complete_step": "Complete step"
+  },
+
+  "path_step_complete": {
+    "title": "Step Completed!",
+    "subtitle": "Ready for the next one?",
+    "back_to_path": "Back to Path"
+  },
+
+  "explore_overview": {
+    "section_label": "Explore",
+    "section_meditate_title": "Meditate",
+    "section_learn_title": "Learn",
+    "section_join_title": "Join free classes",
+    "card_daily_title": "Daily",
+    "card_daily_subtitle": "Meditations tailored to your state and the time of day",
+    "card_path_title": "Path",
+    "card_path_subtitle": "Guided course to go deeper in Sahaja Yoga",
+    "card_techniques_title": "Techniques",
+    "card_techniques_subtitle": "Enhance your meditation",
+    "card_vibes_check_title": "Vibes check",
+    "card_vibes_check_subtitle": "Tailor your meditation to your state",
+    "card_music_title": "Music for meditation",
+    "card_challenges_title": "Challenges",
+    "card_talks_title": "Talks of\nShri Mataji",
+    "card_subtle_system_title": "Subtle System",
+    "card_who_is_title": "Who is\nShri Mataji",
+    "card_what_is_title": "What is Sahaja Yoga?",
+    "card_live_online_title": "Live Online\nClasses",
+    "card_find_classes_title": "Find classes\nnear you",
+    "card_coming_soon": "Coming soon"
+  },
+
+  "explore_subtle_system": {
+    "_source": "yaml meditation.subtle_system.* — moved under explore.* in #388. yaml extras (worked_on_title/subtitle) are not in the new schema (Explore-only surface).",
+    "screen_label": "Subtle system",
+    "diagram_title": "Tap the diagram to learn about chakras & channels",
+    "diagram_subtitle": "",
+    "mode_chakras": "Chakras",
+    "mode_channels": "Channels",
+    "front_view_mirrored": "Front view - left and right are mirrored",
+    "chip_right": "Right",
+    "chip_center": "Center",
+    "chip_left": "Left",
+    "aspect_right": "Right Aspect",
+    "aspect_center": "Center Aspect",
+    "aspect_left": "Left Aspect"
+  },
+
+  "explore_talks_intro": {
+    "unavailable": "This talk is temporarily unavailable",
+    "title": "Shri Mataji's Talks",
+    "generic_description": "Shri Mataji Nirmala Devi discovered a unique method of meditation called \"Sahaja Yoga\" which allows the achievement of inner enlightenment and reveals the true potential of humanity. Shri Mataji devoted her entire life to the development and dissemination of this method, and today hundreds of thousands of people around the world practice Sahaja Yoga.",
+    "clip_description": "You are about to watch a video with the founder of Sahaja Yoga Shri Mataji.",
+    "post_first_meditation_name": "Shri Mataji,",
+    "post_first_meditation_subtitle": "The founder of Sahaja Yoga",
+    "post_first_meditation_description": "Let's now learn about this technique directly from the founder of Sahaja Yoga Meditation",
+    "start": "Start",
+    "maybe_later": "Maybe later",
+    "watch_now": "Watch now"
+  },
+
+  "explore_talks_list": {
+    "screen_title": "SHRI MATAJI'S TALKS",
+    "section_title": "Learn from the source",
+    "description": "Enrich your practice with subtle knowledge straight from the founder of Sahaja Yoga, Shri Mataji Nirmala Devi.",
+    "all_tags": "All tags",
+    "learn_more": "Learn more",
+    "start": "Start",
+    "watched": "Watched"
+  },
+
+  "explore_talks_player": {
+    "unavailable": "We couldn't load this talk right now",
+    "play": "Play",
+    "pause": "Pause",
+    "replay": "Replay",
+    "subtitles_title": "Subtitles",
+    "subtitles_off": "Off",
+    "subtitles_english": "English",
+    "subtitles_turkish": "Turkish",
+    "subtitles_bulgarian": "Bulgarian",
+    "subtitles_portuguese_brazil": "Portuguese (Brazil)",
+    "subtitles_french": "French",
+    "subtitles_spanish": "Spanish"
+  },
+
+  "profile_main": {
+    "_source": "yaml profile.main.* + 5 new keys for the LEGAL section (legal_header + privacy_policy_*/terms_and_conditions_* rows) sourced from the Profile tab Figma. privacy_and_advertising_title/subtitle values corrected against the same screenshot.",
+    "favourites_header": "MY FAVOURITES",
+    "see_all": "See All",
+    "no_favourites_title": "No favourites yet",
+    "no_favourites_subtitle": "Like the meditations you enjoyed the most to save them here",
+    "history_title": "History",
+    "history_subtitle": "Your meditation activities",
+    "account_title": "Account settings",
+    "account_subtitle": "Your details and preferences",
+    "privacy_and_advertising_title": "Privacy & Advertising",
+    "privacy_and_advertising_subtitle": "Privacy choices and ad preferences",
+    "feedback_header": "ANY FEEDBACK?",
+    "contact_title": "Contact us",
+    "contact_subtitle": "Your feedback or ideas",
+    "legal_header": "LEGAL",
+    "privacy_policy_title": "Privacy Policy",
+    "privacy_policy_subtitle": "How we collect and use data",
+    "terms_and_conditions_title": "Terms & Conditions",
+    "terms_and_conditions_subtitle": "Legal terms for using WeMeditate",
+    "joined_fallback": "Joined recently",
+    "joined_one_month": "Joined 1 month ago",
+    "joined_months": "Joined {months} months ago",
+    "joined_less_than_year": "Joined less than a year ago",
+    "joined_one_year": "Joined 1 year ago",
+    "joined_years": "Joined {years} years ago"
+  },
+
+  "profile_favourites": {
+    "title": "FAVOURITES",
+    "removed_from_favourites": "Removed from favourites"
+  },
+
+  "profile_history": {
+    "title": "HISTORY",
+    "empty_title": "No activity",
+    "empty_subtitle": "Your meditations and other activities you do will be displayed here"
+  },
+
+  "profile_account": {
+    "_source": "yaml profile.account.* — yaml has extra phone_*/sign_in_method_*/delete_account_confirmation_*/not_now keys NOT in the new schema (#386 curated subset). Skipped here as not part of this global.",
+    "title": "My Account",
+    "details_header": "YOUR DETAILS",
+    "name_label": "Name",
+    "name_hint": "Your name",
+    "save": "Save",
+    "saving": "Saving...",
+    "saved": "Account settings saved",
+    "first_name_label": "First Name",
+    "email_label": "Email",
+    "password_label": "Password",
+    "edit_action": "Edit",
+    "edit_first_name_title": "Edit First Name",
+    "edit_email_title": "Edit Email",
+    "cancel": "Cancel",
+    "save_changes": "Save Changes",
+    "save_failed": "Failed to save account settings",
+    "reset_password_title": "Reset Password",
+    "reset_password_description": "We will send the password reset link to your registered email:",
+    "reset_password_action": "Reset Password",
+    "reset_password_sent": "Password reset email sent",
+    "reset_password_error": "Failed to send password reset email",
+    "email_edit_unavailable": "Email editing is not available yet",
+    "email_unavailable": "Email not available",
+    "create_account": "Create account",
+    "delete_account_title": "Delete Account",
+    "delete_account_description": "This will permanently delete your account and remove your profile data from the app.",
+    "delete_account_error": "Failed to delete account",
+    "delete_account_requires_recent_login": "Please log in again before deleting your account",
+    "reauthenticate_title": "Confirm Password",
+    "reauthenticate_description": "Please confirm your password to continue deleting your account.",
+    "reauthenticate_required": "Please enter your password to continue",
+    "reauthenticate_invalid": "Incorrect password",
+    "continue_action": "Continue",
+    "guest_email_prompt": "Log in to add email",
+    "guest_password_prompt": "Log in to manage password",
+    "login": "Log in",
+    "logout": "Log out",
+    "privacy_policy": "Privacy policy",
+    "delete_account": "Delete account"
+  },
+
+  "profile_privacy_advertising": {
+    "_source": "Sourced from Figma node-id 11571-40337 plus the Privacy & Advertising screen design. Includes 5 new keys for the Learn more section (header + privacy_policy_*/terms_and_conditions_* rows) that mirror the labels used on the Profile tab.",
+    "_todo": "Editor: confirm the `advertising_platforms_*` values — that section was below the screenshot fold and is not visible in the current design review. May not ship in this iteration.",
+    "strings": {
+      "screen_title": "Help spread the word and make the app better",
+      "status_allowed": "Status: Allowed on {date}",
+      "status_not_allowed": "Status: Not allowed",
+      "product_analytics_title": "Anonymous product analytics",
+      "product_analytics_description": "We log anonymous, aggregated information about how the app is used so we can fix bugs and improve We Meditate. No individual data, no advertisers, no profile of you. You can opt out by turning this off above.",
+      "advertising_title": "Advertising measurement and improvement",
+      "advertising_body_benefits": "We are a non-profit with a modest budget, and this helps us spend it wisely: we see which outreach is useful, avoid bothering people who already use WeMeditate, and help ad platforms find people with similar interests who may benefit from meditation.",
+      "advertising_body_change_hint": "You can change this anytime using the toggle above.",
+      "advertising_platforms_header": "Current advertising platforms",
+      "advertising_platform_meta": "Meta",
+      "advertising_platform_google_ads": "Google Ads",
+      "advertising_platform_apple_search_ads": "Apple Search Ads",
+      "learn_more_header": "Learn more",
+      "privacy_policy_title": "Privacy Policy",
+      "privacy_policy_subtitle": "How we collect and use data",
+      "terms_and_conditions_title": "Terms & Conditions",
+      "terms_and_conditions_subtitle": "Legal terms for using WeMeditate"
+    },
+    "advertising_body_intro": {
+      "_richText": true,
+      "_source": "Collapsed from schema's advertising_body_intro_prefix/_link/_suffix triple. Link target resolves through wm-app-config.privacyPolicyPage with anchor 'what-we-share' (same target as onboarding_consent_modal.body_intro).",
+      "paragraphs": [
+        [
+          { "text": "With your permission, we'll share a few basic app and device details with Meta, Apple Search Ads and Google Ads, like app installs or completed sessions. (" },
+          { "type": "link", "text": "what we share", "href": "wm-app-config://privacyPolicyPage#what-we-share" },
+          { "text": ")." }
+        ]
+      ]
+    },
+    "advertising_body_never_share": {
+      "_richText": true,
+      "_source": "Converted from plain string. One paragraph with two bold spans ('We'll never share' / 'we never sell'), matching the Figma node-id 11571-40337 rendering (single paragraph, two emphasised phrases).",
+      "paragraphs": [
+        [
+          { "text": "We'll never share", "bold": true },
+          { "text": " your mood, goals, hand sensations, reflections, location, or details about your practice. And " },
+          { "text": "we never sell", "bold": true },
+          { "text": " your data, ever." }
+        ]
+      ]
+    }
+  },
+
+  "profile_contact": {
+    "title": "CONTACT US",
+    "header": "We are always looking for ways to improve this app, so your feedback is more than welcome!",
+    "subtitle": "We are always looking for ways to improve this app, so your feedback is more than welcome!",
+    "placeholder": "Type here..",
+    "send": "Send",
+    "sending": "Sending...",
+    "sent": "Thank you for your feedback",
+    "empty_error": "Please enter your message",
+    "min_length_error": "Please write at least 50 characters",
+    "send_error": "Failed to send feedback"
+  },
+
+  "meditation_intent": {
+    "_source": "yaml meditation.intent.* — split from yaml's combined intent+reminder block by #388. Reminder keys (yaml meditation.intent.reminder_*) live under meditation_reminder below.",
+    "carousel_continue": "Continue",
+    "skip_video_and_continue": "Skip video and continue",
+    "repeat_video": "Repeat explanation",
+    "start_meditation": "Start meditation",
+    "skip_and_explore_the_app": "Skip and explore the app",
+    "step_label": "Step 1 of 3",
+    "title_today": "How can we best\nsupport you today?",
+    "title_tonight": "How can we best\nsupport you tonight?",
+    "first_meditation_title": "Your first meditation",
+    "first_meditation_subtitle": "Start with this Kundalini awakening meditation",
+    "repeat_first_meditation_title": "Your First Meditation",
+    "repeat_first_meditation_subtitle": "Express once more the pure desire for your Kundalini energy to rise",
+    "ready_to_try_title": "Ready to try?",
+    "ready_to_try_subtitle_beginner": "Awaken your inner energy with this next meditation.",
+    "ready_to_try_subtitle_repeat": "Awaken your inner energy once more with this next meditation.",
+    "quick_morning_title": "Quick morning meditation",
+    "quick_afternoon_title": "Quick afternoon meditation",
+    "quick_evening_title": "Quick evening meditation",
+    "quick_morning_subtitle": "Get your dose of joy, focus and clarity for the day",
+    "quick_afternoon_subtitle": "Get a quick energy boost,\ncalm down and reconnect",
+    "quick_evening_subtitle": "Simple session to unwind, detox, reconnect and sleep better",
+    "personalized_title": "Personalised meditation, tailored to your state",
+    "personalized_subtitle": "An extended session with more personalisation",
+    "locked_subtitle": "Unlocks after first meditation",
+    "learn_more": "Learn more",
+    "go_to_first_meditation": "Go to first meditation",
+    "set_reminder_for_later": "Set a reminder for later",
+    "locked_quick_start_title": "Start right away",
+    "locked_quick_start_description_morning": "Get your dose of joy, focus and clarity for the day.",
+    "locked_quick_start_description_afternoon": "Get a quick energy boost, calm down and reconnect.",
+    "locked_quick_start_description_evening": "Simple session to unwind, detox, reconnect and sleep better.",
+    "locked_quick_custom_time_title": "Custom time",
+    "locked_quick_custom_time_description": "Choose between 5, 10 and 15 minutes.",
+    "locked_personalized_feeling_title": "How are you feeling?",
+    "locked_personalized_feeling_description": "Choose your current state to personalise your meditation.",
+    "locked_personalized_custom_time_title": "Custom time",
+    "locked_personalized_custom_time_description": "After the first 15 minutes, choose how long you'd like to continue for."
+  },
+
+  "meditation_reminder": {
+    "_source": "yaml meditation.intent.reminder_* — split from the combined intent block by #388, with the reminder_ prefix dropped.",
+    "prompt_title": "Schedule this meditation\nfor later?",
+    "prompt_subtitle": "Pick a time and we'll send a reminder\nto try your first meditation!",
+    "prompt_set_reminder": "Set a reminder",
+    "prompt_no_thanks": "No thanks",
+    "prompt_allow_notifications_title": "Allow notifications, so we can send your reminder",
+    "prompt_allow_notifications_subtitle": "Tap \"Allow\" on the next screen",
+    "prompt_allow_notifications_primary": "Allow notifications",
+    "prompt_not_now": "Not now",
+    "prompt_turn_on_notifications_title": "Turn on notifications",
+    "prompt_turn_on_notifications_subtitle": "Enable notifications in your device settings to receive meditation reminders.",
+    "prompt_open_settings": "Open settings",
+    "sheet_title": "Set a reminder to get back\nto this meditation later",
+    "sheet_dont_set": "Don't set a reminder",
+    "sheet_done": "Done",
+    "sheet_return_to_meditation": "Return to meditation",
+    "sheet_leave_meditation": "Leave meditation",
+    "sheet_success_title": "Reminder set",
+    "sheet_success_subtitle": "We will send a notification to remind you later!",
+    "sheet_explore_app": "Explore the app",
+    "sheet_start_first_meditation": "Start first meditation",
+    "sheet_error": "Couldn't set reminder. Please try again.",
+    "preset_unwind_later_today": "Unwind later today",
+    "preset_start_your_week_calm": "Start your week calm",
+    "preset_find_your_midweek_balance": "Find your midweek balance",
+    "preset_pause_and_recharge": "Pause and recharge",
+    "preset_mindful_break_before_weekend": "Mindful break before the weekend",
+    "preset_end_your_week_with_peace": "End your week with peace",
+    "preset_slow_down_weekend": "Slow down and enjoy your weekend",
+    "preset_reset_for_week_ahead": "Reset for the week ahead",
+    "notification_title": "Time to meditate",
+    "notification_body_locked": "Your meditation reminder is ready when you are.",
+    "notification_body_exit": "Come back to your meditation when you're ready.",
+    "allow_notifications_screen_title": "Allow notifications to set a reminder",
+    "allow_notifications_screen_subtitle": "This way we will be able to send you a\nreminder about your meditation ✨"
+  },
+
+  "meditation_footsoak": {
+    "strings": {
+      "step_label": "Step 3 of 3",
+      "title": "Footsoak with this meditation?",
+      "tutorial_cta": "See how to do it",
+      "start_with_footsoak": "Start with a footsoak",
+      "start_meditation": "Start Meditation"
+    },
+    "description": {
+      "_richText": true,
+      "_source": "Collapsed from yaml meditation.footsoak.description_prefix + .description_emphasis + .description_suffix. Emphasis rendered italic.",
+      "paragraphs": [
+        [
+          { "text": "This would " },
+          { "text": "really", "italic": true },
+          { "text": " help you have a much better meditation!" }
+        ]
+      ]
+    }
+  },
+
+  "meditation_player": {
+    "load_error_title": "Failed to load meditation"
+  },
+
+  "meditation_vibes_check": {
+    "_source": "yaml meditation.vibes_check.* — question_prefix/suffix + left_hand/right_hand kept as separate template placeholder keys per schema (#388). NOT collapsed to richText because left_hand/right_hand are reused as standalone words on interpretation screens.",
+    "intro_question": "What do you feel\non your hands?",
+    "question_prefix": "What do you feel on your\n",
+    "question_suffix": " hand?",
+    "left_hand": "left",
+    "right_hand": "right",
+    "cool": "Cool",
+    "warm": "Warm",
+    "fingers_tingling": "Fingers tingling",
+    "nothing": "Nothing",
+    "continue_action": "Continue",
+    "not_sure": "Not sure",
+    "got_it": "Got it",
+    "interpretation_nothing": "No worries! You will start feeling these sensations as you continue to meditate.",
+    "interpretation_intro": "Feeling cool means it is clear, and the Kundalini energy is flowing nicely :)",
+    "interpretation_detail": "Your left hand is a representation of your left energy channel",
+    "skip_vibes_check": "Skip vibes check",
+    "skip_prompt_title": "Skip vibes check?",
+    "skip_prompt_description": "It will provide explanation to what you have experienced.",
+    "back_to_explanation": "Continue vibes check",
+    "return_to_meditation_prompt_title": "Return to meditation?",
+    "return_to_meditation_prompt_description": "This will start the first meditation from the beginning - you can always skip to the end if you missed something.",
+    "return_to_meditation_action": "Return to meditation",
+    "skip_it": "Skip it"
+  },
+
+  "meditation_feedback": {
+    "_source": "yaml path_meditation_feedback.* — moved from path.* to meditation.* in #388 (generic, not path-specific).",
+    "title": "How was your experience?",
+    "description": "Did you enjoy the meditation? What was good and what could be improved?",
+    "error_length": "Please write at least 50 characters",
+    "hint": "Type here..",
+    "send": "Send",
+    "thank_you": "Thank you!",
+    "thank_you_description": "Your feedback\nhelps us improve\nthis app",
+    "close": "Close"
+  },
+
+  "auth_common": {
+    "or": "or",
+    "continue_with_apple": "Continue with Apple",
+    "continue_with_google": "Continue with Google",
+    "continue_with_facebook": "Continue with Facebook",
+    "continue_with_email": "Continue with Email",
+    "cancel": "Cancel",
+    "error_enter_email": "Please enter your email",
+    "error_invalid_email": "Please enter a valid email",
+    "error_enter_password": "Please enter your password",
+    "error_password_min_length": "Password must be at least 6 characters"
+  },
+
+  "auth_login": {
+    "title": "Log In",
+    "email_label": "Email",
+    "email_placeholder": "Your email",
+    "password_label": "Password",
+    "password_placeholder": "Your password",
+    "next": "Next",
+    "signing_in": "Signing in...",
+    "forgot_password": "Forgot password",
+    "continue_as_new_user": "Continue as new user",
+    "account_not_found_title": "We couldn't find your account",
+    "account_not_found_subtitle": "Please try a different account, create a new one or continue as a new user",
+    "account_exists_title": "Sign in with your existing account",
+    "account_exists_subtitle": "We found another sign-in method for this email. Use {providers} to continue, then we'll connect everything to the same account.",
+    "create_new_account": "Create new account",
+    "try_different_account": "Try different account",
+    "account_exists_existing_provider_fallback": "your existing provider",
+    "open_login": "Open login",
+    "error_cannot_continue_with_email": "We couldn't continue with that email. Please check it or continue as a new user.",
+    "error_invalid_credentials": "Incorrect email or password",
+    "error_too_many_requests": "Too many attempts. Please try again later",
+    "error_session_persistence": "Signed in, but failed to restore your session",
+    "error_generic": "Failed to sign in"
+  },
+
+  "auth_restore_password": {
+    "title": "Restore Password",
+    "description": "Please enter your email address. We'll send you a link to reset your password.",
+    "email_label": "Email",
+    "email_placeholder": "Your email",
+    "submit": "Restore password",
+    "error_invalid_email": "Please enter a valid email"
+  },
+
+  "auth_restore_password_email_sent": {
+    "message": "An email has been sent.\nPlease check your inbox.",
+    "ok": "OK"
+  },
+
+  "auth_create_account": {
+    "strings": {
+      "title": "Create Account",
+      "screen_title": "Let's create your account!",
+      "screen_subtitle": "This will save your progress and unlock all the features of the app",
+      "skip_and_explore": "Skip for now",
+      "error_check_consent": "Check the box to continue",
+      "email_label": "Email",
+      "email_placeholder": "Your email",
+      "password_label": "Password",
+      "password_placeholder": "Create a password",
+      "submit": "Create Account",
+      "creating": "Creating...",
+      "error_email_in_use": "An account with this email already exists. Please login or use a different email.",
+      "login_with_existing_account": "Login with existing account",
+      "error_invalid_email": "Please enter a valid email",
+      "error_weak_password": "Password must be at least 6 characters",
+      "error_too_many_requests": "Too many attempts. Please try again later",
+      "error_session_persistence": "Account created, but failed to restore your session",
+      "error_generic": "Failed to create account",
+      "error_google_failed": "Failed to continue with Google",
+      "error_apple_failed": "Failed to continue with Apple",
+      "error_facebook_failed": "Failed to continue with Facebook",
+      "error_provider_cancelled": "Authentication was cancelled"
+    },
+    "consent_label": {
+      "_richText": true,
+      "_source": "Collapsed from yaml auth.create_account.consent_prefix + .consent_terms + .consent_and_acknowledge + .consent_privacy. Link targets resolve through wm-app-config.termsAndConditionsPage and wm-app-config.privacyPolicyPage.",
+      "paragraphs": [
+        [
+          { "text": "I agree to WeMeditate's " },
+          { "type": "link", "text": "Terms & Conditions", "href": "wm-app-config://termsAndConditionsPage" },
+          { "text": " and confirm that I acknowledge the " },
+          { "type": "link", "text": "Privacy Policy", "href": "wm-app-config://privacyPolicyPage" }
+        ]
+      ]
+    }
+  },
+
+  "navigation": {
+    "daily": "Daily",
+    "path": "Path",
+    "explore": "Explore",
+    "profile": "Profile"
+  },
+
+  "general": {
+    "back": "Back",
+    "retry": "Retry",
+    "undo": "Undo"
+  }
+}

--- a/seeds/wm-app-translations/import.ts
+++ b/seeds/wm-app-translations/import.ts
@@ -1,0 +1,146 @@
+/**
+ * wm-app-translations Import Script
+ *
+ * Seeds the `wm-app-translations` PayloadCMS global with English source copy
+ * from `seeds/wm-app-translations/data.en.json`. The seed data covers all
+ * 40 leaf groups (33 pure-string + 7 mixed-with-richText). Sources documented
+ * inline in the JSON's `_meta` block — see issue #393 for the full rationale.
+ *
+ * Idempotent — re-running overwrites the English locale value for every key
+ * in the seed. Other locales are untouched.
+ *
+ * Usage:
+ *   pnpm seed wm-app-translations --dry-run
+ *   pnpm seed wm-app-translations
+ *   SAHAJCLOUD_URL=https://cloud.sydevelopers.com pnpm seed wm-app-translations
+ */
+
+import * as path from 'path'
+
+import { BaseImporter, type BaseImportOptions } from '../lib'
+
+import {
+  collectSeedTodos,
+  seedLeafToPayloadData,
+  type PayloadLeafData,
+  type SeedFile,
+  type SeedLeaf,
+} from './lexicalConverter'
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+const SEED_DATA_LOCAL_PATH = 'seeds/wm-app-translations/data.en.json'
+const SEED_DATA_WORKER_URL =
+  'https://raw.githubusercontent.com/sydevs/SahajCloud/main/seeds/wm-app-translations/data.en.json'
+
+const GLOBAL_SLUG = 'wm-app-translations'
+const LOCALE: 'en' = 'en'
+
+// ============================================================================
+// Importer
+// ============================================================================
+
+export class WeMeditateAppTranslationsImporter extends BaseImporter<BaseImportOptions> {
+  protected readonly importName = 'WeMeditate App Translations (English seed)'
+  protected readonly cacheDir = path.resolve(
+    process.cwd(),
+    'seeds/cache/wm-app-translations',
+  )
+
+  protected async import(): Promise<void> {
+    // 1. Load seed data (works in both local dev and Workers).
+    const { loadJsonData } = await import('../lib/dataLoader')
+    const seed = await loadJsonData<SeedFile>({
+      localPath: SEED_DATA_LOCAL_PATH,
+      workerUrl: SEED_DATA_WORKER_URL,
+    })
+
+    // 2. Transform every leaf to its Payload data shape (this runs the
+    //    segments→Lexical conversion for the 7 mixed leaves).
+    const data: Record<string, PayloadLeafData> = {}
+    for (const [leafName, leaf] of Object.entries(seed)) {
+      if (leafName.startsWith('_') || !leaf) continue
+      try {
+        data[leafName] = seedLeafToPayloadData(leafName, leaf as SeedLeaf)
+      } catch (error) {
+        this.addError(`Transforming ${leafName}`, error instanceof Error ? error : String(error))
+        return
+      }
+    }
+
+    const leafNames = Object.keys(data)
+    const mixedCount = leafNames.filter(
+      (name) =>
+        'strings' in data[name] &&
+        typeof (data[name] as { strings?: unknown }).strings === 'object',
+    ).length
+    const pureCount = leafNames.length - mixedCount
+
+    await this.logger.info(
+      `Planned writes: ${leafNames.length} leaf groups (${pureCount} pure-string + ${mixedCount} mixed)`,
+    )
+
+    // 3. Surface every `_todo` marker so editors know what to finalise in
+    //    the admin UI after the import lands.
+    const todos = collectSeedTodos(seed)
+    if (todos.length > 0) {
+      await this.logger.warn(
+        `${todos.length} TODO marker(s) — editor should finalise in the admin UI:`,
+      )
+      for (const todo of todos) {
+        await this.logger.warn(`  - ${todo}`)
+      }
+      todos.forEach((todo) => this.addWarning(todo))
+    }
+
+    // 4. Dry-run path: report and stop.
+    if (this.options.dryRun) {
+      await this.logger.info('Dry-run — no write to the global was sent.')
+      // Report each leaf as a "would-be" create so the importer's report
+      // surfaces the planned changes in the summary + SSE progress UI.
+      let current = 0
+      for (const name of leafNames) {
+        this.report.incrementCreated()
+        current += 1
+        await this.reportDocument(GLOBAL_SLUG, name, 'created', {
+          current,
+          total: leafNames.length,
+        })
+      }
+      return
+    }
+
+    // 5. Commit path: single updateGlobal call writes all leaves at once.
+    if (!this.payload) {
+      throw new Error('Payload instance not initialised (BaseImporter contract violation)')
+    }
+    try {
+      await this.payload.updateGlobal({
+        slug: GLOBAL_SLUG,
+        data: data as Parameters<typeof this.payload.updateGlobal>[0]['data'],
+        locale: LOCALE,
+      })
+      await this.logger.success(`Updated global "${GLOBAL_SLUG}" (locale=${LOCALE})`)
+      // Report each leaf so the summary shows the write count.
+      let current = 0
+      for (const name of leafNames) {
+        this.report.incrementUpdated()
+        current += 1
+        await this.reportDocument(GLOBAL_SLUG, name, 'updated', {
+          current,
+          total: leafNames.length,
+        })
+      }
+    } catch (error) {
+      this.addError(
+        `updateGlobal ${GLOBAL_SLUG} locale=${LOCALE}`,
+        error instanceof Error ? error : String(error),
+      )
+      throw error
+    }
+  }
+}
+
+export default WeMeditateAppTranslationsImporter

--- a/seeds/wm-app-translations/lexicalConverter.ts
+++ b/seeds/wm-app-translations/lexicalConverter.ts
@@ -1,0 +1,302 @@
+/**
+ * Lexical Converter — wm-app-translations seed
+ *
+ * Converts the human-readable paragraph/segment shape used in
+ * `seeds/wm-app-translations/data.<locale>.json` into the Lexical JSON
+ * tree shape that Payload's richText fields persist.
+ *
+ * The Lexical shape this emits intentionally matches the conventions of
+ * `seeds/lib/lexicalConverter.ts` (the EditorJS→Lexical converter that
+ * has been tested against the live Payload editor) — same field set on
+ * text/paragraph/link/root nodes, `direction: null` everywhere, link
+ * nodes use `version: 3` with `fields: { linkType: 'custom', url, newTab: false }`.
+ *
+ * Kept as a separate file (not inlined into import.ts) so the conversion
+ * logic can be unit-tested in `tests/unit/wm-app-translations-lexical.spec.ts`
+ * without booting Payload.
+ */
+
+// ============================================================================
+// Public types (seed-side shape)
+// ============================================================================
+
+/**
+ * A single inline segment inside a paragraph.
+ *
+ * - A plain or formatted text run: { text, bold?, italic? }
+ * - An inline link: { type: 'link', text, href, bold?, italic? }
+ */
+export interface SeedTextSegment {
+  text: string
+  bold?: true
+  italic?: true
+}
+
+export interface SeedLinkSegment {
+  type: 'link'
+  text: string
+  href: string
+  bold?: true
+  italic?: true
+}
+
+export type SeedSegment = SeedTextSegment | SeedLinkSegment
+
+/**
+ * The richText payload as written in `data.<locale>.json`.
+ *
+ * The `_richText: true` marker disambiguates from plain-string values that
+ * sit alongside richText fields inside a mixed leaf's `strings` block.
+ *
+ * `_source` and `_todo` are documentation-only fields that the import
+ * script reads for surfacing editor follow-ups but does not write to
+ * Payload.
+ */
+export interface SeedRichTextField {
+  _richText: true
+  _source?: string
+  _todo?: string
+  paragraphs: SeedSegment[][]
+}
+
+export function isSeedRichTextField(value: unknown): value is SeedRichTextField {
+  return (
+    typeof value === 'object' && value !== null && (value as SeedRichTextField)._richText === true
+  )
+}
+
+// ============================================================================
+// Lexical output types
+// ============================================================================
+
+export interface LexicalTextNode {
+  type: 'text'
+  version: 1
+  format: number
+  text: string
+  detail: 0
+  mode: 'normal'
+  style: ''
+}
+
+export interface LexicalLinkNode {
+  type: 'link'
+  version: 3
+  format: ''
+  indent: 0
+  direction: null
+  fields: { linkType: 'custom'; url: string; newTab: boolean }
+  children: LexicalTextNode[]
+}
+
+export interface LexicalParagraphNode {
+  type: 'paragraph'
+  version: 1
+  format: ''
+  indent: 0
+  direction: null
+  textFormat: 0
+  children: Array<LexicalTextNode | LexicalLinkNode>
+}
+
+export interface LexicalRoot {
+  root: {
+    type: 'root'
+    version: 1
+    format: ''
+    indent: 0
+    direction: null
+    children: LexicalParagraphNode[]
+  }
+}
+
+// ============================================================================
+// Conversion
+// ============================================================================
+
+/**
+ * Lexical text-node `format` is a bitmask; the relevant bits for the
+ * basicRichTextEditor preset (Bold + Italic + Link + InlineToolbar) are:
+ *
+ *   bit 0 (value 1) — Bold
+ *   bit 1 (value 2) — Italic
+ *
+ * Underline (4), strikethrough (8), code (16), subscript (32),
+ * superscript (64), highlight (128) are not enabled in the editor preset
+ * and the seed schema does not allow them.
+ */
+const FORMAT_BOLD = 1
+const FORMAT_ITALIC = 2
+
+function segmentFormatFlags(seg: SeedSegment): number {
+  let f = 0
+  if (seg.bold) f |= FORMAT_BOLD
+  if (seg.italic) f |= FORMAT_ITALIC
+  return f
+}
+
+function textNode(text: string, format = 0): LexicalTextNode {
+  return { type: 'text', version: 1, format, text, detail: 0, mode: 'normal', style: '' }
+}
+
+function segmentToLexicalChild(
+  seg: SeedSegment,
+  ctx: string,
+): LexicalTextNode | LexicalLinkNode {
+  if ('type' in seg && seg.type === 'link') {
+    if (!seg.href) {
+      throw new Error(`[${ctx}] link segment missing href: ${JSON.stringify(seg)}`)
+    }
+    if (!seg.text) {
+      throw new Error(`[${ctx}] link segment missing text: ${JSON.stringify(seg)}`)
+    }
+    return {
+      type: 'link',
+      version: 3,
+      format: '',
+      indent: 0,
+      direction: null,
+      fields: { linkType: 'custom', url: seg.href, newTab: false },
+      children: [textNode(seg.text, segmentFormatFlags(seg))],
+    }
+  }
+  if (typeof seg.text !== 'string') {
+    throw new Error(`[${ctx}] text segment missing text: ${JSON.stringify(seg)}`)
+  }
+  return textNode(seg.text, segmentFormatFlags(seg))
+}
+
+/**
+ * Convert a seed richText field (paragraphs of segments) to the Lexical
+ * JSON tree shape that Payload's richText fields persist.
+ *
+ * `ctx` is a human-readable label (e.g. `"onboarding_consent_modal.body_intro"`)
+ * used in error messages when an individual segment is malformed.
+ */
+export function seedRichTextToLexical(field: SeedRichTextField, ctx: string): LexicalRoot {
+  if (!Array.isArray(field.paragraphs) || field.paragraphs.length === 0) {
+    throw new Error(`[${ctx}] richText field must have a non-empty paragraphs array`)
+  }
+  return {
+    root: {
+      type: 'root',
+      version: 1,
+      format: '',
+      indent: 0,
+      direction: null,
+      children: field.paragraphs.map((segments, paragraphIdx) => {
+        if (!Array.isArray(segments) || segments.length === 0) {
+          throw new Error(
+            `[${ctx}] paragraph ${paragraphIdx} must be a non-empty array of segments`,
+          )
+        }
+        return {
+          type: 'paragraph',
+          version: 1,
+          format: '',
+          indent: 0,
+          direction: null,
+          textFormat: 0,
+          children: segments.map((s, segmentIdx) =>
+            segmentToLexicalChild(s, `${ctx}[¶${paragraphIdx}][${segmentIdx}]`),
+          ),
+        }
+      }),
+    },
+  }
+}
+
+// ============================================================================
+// Leaf transformation
+// ============================================================================
+
+/**
+ * One leaf-group entry as written in `data.<locale>.json`.
+ *
+ * - Pure-string leaf: `{ key1: "value1", key2: "value2", ... }` (no `strings` block).
+ * - Mixed leaf: `{ strings: { key1, key2 }, richKey1: SeedRichTextField, ... }`.
+ *
+ * Documentation-only keys (`_source`, `_todo`, ...) start with `_` and are
+ * ignored when shaping the Payload write.
+ */
+export type SeedLeaf =
+  | Record<string, string>
+  | ({ strings: Record<string, string> } & Record<string, SeedRichTextField | string>)
+
+/**
+ * The Payload data shape that gets written to a single leaf-group field on
+ * the wm-app-translations global.
+ *
+ * - Pure-string leaf: `Record<string, string>` — same as before Phase 1.
+ * - Mixed leaf: `{ strings: Record<string, string>, richKey: LexicalRoot, ... }`
+ *   matching the Payload group field that wraps the leaf post-Phase-1.
+ */
+export type PayloadLeafData =
+  | Record<string, string>
+  | ({ strings: Record<string, string> } & Record<string, LexicalRoot>)
+
+/**
+ * Convert a seed leaf to the Payload data shape, dropping `_*` metadata
+ * keys and running every richText sibling through {@link seedRichTextToLexical}.
+ */
+export function seedLeafToPayloadData(leafName: string, leaf: SeedLeaf): PayloadLeafData {
+  const stringsBlock = (leaf as { strings?: Record<string, string> }).strings
+  if (!stringsBlock) {
+    // Pure-string leaf.
+    const out: Record<string, string> = {}
+    for (const [k, v] of Object.entries(leaf)) {
+      if (k.startsWith('_')) continue
+      if (typeof v !== 'string') {
+        throw new Error(
+          `[${leafName}.${k}] pure-string leaf has non-string value: ${JSON.stringify(v)}`,
+        )
+      }
+      out[k] = v
+    }
+    return out
+  }
+  // Mixed leaf.
+  const out: Record<string, Record<string, string> | LexicalRoot> = {
+    strings: { ...stringsBlock },
+  }
+  for (const [k, v] of Object.entries(leaf)) {
+    if (k === 'strings' || k.startsWith('_')) continue
+    if (!isSeedRichTextField(v)) {
+      throw new Error(
+        `[${leafName}.${k}] sibling of "strings" is not a richText field: ${JSON.stringify(v)}`,
+      )
+    }
+    out[k] = seedRichTextToLexical(v, `${leafName}.${k}`)
+  }
+  return out as PayloadLeafData
+}
+
+/**
+ * Top-level seed file shape: an envelope with an optional `_meta` block
+ * documenting source and conventions, plus one entry per leaf-group field.
+ */
+export interface SeedFile {
+  _meta?: Record<string, unknown>
+  [leafFieldName: string]: SeedLeaf | Record<string, unknown> | undefined
+}
+
+/**
+ * Walk the seed and surface every `_todo` marker (at the leaf-group level
+ * and at the richText-field level) so the importer can log them.
+ */
+export function collectSeedTodos(seed: SeedFile): string[] {
+  const todos: string[] = []
+  for (const [leafName, leaf] of Object.entries(seed)) {
+    if (leafName.startsWith('_') || !leaf) continue
+    const obj = leaf as Record<string, unknown>
+    if (typeof obj._todo === 'string') {
+      todos.push(`${leafName}: ${obj._todo}`)
+    }
+    for (const [k, v] of Object.entries(obj)) {
+      if (isSeedRichTextField(v) && v._todo) {
+        todos.push(`${leafName}.${k}: ${v._todo}`)
+      }
+    }
+  }
+  return todos
+}

--- a/src/app/(payload)/api/seed/[script]/route.ts
+++ b/src/app/(payload)/api/seed/[script]/route.ts
@@ -13,6 +13,7 @@
  * - wemeditate: Authors, Albums, Music, Pages
  * - meditations: Meditations, Frames, Music
  * - storyblok: Lessons, Lectures
+ * - wm-app-translations: WeMeditate App Translations global (English seed)
  *
  * Authentication: Requires admin session
  *
@@ -38,7 +39,13 @@ import {
   type ScriptName,
 } from '../../../../../../seeds/lib/expectedCounts'
 
-const VALID_SCRIPTS: ScriptName[] = ['tags', 'wemeditate', 'meditations', 'storyblok']
+const VALID_SCRIPTS: ScriptName[] = [
+  'tags',
+  'wemeditate',
+  'meditations',
+  'storyblok',
+  'wm-app-translations',
+]
 
 /**
  * Heartbeat interval in milliseconds (5 seconds)
@@ -371,6 +378,12 @@ async function getImporter(
       const { StoryblokImporter } = await import('../../../../../../seeds/storyblok/import')
       return new StoryblokImporter(options, token)
     }
+    case 'wm-app-translations': {
+      const { WeMeditateAppTranslationsImporter } = await import(
+        '../../../../../../seeds/wm-app-translations/import'
+      )
+      return new WeMeditateAppTranslationsImporter(options)
+    }
     default:
       return null
   }
@@ -420,6 +433,12 @@ async function getDatabaseCounts(
         const lectures = await payload.count({ collection: 'lectures' })
         counts['lessons'] = lessons.totalDocs
         counts['lectures'] = lectures.totalDocs
+        break
+      }
+      case 'wm-app-translations': {
+        // Target is the wm-app-translations PayloadCMS global, not a collection.
+        // Verification (verifyCountsForScript) sees an empty EXPECTED_COUNTS entry
+        // and passes by default — return an empty object to match.
         break
       }
     }

--- a/src/fields/translationsField.ts
+++ b/src/fields/translationsField.ts
@@ -1,13 +1,15 @@
 import type { JSONSchema4 } from 'json-schema'
-import type { JSONField, TabsField, UIField } from 'payload'
+import type { Field, GroupField, JSONField, RichTextField, TabsField, UIField } from 'payload'
+
+import { basicRichTextEditor } from '@/lib/richEditor'
 
 // ============================================================================
 // Types
 // ============================================================================
 
 /**
- * Schema entry for a single translation key
- * Used by TranslationsTable component to render each row
+ * Schema entry for a single string translation key.
+ * Used by TranslationsTable component to render each row.
  */
 export interface SchemaEntry {
   key: string
@@ -15,7 +17,7 @@ export interface SchemaEntry {
 }
 
 /**
- * JSON Schema property definition for a string field
+ * JSON Schema property definition for a plain-string translation key.
  */
 interface StringPropertySchema {
   type: 'string'
@@ -23,15 +25,36 @@ interface StringPropertySchema {
 }
 
 /**
+ * JSON Schema property definition for a rich-text translation key.
+ *
+ * Rendered as a Payload `richText` field using the `basicRichTextEditor`
+ * preset (Bold, Italic, Link, InlineToolbar — the minimum needed for inline
+ * formatting in body copy). Used for paragraphs that need inline links or
+ * bold/italic spans the translator can move freely.
+ */
+interface RichTextPropertySchema {
+  type: 'richText'
+  description?: string
+}
+
+/**
+ * A leaf property in the translations schema — either a string or a richText.
+ */
+type LeafPropertySchema = StringPropertySchema | RichTextPropertySchema
+
+/**
  * JSON Schema definition for a group of translations.
  *
  * A group is either:
- * - a leaf group with `properties` of `StringPropertySchema` (renders as one tab
- *   with a flat TranslationsTable), or
+ * - a leaf group with `properties` of `LeafPropertySchema` (strings and/or
+ *   richText). All-string leaves render as one tab with a flat
+ *   TranslationsTable. Leaves containing at least one richText property
+ *   render as a `group` field with `strings` (JSON, only string-typed entries)
+ *   plus one stock Payload `richText` field per richText-typed entry.
  * - a parent group with `properties` of nested `GroupSchema` values (renders as
  *   a tab containing inner sub-tabs, one per child group).
  *
- * Mixing string and object properties at the same level is not supported.
+ * Mixing leaf properties and nested groups at the same level is not supported.
  *
  * Non-JSON-Schema extension fields (ignored by Monaco validation, consumed only
  * by the Payload admin builder):
@@ -46,14 +69,14 @@ interface StringPropertySchema {
 interface GroupSchema {
   type: 'object'
   description?: string
-  properties?: Record<string, StringPropertySchema | GroupSchema>
+  properties?: Record<string, LeafPropertySchema | GroupSchema>
   additionalProperties?: boolean
   screenshot?: string
 }
 
 /**
- * Top-level translations schema structure
- * Each property is a group (e.g., "common", "navigation")
+ * Top-level translations schema structure.
+ * Each property is a group (e.g., "common", "navigation").
  */
 export interface TranslationsSchema {
   type: 'object'
@@ -61,13 +84,24 @@ export interface TranslationsSchema {
   additionalProperties?: boolean
 }
 
-/**
- * Type guard: true when a property is a nested GroupSchema rather than a string leaf.
- */
+// ============================================================================
+// Type guards
+// ============================================================================
+
 function isGroupSchema(
-  prop: StringPropertySchema | GroupSchema | undefined,
+  prop: LeafPropertySchema | GroupSchema | undefined,
 ): prop is GroupSchema {
   return !!prop && prop.type === 'object'
+}
+
+function isStringProp(prop: LeafPropertySchema | GroupSchema): prop is StringPropertySchema {
+  return prop.type === 'string'
+}
+
+function isRichTextProp(
+  prop: LeafPropertySchema | GroupSchema,
+): prop is RichTextPropertySchema {
+  return prop.type === 'richText'
 }
 
 // ============================================================================
@@ -75,7 +109,7 @@ function isGroupSchema(
 // ============================================================================
 
 /**
- * Converts a slug to Title Case
+ * Converts a slug to Title Case.
  * "common" -> "Common"
  * "navigation_links" -> "Navigation Links"
  * "user-settings" -> "User Settings"
@@ -87,16 +121,16 @@ function toTitleCase(slug: string): string {
 /**
  * Extracts schema entries from a leaf group's string properties.
  * Each entry contains the key and its description for the TranslationsTable component.
- * Any non-string (nested-group) entries are skipped — leaf groups are not expected
- * to mix strings and nested groups.
+ * Non-string entries (richText, nested-group) are skipped — they are rendered
+ * as separate fields outside the TranslationsTable.
  */
 function extractSchemaEntries(
-  groupProperties: Record<string, StringPropertySchema | GroupSchema> | undefined,
+  groupProperties: Record<string, LeafPropertySchema | GroupSchema> | undefined,
 ): SchemaEntry[] {
   if (!groupProperties) return []
 
   return Object.entries(groupProperties)
-    .filter(([, prop]) => prop.type === 'string')
+    .filter(([, prop]) => isStringProp(prop))
     .map(([key, prop]) => ({
       key,
       description: prop.description || '',
@@ -133,28 +167,27 @@ function createScreenshotField(
 }
 
 /**
- * Creates a JSON field configuration for a leaf translation group (one whose
- * properties are all string leaves).
+ * Creates the JSON field configuration for the string-only portion of a leaf
+ * group. Field name is `strings` when the leaf is mixed (lives inside a wrapper
+ * group), otherwise the leaf's own slug. Only string-typed schema properties
+ * are surfaced here; richText properties become sibling fields outside this
+ * JSON field.
  */
-function createGroupJsonField(
-  groupSlug: string,
+function createStringsJsonField(
+  fieldName: string,
   groupSchema: GroupSchema,
   globalSlug: string,
+  jsonSchemaUriSlug: string,
 ): JSONField {
   const schemaEntries = extractSchemaEntries(groupSchema.properties)
 
-  // Only string properties are required keys on the JSON field's own schema.
-  // Nested-group properties, if any, are rendered as separate sub-tabs and not
-  // included in this field's value.
   const stringProperties: Record<string, StringPropertySchema> = Object.fromEntries(
-    Object.entries(groupSchema.properties || {}).filter(
-      ([, prop]) => prop.type === 'string',
-    ) as Array<[string, StringPropertySchema]>,
+    Object.entries(groupSchema.properties || {}).filter(([, prop]) => isStringProp(prop)) as Array<
+      [string, StringPropertySchema]
+    >,
   )
   const requiredKeys = Object.keys(stringProperties)
 
-  // Create a standalone JSON Schema for this group
-  // This allows Monaco editor validation per-tab
   const groupJsonSchema: JSONSchema4 = {
     type: 'object',
     properties: stringProperties,
@@ -163,7 +196,7 @@ function createGroupJsonField(
   }
 
   return {
-    name: groupSlug,
+    name: fieldName,
     type: 'json',
     localized: true,
     label: false,
@@ -177,11 +210,88 @@ function createGroupJsonField(
       },
     },
     jsonSchema: {
-      uri: `a://${globalSlug}/${groupSlug}.json`,
-      fileMatch: [`a://${globalSlug}/${groupSlug}.json`],
+      uri: `a://${globalSlug}/${jsonSchemaUriSlug}.json`,
+      fileMatch: [`a://${globalSlug}/${jsonSchemaUriSlug}.json`],
       schema: groupJsonSchema,
     },
   }
+}
+
+/**
+ * Creates a stock Payload richText field for a single richText-typed leaf
+ * property. Uses the `basicRichTextEditor` preset — Bold, Italic, Link,
+ * InlineToolbar. Localized.
+ */
+function createRichTextSubfield(
+  fieldName: string,
+  property: RichTextPropertySchema,
+): RichTextField {
+  return {
+    name: fieldName,
+    type: 'richText',
+    editor: basicRichTextEditor,
+    localized: true,
+    label: toTitleCase(fieldName),
+    admin: {
+      description: property.description,
+    },
+  }
+}
+
+/**
+ * Builds the fields that represent a leaf group. The shape depends on whether
+ * the leaf contains any richText properties:
+ *
+ * - **Pure-string leaf** → a single JSON field rendered by TranslationsTable,
+ *   named after the leaf slug. Same shape and field name as the pre-richText
+ *   behaviour — backward compatible.
+ *
+ * - **Mixed leaf** (has ≥ 1 richText) → a wrapper Payload `group` field named
+ *   after the leaf slug, containing:
+ *     - `strings` — JSON field rendered by TranslationsTable, holding only the
+ *       string-typed entries.
+ *     - one Payload `richText` field per richText-typed entry, in declaration
+ *       order, each using `basicRichTextEditor`.
+ *
+ *   The wrapping group is necessary to keep the API/data shape predictable —
+ *   `<leafSlug>: { strings: { ... }, body_intro: <lexical>, ... }`.
+ */
+function createLeafFields(
+  leafSlug: string,
+  groupSchema: GroupSchema,
+  globalSlug: string,
+): Field[] {
+  const screenshotField = createScreenshotField(leafSlug, groupSchema, globalSlug)
+  const props = groupSchema.properties || {}
+  const richTextProps = Object.entries(props).filter(
+    (entry): entry is [string, RichTextPropertySchema] => isRichTextProp(entry[1]),
+  )
+  const hasRichText = richTextProps.length > 0
+
+  if (!hasRichText) {
+    // Pure-string leaf — single JSON field, same as the previous behaviour.
+    return [
+      ...(screenshotField ? [screenshotField] : []),
+      createStringsJsonField(leafSlug, groupSchema, globalSlug, leafSlug),
+    ]
+  }
+
+  // Mixed leaf — wrap in a Payload group containing strings JSON + richText siblings.
+  const richTextFields: RichTextField[] = richTextProps.map(([key, property]) =>
+    createRichTextSubfield(key, property),
+  )
+
+  const wrapperGroup: GroupField = {
+    name: leafSlug,
+    type: 'group',
+    label: false,
+    fields: [
+      createStringsJsonField('strings', groupSchema, globalSlug, leafSlug),
+      ...richTextFields,
+    ],
+  }
+
+  return [...(screenshotField ? [screenshotField] : []), wrapperGroup]
 }
 
 // ============================================================================
@@ -192,18 +302,18 @@ function createGroupJsonField(
  * Converts a translations schema into PayloadCMS tabs configuration.
  *
  * Top-level rules:
- * - A top-level group whose `properties` are all `string` leaves becomes one tab
- *   with a single JSON field rendered by the TranslationsTable component.
+ * - A top-level group whose `properties` are all leaf properties (string or
+ *   richText) becomes one tab; its leaf fields are emitted by createLeafFields().
  * - A top-level group whose `properties` are nested `GroupSchema` values becomes
  *   one tab containing an inner tabs field, one sub-tab per child group. Each
- *   sub-tab's JSON field is named `<parentSlug>_<childSlug>` so the global's
- *   API/data shape stays flat (one top-level key per leaf group) — this is the
- *   same field naming the previous flat schema used.
+ *   sub-tab's leaf field name is `<parentSlug>_<childSlug>` so the global's
+ *   API/data shape stays flat-ish (one top-level key per leaf group).
  *
- * Mixing strings and nested groups at the same level is not supported. Backward
- * compatible: schemas with no nested groups behave exactly as before.
+ * Mixing leaf properties and nested groups at the same level is not supported.
+ * Backward compatible: schemas with no richText properties behave exactly as
+ * before — a single JSON field per leaf.
  *
- * @param schema - The translations schema with optional nested groups
+ * @param schema - The translations schema (may include richText leaf properties)
  * @param globalSlug - The global's slug for API fetching and unique URIs
  * @returns Array of tab configurations for use in a TabsField
  */
@@ -214,7 +324,7 @@ export function buildTranslationTabs(
   const properties = schema.properties || {}
 
   return Object.entries(properties)
-    .filter(([groupSlug]) => groupSlug.trim().length > 0) // Skip empty group slugs
+    .filter(([groupSlug]) => groupSlug.trim().length > 0)
     .map(([groupSlug, groupSchema]) => {
       const groupProps = groupSchema.properties || {}
       const subgroups = Object.entries(groupProps).filter(
@@ -222,8 +332,6 @@ export function buildTranslationTabs(
       )
 
       // Parent group → outer tab containing one sub-tab per child group.
-      // Screenshots configured on the parent are ignored (parents are pure
-      // containers); each child group renders its own optional screenshot.
       if (subgroups.length > 0) {
         return {
           label: toTitleCase(groupSlug),
@@ -233,18 +341,10 @@ export function buildTranslationTabs(
               type: 'tabs',
               tabs: subgroups.map(([subSlug, subSchema]) => {
                 const leafSlug = `${groupSlug}_${subSlug}`
-                const screenshotField = createScreenshotField(
-                  leafSlug,
-                  subSchema,
-                  globalSlug,
-                )
                 return {
                   label: toTitleCase(subSlug),
                   description: subSchema.description,
-                  fields: [
-                    ...(screenshotField ? [screenshotField] : []),
-                    createGroupJsonField(leafSlug, subSchema, globalSlug),
-                  ],
+                  fields: createLeafFields(leafSlug, subSchema, globalSlug),
                 }
               }),
             },
@@ -252,16 +352,11 @@ export function buildTranslationTabs(
         }
       }
 
-      // Leaf group → single tab with a flat translations table, optionally
-      // preceded by a screenshot for editor orientation.
-      const screenshotField = createScreenshotField(groupSlug, groupSchema, globalSlug)
+      // Leaf group at the top level (no nesting).
       return {
         label: toTitleCase(groupSlug),
         description: groupSchema.description,
-        fields: [
-          ...(screenshotField ? [screenshotField] : []),
-          createGroupJsonField(groupSlug, groupSchema, globalSlug),
-        ],
+        fields: createLeafFields(groupSlug, groupSchema, globalSlug),
       }
     })
 }

--- a/src/globals/wemeditate-app/translationsSchema.json
+++ b/src/globals/wemeditate-app/translationsSchema.json
@@ -25,22 +25,6 @@
               "type": "string",
               "description": "Secondary CTA for returning users who already have an account."
             },
-            "legal_disclaimer_prefix": {
-              "type": "string",
-              "description": "First inline-text fragment of the legal disclaimer shown under the CTAs. Followed by the Terms link, the connector, and the Privacy Policy link. Include any required trailing space."
-            },
-            "legal_disclaimer_and": {
-              "type": "string",
-              "description": "Connector word between the Terms link and the Privacy Policy link in the inline disclaimer. Include any required surrounding spaces (e.g. ' & ')."
-            },
-            "legal_terms": {
-              "type": "string",
-              "description": "Inline link label that opens the in-app Terms & Conditions webview."
-            },
-            "legal_privacy_policy": {
-              "type": "string",
-              "description": "Inline link label that opens the in-app Privacy Policy webview."
-            },
             "privacy_policy_title": {
               "type": "string",
               "description": "Title of the in-app webview screen that displays the Privacy Policy. The Privacy Policy body itself is the CMS page referenced by wm-app-config.privacyPolicyPage, not a translation string."
@@ -56,6 +40,10 @@
             "link_open_failed": {
               "type": "string",
               "description": "Generic error toast shown when an inline link on the welcome screen fails to open."
+            },
+            "legal_disclaimer": {
+              "type": "richText",
+              "description": "Inline legal disclaimer below the primary CTAs. Renders two inline links to the in-app Terms and Privacy Policy webviews (URLs use the wemeditate://legal/* scheme — see ticket for full reference). Translators control word order, link placement, and the connector between the two link labels."
             }
           },
           "additionalProperties": false,
@@ -97,18 +85,6 @@
           "type": "object",
           "description": "Onboarding step where the user self-classifies (complete beginner, tried before, attending classes, yogi). Drives downstream personalisation and the analytics yogi-exclusion gate.",
           "properties": {
-            "title_prefix": {
-              "type": "string",
-              "description": "First text fragment of the screen title. Combined with title_brand and title_suffix to form the full prompt (e.g. 'Have you tried Sahaja Yoga before?'). Preserve the trailing line break (\\n)."
-            },
-            "title_brand": {
-              "type": "string",
-              "description": "The 'Sahaja Yoga' brand fragment in the title. Usually kept in original spelling, with optional locale-script transliteration."
-            },
-            "title_suffix": {
-              "type": "string",
-              "description": "Closing text fragment of the title (typically ' before?'). Include the leading space if needed for the locale."
-            },
             "get_started": {
               "type": "string",
               "description": "Primary CTA used after the user picks their classification."
@@ -128,6 +104,10 @@
             "option_yogi": {
               "type": "string",
               "description": "Selectable option for long-time Sahaja Yoga practitioners. Maps to userType = yogi (excluded from the ad-measurement path)."
+            },
+            "title": {
+              "type": "richText",
+              "description": "Screen title prompt (e.g. 'Have you tried Sahaja Yoga before?'). The brand fragment 'Sahaja Yoga' is rendered as a bold inline span; translators may choose a different word to bold or apply no bold per locale convention."
             }
           },
           "additionalProperties": false,
@@ -145,14 +125,6 @@
               "type": "string",
               "description": "Slide 1 supporting copy."
             },
-            "page_true_self_prefix": {
-              "type": "string",
-              "description": "Slide 2 title prefix; combined inline with page_true_self_highlight (e.g. 'Get to know your true self'). Include the trailing space."
-            },
-            "page_true_self_highlight": {
-              "type": "string",
-              "description": "Highlighted phrase at the end of slide 2 title, typically rendered in an accent colour (e.g. 'true self')."
-            },
             "page_true_self_subtitle": {
               "type": "string",
               "description": "Slide 2 supporting copy."
@@ -164,6 +136,10 @@
             "page_unlock_potential_subtitle": {
               "type": "string",
               "description": "Slide 3 supporting copy."
+            },
+            "page_true_self_title": {
+              "type": "richText",
+              "description": "Slide 2 title (e.g. 'Get to know your true self'). The 'true self' fragment is rendered as a bold inline span; the Flutter renderer may also apply an accent colour to bolded segments on this slide."
             }
           },
           "additionalProperties": false,
@@ -177,29 +153,17 @@
               "type": "string",
               "description": "Modal title (e.g. 'Help spread the word')."
             },
-            "body_intro_prefix": {
-              "type": "string",
-              "description": "First paragraph prefix; combined inline with body_intro_link and body_intro_suffix to form a single sentence. Include any trailing space."
-            },
-            "body_intro_link": {
-              "type": "string",
-              "description": "Inline link text inside the first paragraph (e.g. 'what we share'). Tapping opens a detail sheet listing exactly which fields are sent to Meta, Apple and Google Ads."
-            },
-            "body_intro_suffix": {
-              "type": "string",
-              "description": "First paragraph suffix completing the sentence after the inline link. Include the leading separator if needed (e.g. ') with Meta, Apple and Google Ads to understand which outreach helps people discover meditation.')."
-            },
             "body_benefits": {
               "type": "string",
               "description": "Second paragraph explaining the benefits of granting consent (improving campaigns, using donations responsibly, suppressing ads to existing users, reaching similar people)."
             },
             "body_never_share": {
-              "type": "string",
-              "description": "Third paragraph listing categories that are never sent for advertising (mood, goals, hand sensations, reflections, class location, spiritual-practice details). Must remain consistent with the privacy filter in analytics-simplified/03-marketing-event-taxonomy.md §2."
+              "type": "richText",
+              "description": "Third paragraph listing categories that are never sent for advertising (mood, goals, hand sensations, reflections, class location, spiritual-practice details). Lead phrase 'We'll never share' is rendered as a bold inline span. Must remain consistent with the privacy filter in analytics-simplified/03-marketing-event-taxonomy.md §2."
             },
             "body_never_sell": {
-              "type": "string",
-              "description": "Fourth paragraph: short statement that the app never sells user data."
+              "type": "richText",
+              "description": "Fourth paragraph: short statement that the app never sells user data. Phrase 'we never sell' is rendered as a bold inline span."
             },
             "body_settings_hint": {
               "type": "string",
@@ -212,6 +176,10 @@
             "reject": {
               "type": "string",
               "description": "Decline CTA. Decline is a single tap and must not block account creation (see analytics-simplified/05-flutter-implementation.md §9)."
+            },
+            "body_intro": {
+              "type": "richText",
+              "description": "First paragraph of the consent modal. Contains an inline link (e.g. 'what we share') opening the privacy-detail sheet that lists the exact fields sent to Meta, Apple Search Ads and Google Ads. Link URL uses the wemeditate://legal/what-we-share scheme."
             }
           },
           "additionalProperties": false,
@@ -1075,7 +1043,7 @@
             },
             "privacy_and_advertising_subtitle": {
               "type": "string",
-              "description": "Subtitle of the Privacy & advertising entry in the Profile menu."
+              "description": "Subtitle of the Privacy & Advertising entry in the Profile menu (e.g. 'Privacy choices and ad preferences')."
             },
             "feedback_header": {
               "type": "string",
@@ -1112,6 +1080,26 @@
             "joined_years": {
               "type": "string",
               "description": "Joined-date string for multiple years ago. MUST preserve the {years} placeholder — it is replaced at runtime with the year count."
+            },
+            "legal_header": {
+              "type": "string",
+              "description": "Section header above the legal-page navigation rows in the Profile menu (typically capitalised, e.g. 'LEGAL'). Sits between the Contact-us feedback row and the Privacy Policy / Terms & Conditions / Privacy & Advertising rows."
+            },
+            "privacy_policy_title": {
+              "type": "string",
+              "description": "Title of the Privacy Policy entry in the Profile menu's Legal section. Tapping opens the Privacy Policy page (CMS page id 73)."
+            },
+            "privacy_policy_subtitle": {
+              "type": "string",
+              "description": "Subtitle of the Privacy Policy entry in the Profile menu's Legal section (e.g. 'How we collect and use data')."
+            },
+            "terms_and_conditions_title": {
+              "type": "string",
+              "description": "Title of the Terms & Conditions entry in the Profile menu's Legal section. Tapping opens the Terms & Conditions page (CMS page id 76)."
+            },
+            "terms_and_conditions_subtitle": {
+              "type": "string",
+              "description": "Subtitle of the Terms & Conditions entry in the Profile menu's Legal section (e.g. 'Legal terms for using WeMeditate')."
             }
           },
           "additionalProperties": false,
@@ -1345,25 +1333,13 @@
               "type": "string",
               "description": "Section title for the advertising-measurement toggle (e.g. 'Advertising measurement and improvement'). Drives adsMarketingConsent."
             },
-            "advertising_body_intro_prefix": {
-              "type": "string",
-              "description": "First paragraph prefix of the advertising section; combined inline with advertising_body_intro_link and advertising_body_intro_suffix. Include any trailing space."
-            },
-            "advertising_body_intro_link": {
-              "type": "string",
-              "description": "Inline link text inside the first paragraph (e.g. 'what we share'). Tapping opens the same 'what we share' detail used by the ad consent modal."
-            },
-            "advertising_body_intro_suffix": {
-              "type": "string",
-              "description": "First paragraph suffix completing the sentence after the inline link. Include the leading separator if needed."
-            },
             "advertising_body_benefits": {
               "type": "string",
               "description": "Second paragraph of the advertising section: how granting consent helps WeMeditate use donations responsibly, improve campaigns, suppress ads to existing users, and reach similar people."
             },
             "advertising_body_never_share": {
-              "type": "string",
-              "description": "Third paragraph of the advertising section reiterating the never-shared categories (mood, goals, hand sensations, reflections, class location, spiritual-practice details). Must remain consistent with analytics-simplified/03-marketing-event-taxonomy.md §2."
+              "type": "richText",
+              "description": "Third paragraph of the advertising section. Covers both the never-shared categories AND the never-sell statement in a single paragraph with two bold spans ('We'll never share' / 'we never sell'). Must remain consistent with analytics-simplified/03-marketing-event-taxonomy.md §2."
             },
             "advertising_body_change_hint": {
               "type": "string",
@@ -1384,6 +1360,30 @@
             "advertising_platform_apple_search_ads": {
               "type": "string",
               "description": "Bullet item for Apple Search Ads. Brand name — usually kept as 'Apple Search Ads'."
+            },
+            "advertising_body_intro": {
+              "type": "richText",
+              "description": "First paragraph of the advertising section. Contains an inline link (e.g. 'what we share') that opens the Privacy Policy page (CMS page id 73, scrolled to the 'what we share' heading) — same link target as onboarding_consent_modal.body_intro."
+            },
+            "learn_more_header": {
+              "type": "string",
+              "description": "Section header above the legal-page navigation rows at the bottom of the Privacy & Advertising screen (e.g. 'Learn more'). Below this header sit the Privacy Policy and Terms & Conditions rows, which reuse the same labels as the Profile-tab Legal section."
+            },
+            "privacy_policy_title": {
+              "type": "string",
+              "description": "Title of the Privacy Policy row in the Learn-more section at the bottom of the Privacy & Advertising screen. Tapping opens the Privacy Policy page (CMS page id 73). Reuses the same English label as profile_main.privacy_policy_title."
+            },
+            "privacy_policy_subtitle": {
+              "type": "string",
+              "description": "Subtitle of the Privacy Policy row in the Learn-more section (e.g. 'How we collect and use data')."
+            },
+            "terms_and_conditions_title": {
+              "type": "string",
+              "description": "Title of the Terms & Conditions row in the Learn-more section at the bottom of the Privacy & Advertising screen. Tapping opens the Terms & Conditions page (CMS page id 76)."
+            },
+            "terms_and_conditions_subtitle": {
+              "type": "string",
+              "description": "Subtitle of the Terms & Conditions row in the Learn-more section (e.g. 'Legal terms for using WeMeditate')."
             }
           },
           "additionalProperties": false,
@@ -1754,18 +1754,6 @@
               "type": "string",
               "description": "Screen title asking whether the user wants to foot-soak with this meditation."
             },
-            "description_prefix": {
-              "type": "string",
-              "description": "Body-copy prefix; combined inline with description_emphasis and description_suffix to form a single sentence. Include trailing space if the locale needs one."
-            },
-            "description_emphasis": {
-              "type": "string",
-              "description": "Emphasised word in the foot-soak body copy, typically rendered in italic or bold (e.g. 'really')."
-            },
-            "description_suffix": {
-              "type": "string",
-              "description": "Body-copy suffix completing the foot-soak description sentence. Include the leading space."
-            },
             "tutorial_cta": {
               "type": "string",
               "description": "Inline link/CTA opening the foot-soak tutorial."
@@ -1777,6 +1765,10 @@
             "start_meditation": {
               "type": "string",
               "description": "Secondary CTA that starts the meditation without a foot-soak."
+            },
+            "description": {
+              "type": "richText",
+              "description": "Body copy of the foot-soak screen. Contains a short emphasised span (typically italic, e.g. 'really') that translators position freely within the sentence."
             }
           },
           "additionalProperties": false
@@ -2150,22 +2142,6 @@
               "type": "string",
               "description": "Tertiary action allowing a guest user to skip account creation."
             },
-            "consent_prefix": {
-              "type": "string",
-              "description": "Inline-text prefix of the consent checkbox label. Combined with consent_terms, consent_and_acknowledge, and consent_privacy. Include any trailing space."
-            },
-            "consent_terms": {
-              "type": "string",
-              "description": "Inline link text for the Terms & Conditions, opening the in-app webview."
-            },
-            "consent_and_acknowledge": {
-              "type": "string",
-              "description": "Connector text between the Terms link and the Privacy Policy link. Include any required spaces."
-            },
-            "consent_privacy": {
-              "type": "string",
-              "description": "Inline link text for the Privacy Policy, opening the in-app webview."
-            },
             "error_check_consent": {
               "type": "string",
               "description": "Validation error shown when the user tries to submit without checking the consent box."
@@ -2237,6 +2213,10 @@
             "error_provider_cancelled": {
               "type": "string",
               "description": "Message shown when the user cancels the social-auth flow."
+            },
+            "consent_label": {
+              "type": "richText",
+              "description": "Consent checkbox label on the account creation screen. Contains two inline links (Terms & Conditions, Privacy Policy) opening the corresponding in-app webviews (wemeditate://legal/terms, wemeditate://legal/privacy). Independent of the ad-measurement consent."
             }
           },
           "additionalProperties": false,

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -3151,54 +3151,58 @@ export interface WmAppConfig {
 export interface WmAppTranslation {
   id: number;
   onboarding_welcome?: {
+    strings?: {
+      /**
+       * Hero title on the welcome screen. Short greeting (e.g. 'Welcome, friend').
+       */
+      title: string;
+      /**
+       * Hero subtitle below the welcome title.
+       */
+      subtitle: string;
+      /**
+       * Primary CTA that begins onboarding for a new user.
+       */
+      get_started: string;
+      /**
+       * Secondary CTA for returning users who already have an account.
+       */
+      use_existing_account: string;
+      /**
+       * Title of the in-app webview screen that displays the Privacy Policy. The Privacy Policy body itself is the CMS page referenced by wm-app-config.privacyPolicyPage, not a translation string.
+       */
+      privacy_policy_title: string;
+      /**
+       * Title of the in-app webview screen that displays the Terms & Conditions. The body itself is the CMS page referenced by wm-app-config.termsAndConditionsPage.
+       */
+      terms_and_conditions_title: string;
+      /**
+       * Error toast shown when the OS cannot find an installed email client to handle a mailto: link from the welcome screen.
+       */
+      email_app_unavailable: string;
+      /**
+       * Generic error toast shown when an inline link on the welcome screen fails to open.
+       */
+      link_open_failed: string;
+    };
     /**
-     * Hero title on the welcome screen. Short greeting (e.g. 'Welcome, friend').
+     * Inline legal disclaimer below the primary CTAs. Renders two inline links to the in-app Terms and Privacy Policy webviews (URLs use the wemeditate://legal/* scheme — see ticket for full reference). Translators control word order, link placement, and the connector between the two link labels.
      */
-    title: string;
-    /**
-     * Hero subtitle below the welcome title.
-     */
-    subtitle: string;
-    /**
-     * Primary CTA that begins onboarding for a new user.
-     */
-    get_started: string;
-    /**
-     * Secondary CTA for returning users who already have an account.
-     */
-    use_existing_account: string;
-    /**
-     * First inline-text fragment of the legal disclaimer shown under the CTAs. Followed by the Terms link, the connector, and the Privacy Policy link. Include any required trailing space.
-     */
-    legal_disclaimer_prefix: string;
-    /**
-     * Connector word between the Terms link and the Privacy Policy link in the inline disclaimer. Include any required surrounding spaces (e.g. ' & ').
-     */
-    legal_disclaimer_and: string;
-    /**
-     * Inline link label that opens the in-app Terms & Conditions webview.
-     */
-    legal_terms: string;
-    /**
-     * Inline link label that opens the in-app Privacy Policy webview.
-     */
-    legal_privacy_policy: string;
-    /**
-     * Title of the in-app webview screen that displays the Privacy Policy. The Privacy Policy body itself is the CMS page referenced by wm-app-config.privacyPolicyPage, not a translation string.
-     */
-    privacy_policy_title: string;
-    /**
-     * Title of the in-app webview screen that displays the Terms & Conditions. The body itself is the CMS page referenced by wm-app-config.termsAndConditionsPage.
-     */
-    terms_and_conditions_title: string;
-    /**
-     * Error toast shown when the OS cannot find an installed email client to handle a mailto: link from the welcome screen.
-     */
-    email_app_unavailable: string;
-    /**
-     * Generic error toast shown when an inline link on the welcome screen fails to open.
-     */
-    link_open_failed: string;
+    legal_disclaimer?: {
+      root: {
+        type: string;
+        children: {
+          type: any;
+          version: number;
+          [k: string]: unknown;
+        }[];
+        direction: ('ltr' | 'rtl') | null;
+        format: 'left' | 'start' | 'center' | 'right' | 'end' | 'justify' | '';
+        indent: number;
+        version: number;
+      };
+      [k: string]: unknown;
+    } | null;
   };
   onboarding_name?: {
     /**
@@ -3221,110 +3225,166 @@ export interface WmAppTranslation {
     message_prefix: string;
   };
   onboarding_user_type?: {
+    strings?: {
+      /**
+       * Primary CTA used after the user picks their classification.
+       */
+      get_started: string;
+      /**
+       * Selectable option for users completely new to meditation. Maps to userType = user-complete-beginner.
+       */
+      option_complete_beginner: string;
+      /**
+       * Selectable option for users who have tried meditation before but not deeply. Maps to userType = user-tried-before.
+       */
+      option_tried_before: string;
+      /**
+       * Selectable option for users currently in an in-person or online newcomer class. Maps to userType = user-attending-classes.
+       */
+      option_attending_classes: string;
+      /**
+       * Selectable option for long-time Sahaja Yoga practitioners. Maps to userType = yogi (excluded from the ad-measurement path).
+       */
+      option_yogi: string;
+    };
     /**
-     * First text fragment of the screen title. Combined with title_brand and title_suffix to form the full prompt (e.g. 'Have you tried Sahaja Yoga before?'). Preserve the trailing line break (\n).
+     * Screen title prompt (e.g. 'Have you tried Sahaja Yoga before?'). The brand fragment 'Sahaja Yoga' is rendered as a bold inline span; translators may choose a different word to bold or apply no bold per locale convention.
      */
-    title_prefix: string;
-    /**
-     * The 'Sahaja Yoga' brand fragment in the title. Usually kept in original spelling, with optional locale-script transliteration.
-     */
-    title_brand: string;
-    /**
-     * Closing text fragment of the title (typically ' before?'). Include the leading space if needed for the locale.
-     */
-    title_suffix: string;
-    /**
-     * Primary CTA used after the user picks their classification.
-     */
-    get_started: string;
-    /**
-     * Selectable option for users completely new to meditation. Maps to userType = user-complete-beginner.
-     */
-    option_complete_beginner: string;
-    /**
-     * Selectable option for users who have tried meditation before but not deeply. Maps to userType = user-tried-before.
-     */
-    option_tried_before: string;
-    /**
-     * Selectable option for users currently in an in-person or online newcomer class. Maps to userType = user-attending-classes.
-     */
-    option_attending_classes: string;
-    /**
-     * Selectable option for long-time Sahaja Yoga practitioners. Maps to userType = yogi (excluded from the ad-measurement path).
-     */
-    option_yogi: string;
+    title?: {
+      root: {
+        type: string;
+        children: {
+          type: any;
+          version: number;
+          [k: string]: unknown;
+        }[];
+        direction: ('ltr' | 'rtl') | null;
+        format: 'left' | 'start' | 'center' | 'right' | 'end' | 'justify' | '';
+        indent: number;
+        version: number;
+      };
+      [k: string]: unknown;
+    } | null;
   };
   onboarding_carousel?: {
+    strings?: {
+      /**
+       * Slide 1 title (e.g. 'A moment of peace').
+       */
+      page_moment_title: string;
+      /**
+       * Slide 1 supporting copy.
+       */
+      page_moment_subtitle: string;
+      /**
+       * Slide 2 supporting copy.
+       */
+      page_true_self_subtitle: string;
+      /**
+       * Slide 3 title (e.g. 'Unlock your potential').
+       */
+      page_unlock_potential_title: string;
+      /**
+       * Slide 3 supporting copy.
+       */
+      page_unlock_potential_subtitle: string;
+    };
     /**
-     * Slide 1 title (e.g. 'A moment of peace').
+     * Slide 2 title (e.g. 'Get to know your true self'). The 'true self' fragment is rendered as a bold inline span; the Flutter renderer may also apply an accent colour to bolded segments on this slide.
      */
-    page_moment_title: string;
-    /**
-     * Slide 1 supporting copy.
-     */
-    page_moment_subtitle: string;
-    /**
-     * Slide 2 title prefix; combined inline with page_true_self_highlight (e.g. 'Get to know your true self'). Include the trailing space.
-     */
-    page_true_self_prefix: string;
-    /**
-     * Highlighted phrase at the end of slide 2 title, typically rendered in an accent colour (e.g. 'true self').
-     */
-    page_true_self_highlight: string;
-    /**
-     * Slide 2 supporting copy.
-     */
-    page_true_self_subtitle: string;
-    /**
-     * Slide 3 title (e.g. 'Unlock your potential').
-     */
-    page_unlock_potential_title: string;
-    /**
-     * Slide 3 supporting copy.
-     */
-    page_unlock_potential_subtitle: string;
+    page_true_self_title?: {
+      root: {
+        type: string;
+        children: {
+          type: any;
+          version: number;
+          [k: string]: unknown;
+        }[];
+        direction: ('ltr' | 'rtl') | null;
+        format: 'left' | 'start' | 'center' | 'right' | 'end' | 'justify' | '';
+        indent: number;
+        version: number;
+      };
+      [k: string]: unknown;
+    } | null;
   };
   onboarding_consent_modal?: {
+    strings?: {
+      /**
+       * Modal title (e.g. 'Help spread the word').
+       */
+      title: string;
+      /**
+       * Second paragraph explaining the benefits of granting consent (improving campaigns, using donations responsibly, suppressing ads to existing users, reaching similar people).
+       */
+      body_benefits: string;
+      /**
+       * Fifth paragraph telling the user they can change this anytime via Settings → Privacy & advertising. Preserve the arrow character (→) or substitute the locale equivalent.
+       */
+      body_settings_hint: string;
+      /**
+       * Primary CTA granting consent (sets adsMarketingConsent = true).
+       */
+      allow: string;
+      /**
+       * Decline CTA. Decline is a single tap and must not block account creation (see analytics-simplified/05-flutter-implementation.md §9).
+       */
+      reject: string;
+    };
     /**
-     * Modal title (e.g. 'Help spread the word').
+     * Third paragraph listing categories that are never sent for advertising (mood, goals, hand sensations, reflections, class location, spiritual-practice details). Lead phrase 'We'll never share' is rendered as a bold inline span. Must remain consistent with the privacy filter in analytics-simplified/03-marketing-event-taxonomy.md §2.
      */
-    title: string;
+    body_never_share?: {
+      root: {
+        type: string;
+        children: {
+          type: any;
+          version: number;
+          [k: string]: unknown;
+        }[];
+        direction: ('ltr' | 'rtl') | null;
+        format: 'left' | 'start' | 'center' | 'right' | 'end' | 'justify' | '';
+        indent: number;
+        version: number;
+      };
+      [k: string]: unknown;
+    } | null;
     /**
-     * First paragraph prefix; combined inline with body_intro_link and body_intro_suffix to form a single sentence. Include any trailing space.
+     * Fourth paragraph: short statement that the app never sells user data. Phrase 'we never sell' is rendered as a bold inline span.
      */
-    body_intro_prefix: string;
+    body_never_sell?: {
+      root: {
+        type: string;
+        children: {
+          type: any;
+          version: number;
+          [k: string]: unknown;
+        }[];
+        direction: ('ltr' | 'rtl') | null;
+        format: 'left' | 'start' | 'center' | 'right' | 'end' | 'justify' | '';
+        indent: number;
+        version: number;
+      };
+      [k: string]: unknown;
+    } | null;
     /**
-     * Inline link text inside the first paragraph (e.g. 'what we share'). Tapping opens a detail sheet listing exactly which fields are sent to Meta, Apple and Google Ads.
+     * First paragraph of the consent modal. Contains an inline link (e.g. 'what we share') opening the privacy-detail sheet that lists the exact fields sent to Meta, Apple Search Ads and Google Ads. Link URL uses the wemeditate://legal/what-we-share scheme.
      */
-    body_intro_link: string;
-    /**
-     * First paragraph suffix completing the sentence after the inline link. Include the leading separator if needed (e.g. ') with Meta, Apple and Google Ads to understand which outreach helps people discover meditation.').
-     */
-    body_intro_suffix: string;
-    /**
-     * Second paragraph explaining the benefits of granting consent (improving campaigns, using donations responsibly, suppressing ads to existing users, reaching similar people).
-     */
-    body_benefits: string;
-    /**
-     * Third paragraph listing categories that are never sent for advertising (mood, goals, hand sensations, reflections, class location, spiritual-practice details). Must remain consistent with the privacy filter in analytics-simplified/03-marketing-event-taxonomy.md §2.
-     */
-    body_never_share: string;
-    /**
-     * Fourth paragraph: short statement that the app never sells user data.
-     */
-    body_never_sell: string;
-    /**
-     * Fifth paragraph telling the user they can change this anytime via Settings → Privacy & advertising. Preserve the arrow character (→) or substitute the locale equivalent.
-     */
-    body_settings_hint: string;
-    /**
-     * Primary CTA granting consent (sets adsMarketingConsent = true).
-     */
-    allow: string;
-    /**
-     * Decline CTA. Decline is a single tap and must not block account creation (see analytics-simplified/05-flutter-implementation.md §9).
-     */
-    reject: string;
+    body_intro?: {
+      root: {
+        type: string;
+        children: {
+          type: any;
+          version: number;
+          [k: string]: unknown;
+        }[];
+        direction: ('ltr' | 'rtl') | null;
+        format: 'left' | 'start' | 'center' | 'right' | 'end' | 'justify' | '';
+        indent: number;
+        version: number;
+      };
+      [k: string]: unknown;
+    } | null;
   };
   daily_main?: {
     /**
@@ -4070,7 +4130,7 @@ export interface WmAppTranslation {
      */
     privacy_and_advertising_title: string;
     /**
-     * Subtitle of the Privacy & advertising entry in the Profile menu.
+     * Subtitle of the Privacy & Advertising entry in the Profile menu (e.g. 'Privacy choices and ad preferences').
      */
     privacy_and_advertising_subtitle: string;
     /**
@@ -4109,6 +4169,26 @@ export interface WmAppTranslation {
      * Joined-date string for multiple years ago. MUST preserve the {years} placeholder — it is replaced at runtime with the year count.
      */
     joined_years: string;
+    /**
+     * Section header above the legal-page navigation rows in the Profile menu (typically capitalised, e.g. 'LEGAL'). Sits between the Contact-us feedback row and the Privacy Policy / Terms & Conditions / Privacy & Advertising rows.
+     */
+    legal_header: string;
+    /**
+     * Title of the Privacy Policy entry in the Profile menu's Legal section. Tapping opens the Privacy Policy page (CMS page id 73).
+     */
+    privacy_policy_title: string;
+    /**
+     * Subtitle of the Privacy Policy entry in the Profile menu's Legal section (e.g. 'How we collect and use data').
+     */
+    privacy_policy_subtitle: string;
+    /**
+     * Title of the Terms & Conditions entry in the Profile menu's Legal section. Tapping opens the Terms & Conditions page (CMS page id 76).
+     */
+    terms_and_conditions_title: string;
+    /**
+     * Subtitle of the Terms & Conditions entry in the Profile menu's Legal section (e.g. 'Legal terms for using WeMeditate').
+     */
+    terms_and_conditions_subtitle: string;
   };
   profile_favourites?: {
     /**
@@ -4293,70 +4373,112 @@ export interface WmAppTranslation {
     delete_account: string;
   };
   profile_privacy_advertising?: {
+    strings?: {
+      /**
+       * Screen title (e.g. 'Help spread the word and make the app better').
+       */
+      screen_title: string;
+      /**
+       * Status label shown next to a toggle that is currently allowed. MUST preserve the {date} placeholder — it is replaced at runtime with the localized date of the most recent consent decision (e.g. '16 May 2026').
+       */
+      status_allowed: string;
+      /**
+       * Status label shown next to a toggle that is currently disallowed.
+       */
+      status_not_allowed: string;
+      /**
+       * Section title for the anonymous product analytics toggle (e.g. 'Anonymous product analytics'). Drives productAnalyticsOptOut.
+       */
+      product_analytics_title: string;
+      /**
+       * Section body explaining anonymous product analytics: we log aggregated usage data to fix bugs and improve We Meditate, no individual data, no advertisers, no user profile. Must remain consistent with the TelemetryDeck posture in analytics-simplified/01-strategy.md §4.
+       */
+      product_analytics_description: string;
+      /**
+       * Section title for the advertising-measurement toggle (e.g. 'Advertising measurement and improvement'). Drives adsMarketingConsent.
+       */
+      advertising_title: string;
+      /**
+       * Second paragraph of the advertising section: how granting consent helps WeMeditate use donations responsibly, improve campaigns, suppress ads to existing users, and reach similar people.
+       */
+      advertising_body_benefits: string;
+      /**
+       * Fourth paragraph of the advertising section explaining that the user can change their choice anytime using the toggle at the top of this screen.
+       */
+      advertising_body_change_hint: string;
+      /**
+       * Sub-section header listing current advertising platforms (e.g. 'Current advertising platforms').
+       */
+      advertising_platforms_header: string;
+      /**
+       * Bullet item for Meta (Facebook + Instagram + Audience Network). Brand name — usually kept as 'Meta'.
+       */
+      advertising_platform_meta: string;
+      /**
+       * Bullet item for Google Ads. Brand name — usually kept as 'Google Ads'.
+       */
+      advertising_platform_google_ads: string;
+      /**
+       * Bullet item for Apple Search Ads. Brand name — usually kept as 'Apple Search Ads'.
+       */
+      advertising_platform_apple_search_ads: string;
+      /**
+       * Section header above the legal-page navigation rows at the bottom of the Privacy & Advertising screen (e.g. 'Learn more'). Below this header sit the Privacy Policy and Terms & Conditions rows, which reuse the same labels as the Profile-tab Legal section.
+       */
+      learn_more_header: string;
+      /**
+       * Title of the Privacy Policy row in the Learn-more section at the bottom of the Privacy & Advertising screen. Tapping opens the Privacy Policy page (CMS page id 73). Reuses the same English label as profile_main.privacy_policy_title.
+       */
+      privacy_policy_title: string;
+      /**
+       * Subtitle of the Privacy Policy row in the Learn-more section (e.g. 'How we collect and use data').
+       */
+      privacy_policy_subtitle: string;
+      /**
+       * Title of the Terms & Conditions row in the Learn-more section at the bottom of the Privacy & Advertising screen. Tapping opens the Terms & Conditions page (CMS page id 76).
+       */
+      terms_and_conditions_title: string;
+      /**
+       * Subtitle of the Terms & Conditions row in the Learn-more section (e.g. 'Legal terms for using WeMeditate').
+       */
+      terms_and_conditions_subtitle: string;
+    };
     /**
-     * Screen title (e.g. 'Help spread the word and make the app better').
+     * Third paragraph of the advertising section. Covers both the never-shared categories AND the never-sell statement in a single paragraph with two bold spans ('We'll never share' / 'we never sell'). Must remain consistent with analytics-simplified/03-marketing-event-taxonomy.md §2.
      */
-    screen_title: string;
+    advertising_body_never_share?: {
+      root: {
+        type: string;
+        children: {
+          type: any;
+          version: number;
+          [k: string]: unknown;
+        }[];
+        direction: ('ltr' | 'rtl') | null;
+        format: 'left' | 'start' | 'center' | 'right' | 'end' | 'justify' | '';
+        indent: number;
+        version: number;
+      };
+      [k: string]: unknown;
+    } | null;
     /**
-     * Status label shown next to a toggle that is currently allowed. MUST preserve the {date} placeholder — it is replaced at runtime with the localized date of the most recent consent decision (e.g. '16 May 2026').
+     * First paragraph of the advertising section. Contains an inline link (e.g. 'what we share') that opens the Privacy Policy page (CMS page id 73, scrolled to the 'what we share' heading) — same link target as onboarding_consent_modal.body_intro.
      */
-    status_allowed: string;
-    /**
-     * Status label shown next to a toggle that is currently disallowed.
-     */
-    status_not_allowed: string;
-    /**
-     * Section title for the anonymous product analytics toggle (e.g. 'Anonymous product analytics'). Drives productAnalyticsOptOut.
-     */
-    product_analytics_title: string;
-    /**
-     * Section body explaining anonymous product analytics: we log aggregated usage data to fix bugs and improve We Meditate, no individual data, no advertisers, no user profile. Must remain consistent with the TelemetryDeck posture in analytics-simplified/01-strategy.md §4.
-     */
-    product_analytics_description: string;
-    /**
-     * Section title for the advertising-measurement toggle (e.g. 'Advertising measurement and improvement'). Drives adsMarketingConsent.
-     */
-    advertising_title: string;
-    /**
-     * First paragraph prefix of the advertising section; combined inline with advertising_body_intro_link and advertising_body_intro_suffix. Include any trailing space.
-     */
-    advertising_body_intro_prefix: string;
-    /**
-     * Inline link text inside the first paragraph (e.g. 'what we share'). Tapping opens the same 'what we share' detail used by the ad consent modal.
-     */
-    advertising_body_intro_link: string;
-    /**
-     * First paragraph suffix completing the sentence after the inline link. Include the leading separator if needed.
-     */
-    advertising_body_intro_suffix: string;
-    /**
-     * Second paragraph of the advertising section: how granting consent helps WeMeditate use donations responsibly, improve campaigns, suppress ads to existing users, and reach similar people.
-     */
-    advertising_body_benefits: string;
-    /**
-     * Third paragraph of the advertising section reiterating the never-shared categories (mood, goals, hand sensations, reflections, class location, spiritual-practice details). Must remain consistent with analytics-simplified/03-marketing-event-taxonomy.md §2.
-     */
-    advertising_body_never_share: string;
-    /**
-     * Fourth paragraph of the advertising section explaining that the user can change their choice anytime using the toggle at the top of this screen.
-     */
-    advertising_body_change_hint: string;
-    /**
-     * Sub-section header listing current advertising platforms (e.g. 'Current advertising platforms').
-     */
-    advertising_platforms_header: string;
-    /**
-     * Bullet item for Meta (Facebook + Instagram + Audience Network). Brand name — usually kept as 'Meta'.
-     */
-    advertising_platform_meta: string;
-    /**
-     * Bullet item for Google Ads. Brand name — usually kept as 'Google Ads'.
-     */
-    advertising_platform_google_ads: string;
-    /**
-     * Bullet item for Apple Search Ads. Brand name — usually kept as 'Apple Search Ads'.
-     */
-    advertising_platform_apple_search_ads: string;
+    advertising_body_intro?: {
+      root: {
+        type: string;
+        children: {
+          type: any;
+          version: number;
+          [k: string]: unknown;
+        }[];
+        direction: ('ltr' | 'rtl') | null;
+        format: 'left' | 'start' | 'center' | 'right' | 'end' | 'justify' | '';
+        indent: number;
+        version: number;
+      };
+      [k: string]: unknown;
+    } | null;
   };
   profile_contact?: {
     /**
@@ -4689,38 +4811,46 @@ export interface WmAppTranslation {
     allow_notifications_screen_subtitle: string;
   };
   meditation_footsoak?: {
+    strings?: {
+      /**
+       * Step indicator (e.g. 'Step 3 of 3') at the top of the foot-soak screen.
+       */
+      step_label: string;
+      /**
+       * Screen title asking whether the user wants to foot-soak with this meditation.
+       */
+      title: string;
+      /**
+       * Inline link/CTA opening the foot-soak tutorial.
+       */
+      tutorial_cta: string;
+      /**
+       * Primary CTA that starts the meditation with a foot-soak.
+       */
+      start_with_footsoak: string;
+      /**
+       * Secondary CTA that starts the meditation without a foot-soak.
+       */
+      start_meditation: string;
+    };
     /**
-     * Step indicator (e.g. 'Step 3 of 3') at the top of the foot-soak screen.
+     * Body copy of the foot-soak screen. Contains a short emphasised span (typically italic, e.g. 'really') that translators position freely within the sentence.
      */
-    step_label: string;
-    /**
-     * Screen title asking whether the user wants to foot-soak with this meditation.
-     */
-    title: string;
-    /**
-     * Body-copy prefix; combined inline with description_emphasis and description_suffix to form a single sentence. Include trailing space if the locale needs one.
-     */
-    description_prefix: string;
-    /**
-     * Emphasised word in the foot-soak body copy, typically rendered in italic or bold (e.g. 'really').
-     */
-    description_emphasis: string;
-    /**
-     * Body-copy suffix completing the foot-soak description sentence. Include the leading space.
-     */
-    description_suffix: string;
-    /**
-     * Inline link/CTA opening the foot-soak tutorial.
-     */
-    tutorial_cta: string;
-    /**
-     * Primary CTA that starts the meditation with a foot-soak.
-     */
-    start_with_footsoak: string;
-    /**
-     * Secondary CTA that starts the meditation without a foot-soak.
-     */
-    start_meditation: string;
+    description?: {
+      root: {
+        type: string;
+        children: {
+          type: any;
+          version: number;
+          [k: string]: unknown;
+        }[];
+        direction: ('ltr' | 'rtl') | null;
+        format: 'left' | 'start' | 'center' | 'right' | 'end' | 'justify' | '';
+        indent: number;
+        version: number;
+      };
+      [k: string]: unknown;
+    } | null;
   };
   meditation_player?: {
     /**
@@ -5025,110 +5155,114 @@ export interface WmAppTranslation {
     ok: string;
   };
   auth_create_account?: {
+    strings?: {
+      /**
+       * Sheet / modal title shown in the navigation chrome.
+       */
+      title: string;
+      /**
+       * Hero title on the account creation screen.
+       */
+      screen_title: string;
+      /**
+       * Hero subtitle on the account creation screen.
+       */
+      screen_subtitle: string;
+      /**
+       * Tertiary action allowing a guest user to skip account creation.
+       */
+      skip_and_explore: string;
+      /**
+       * Validation error shown when the user tries to submit without checking the consent box.
+       */
+      error_check_consent: string;
+      /**
+       * Label for the email input.
+       */
+      email_label: string;
+      /**
+       * Placeholder hint for the email input.
+       */
+      email_placeholder: string;
+      /**
+       * Label for the password input.
+       */
+      password_label: string;
+      /**
+       * Placeholder hint for the password input.
+       */
+      password_placeholder: string;
+      /**
+       * Primary CTA submitting account creation.
+       */
+      submit: string;
+      /**
+       * Loading-state label shown on the primary CTA while account creation is in flight.
+       */
+      creating: string;
+      /**
+       * Error shown when the email is already associated with an account.
+       */
+      error_email_in_use: string;
+      /**
+       * CTA on the email-in-use branch redirecting to login.
+       */
+      login_with_existing_account: string;
+      /**
+       * Validation error for an invalid email.
+       */
+      error_invalid_email: string;
+      /**
+       * Validation error for a password shorter than the minimum length.
+       */
+      error_weak_password: string;
+      /**
+       * Error shown when account creation is rate-limited.
+       */
+      error_too_many_requests: string;
+      /**
+       * Error shown when the account is created but the local session cannot be persisted.
+       */
+      error_session_persistence: string;
+      /**
+       * Generic account-creation failure error.
+       */
+      error_generic: string;
+      /**
+       * Error shown when Google sign-in fails during account creation.
+       */
+      error_google_failed: string;
+      /**
+       * Error shown when Apple sign-in fails during account creation.
+       */
+      error_apple_failed: string;
+      /**
+       * Error shown when Facebook sign-in fails during account creation.
+       */
+      error_facebook_failed: string;
+      /**
+       * Message shown when the user cancels the social-auth flow.
+       */
+      error_provider_cancelled: string;
+    };
     /**
-     * Sheet / modal title shown in the navigation chrome.
+     * Consent checkbox label on the account creation screen. Contains two inline links (Terms & Conditions, Privacy Policy) opening the corresponding in-app webviews (wemeditate://legal/terms, wemeditate://legal/privacy). Independent of the ad-measurement consent.
      */
-    title: string;
-    /**
-     * Hero title on the account creation screen.
-     */
-    screen_title: string;
-    /**
-     * Hero subtitle on the account creation screen.
-     */
-    screen_subtitle: string;
-    /**
-     * Tertiary action allowing a guest user to skip account creation.
-     */
-    skip_and_explore: string;
-    /**
-     * Inline-text prefix of the consent checkbox label. Combined with consent_terms, consent_and_acknowledge, and consent_privacy. Include any trailing space.
-     */
-    consent_prefix: string;
-    /**
-     * Inline link text for the Terms & Conditions, opening the in-app webview.
-     */
-    consent_terms: string;
-    /**
-     * Connector text between the Terms link and the Privacy Policy link. Include any required spaces.
-     */
-    consent_and_acknowledge: string;
-    /**
-     * Inline link text for the Privacy Policy, opening the in-app webview.
-     */
-    consent_privacy: string;
-    /**
-     * Validation error shown when the user tries to submit without checking the consent box.
-     */
-    error_check_consent: string;
-    /**
-     * Label for the email input.
-     */
-    email_label: string;
-    /**
-     * Placeholder hint for the email input.
-     */
-    email_placeholder: string;
-    /**
-     * Label for the password input.
-     */
-    password_label: string;
-    /**
-     * Placeholder hint for the password input.
-     */
-    password_placeholder: string;
-    /**
-     * Primary CTA submitting account creation.
-     */
-    submit: string;
-    /**
-     * Loading-state label shown on the primary CTA while account creation is in flight.
-     */
-    creating: string;
-    /**
-     * Error shown when the email is already associated with an account.
-     */
-    error_email_in_use: string;
-    /**
-     * CTA on the email-in-use branch redirecting to login.
-     */
-    login_with_existing_account: string;
-    /**
-     * Validation error for an invalid email.
-     */
-    error_invalid_email: string;
-    /**
-     * Validation error for a password shorter than the minimum length.
-     */
-    error_weak_password: string;
-    /**
-     * Error shown when account creation is rate-limited.
-     */
-    error_too_many_requests: string;
-    /**
-     * Error shown when the account is created but the local session cannot be persisted.
-     */
-    error_session_persistence: string;
-    /**
-     * Generic account-creation failure error.
-     */
-    error_generic: string;
-    /**
-     * Error shown when Google sign-in fails during account creation.
-     */
-    error_google_failed: string;
-    /**
-     * Error shown when Apple sign-in fails during account creation.
-     */
-    error_apple_failed: string;
-    /**
-     * Error shown when Facebook sign-in fails during account creation.
-     */
-    error_facebook_failed: string;
-    /**
-     * Message shown when the user cancels the social-auth flow.
-     */
-    error_provider_cancelled: string;
+    consent_label?: {
+      root: {
+        type: string;
+        children: {
+          type: any;
+          version: number;
+          [k: string]: unknown;
+        }[];
+        direction: ('ltr' | 'rtl') | null;
+        format: 'left' | 'start' | 'center' | 'right' | 'end' | 'justify' | '';
+        indent: number;
+        version: number;
+      };
+      [k: string]: unknown;
+    } | null;
   };
   navigation?: {
     /**
@@ -5661,12 +5795,34 @@ export interface WmAppConfigSelect<T extends boolean = true> {
  * via the `definition` "wm-app-translations_select".
  */
 export interface WmAppTranslationsSelect<T extends boolean = true> {
-  onboarding_welcome?: T;
+  onboarding_welcome?:
+    | T
+    | {
+        strings?: T;
+        legal_disclaimer?: T;
+      };
   onboarding_name?: T;
   onboarding_greeting?: T;
-  onboarding_user_type?: T;
-  onboarding_carousel?: T;
-  onboarding_consent_modal?: T;
+  onboarding_user_type?:
+    | T
+    | {
+        strings?: T;
+        title?: T;
+      };
+  onboarding_carousel?:
+    | T
+    | {
+        strings?: T;
+        page_true_self_title?: T;
+      };
+  onboarding_consent_modal?:
+    | T
+    | {
+        strings?: T;
+        body_never_share?: T;
+        body_never_sell?: T;
+        body_intro?: T;
+      };
   daily_main?: T;
   daily_common?: T;
   daily_load_info?: T;
@@ -5686,11 +5842,22 @@ export interface WmAppTranslationsSelect<T extends boolean = true> {
   profile_favourites?: T;
   profile_history?: T;
   profile_account?: T;
-  profile_privacy_advertising?: T;
+  profile_privacy_advertising?:
+    | T
+    | {
+        strings?: T;
+        advertising_body_never_share?: T;
+        advertising_body_intro?: T;
+      };
   profile_contact?: T;
   meditation_intent?: T;
   meditation_reminder?: T;
-  meditation_footsoak?: T;
+  meditation_footsoak?:
+    | T
+    | {
+        strings?: T;
+        description?: T;
+      };
   meditation_player?: T;
   meditation_vibes_check?: T;
   meditation_feedback?: T;
@@ -5698,7 +5865,12 @@ export interface WmAppTranslationsSelect<T extends boolean = true> {
   auth_login?: T;
   auth_restore_password?: T;
   auth_restore_password_email_sent?: T;
-  auth_create_account?: T;
+  auth_create_account?:
+    | T
+    | {
+        strings?: T;
+        consent_label?: T;
+      };
   navigation?: T;
   general?: T;
   markReviewed?: T;

--- a/tests/int/translations-globals.int.spec.ts
+++ b/tests/int/translations-globals.int.spec.ts
@@ -131,6 +131,22 @@ describe('Translations Globals Configuration', () => {
       const global = payload.globals.config.find((g) => g.slug === 'wm-app-translations')
       const tabsField = global?.fields[0]
 
+      // Mixed leaves (with at least one richText property) wrap their JSON field
+      // inside a Payload group. Pure-string leaves keep the JSON field as a direct
+      // child of the tab. Both paths must surface `globalSlug`.
+      const findJsonField = (fields: ReadonlyArray<{ type: string }>): unknown => {
+        for (const f of fields) {
+          if (f.type === 'json') return f
+          if (f.type === 'group') {
+            const inner = (f as { fields: Array<{ type: string }> }).fields.find(
+              (sub) => sub.type === 'json',
+            )
+            if (inner) return inner
+          }
+        }
+        return undefined
+      }
+
       if (tabsField?.type === 'tabs') {
         for (const tab of tabsField.tabs) {
           if (tab.label === 'Review') continue
@@ -138,12 +154,16 @@ describe('Translations Globals Configuration', () => {
           if (firstField.type === 'tabs') {
             // Parent group: check globalSlug on each inner sub-tab's JSON field.
             for (const innerTab of (firstField as { type: 'tabs'; tabs: typeof tabsField.tabs }).tabs) {
-              const jsonField = innerTab.fields.find((f) => f.type === 'json')
+              const jsonField = findJsonField(innerTab.fields) as
+                | { admin?: { custom?: { globalSlug?: string } } }
+                | undefined
               expect(jsonField?.admin?.custom?.globalSlug).toBe('wm-app-translations')
             }
           } else {
             // Leaf group: check globalSlug on the direct JSON field.
-            const jsonField = tab.fields.find((f) => f.type === 'json')
+            const jsonField = findJsonField(tab.fields) as
+              | { admin?: { custom?: { globalSlug?: string } } }
+              | undefined
             expect(jsonField?.admin?.custom?.globalSlug).toBe('wm-app-translations')
           }
         }
@@ -182,6 +202,58 @@ describe('Translations Globals Configuration', () => {
         expect(talksPlayerKeys).toContain('play')
         expect(talksPlayerKeys).toContain('pause')
       }
+    })
+
+    it('should wrap mixed-leaf groups (with richText) in a Payload group with strings JSON + richText siblings', () => {
+      const global = payload.globals.config.find((g) => g.slug === 'wm-app-translations')
+      const tabsField = global?.fields[0]
+      if (tabsField?.type !== 'tabs') return
+
+      // onboarding > consent_modal has 3 richText keys: body_intro, body_never_share, body_never_sell.
+      const onboardingInnerTabs = (
+        tabsField.tabs[0].fields[0] as { type: 'tabs'; tabs: typeof tabsField.tabs }
+      ).tabs
+      const consentModalTab = onboardingInnerTabs.find((t) => t.label === 'Consent Modal')
+      expect(consentModalTab).toBeDefined()
+      if (!consentModalTab) return
+
+      // The wrapper group is named `onboarding_consent_modal`.
+      const wrapperGroup = consentModalTab.fields.find(
+        (f) => f.type === 'group',
+      ) as { name?: string; fields?: Array<{ type: string; name?: string }> } | undefined
+      expect(wrapperGroup).toBeDefined()
+      expect(wrapperGroup?.name).toBe('onboarding_consent_modal')
+
+      // Inside the group: `strings` JSON + 3 richText siblings.
+      const inner = wrapperGroup?.fields ?? []
+      const stringsField = inner.find((f) => f.type === 'json')
+      expect(stringsField?.name).toBe('strings')
+
+      const richTextNames = inner.filter((f) => f.type === 'richText').map((f) => f.name)
+      expect(richTextNames).toEqual(
+        expect.arrayContaining(['body_intro', 'body_never_share', 'body_never_sell']),
+      )
+    })
+
+    it('should keep pure-string leaves as a direct JSON field (backward compatible)', () => {
+      const global = payload.globals.config.find((g) => g.slug === 'wm-app-translations')
+      const tabsField = global?.fields[0]
+      if (tabsField?.type !== 'tabs') return
+
+      // onboarding > name has no richText keys → should remain a direct JSON field.
+      const onboardingInnerTabs = (
+        tabsField.tabs[0].fields[0] as { type: 'tabs'; tabs: typeof tabsField.tabs }
+      ).tabs
+      const nameTab = onboardingInnerTabs.find((t) => t.label === 'Name')
+      expect(nameTab).toBeDefined()
+      if (!nameTab) return
+
+      const jsonField = nameTab.fields.find((f) => f.type === 'json') as
+        | { name?: string }
+        | undefined
+      expect(jsonField?.name).toBe('onboarding_name')
+      // And no wrapper group at the tab level.
+      expect(nameTab.fields.find((f) => f.type === 'group')).toBeUndefined()
     })
 
     it('should have a Review tab with markReviewed and lastReviewedAt fields', () => {

--- a/tests/unit/wm-app-translations-lexical.spec.ts
+++ b/tests/unit/wm-app-translations-lexical.spec.ts
@@ -1,0 +1,416 @@
+/**
+ * Unit tests for the segments → Lexical converter used by the
+ * `wm-app-translations` seed importer.
+ *
+ * These tests run in the unit lane (no Payload bootstrap) because the
+ * converter is a pure function. The Lexical shape it emits is asserted
+ * exactly so that any drift from the project's known-working Lexical
+ * conventions (matched against `seeds/lib/lexicalConverter.ts`) is caught.
+ *
+ * In particular:
+ *   - All container nodes use `direction: null` (NOT `'ltr'`) — this matches
+ *     the EditorJS-converted documents Payload already persists.
+ *   - Link nodes use `version: 3` with `fields: { linkType: 'custom', url, newTab: false }`.
+ *   - Text-node `format` is a bitmask: bit 0 = bold (1), bit 1 = italic (2).
+ */
+
+import { describe, expect, it } from 'vitest'
+
+import {
+  collectSeedTodos,
+  isSeedRichTextField,
+  seedLeafToPayloadData,
+  seedRichTextToLexical,
+  type SeedFile,
+  type SeedRichTextField,
+} from '../../seeds/wm-app-translations/lexicalConverter'
+
+describe('seeds/wm-app-translations/lexicalConverter', () => {
+  describe('isSeedRichTextField', () => {
+    it('recognises objects with the _richText marker', () => {
+      expect(isSeedRichTextField({ _richText: true, paragraphs: [] })).toBe(true)
+    })
+
+    it('rejects plain strings and other shapes', () => {
+      expect(isSeedRichTextField('plain string')).toBe(false)
+      expect(isSeedRichTextField(null)).toBe(false)
+      expect(isSeedRichTextField(undefined)).toBe(false)
+      expect(isSeedRichTextField({})).toBe(false)
+      expect(isSeedRichTextField({ paragraphs: [] })).toBe(false)
+      expect(isSeedRichTextField({ _richText: false, paragraphs: [] })).toBe(false)
+    })
+  })
+
+  describe('seedRichTextToLexical', () => {
+    it('emits a root with direction:null and a single paragraph for plain text', () => {
+      const field: SeedRichTextField = {
+        _richText: true,
+        paragraphs: [[{ text: 'Hello, friend.' }]],
+      }
+      const out = seedRichTextToLexical(field, 'test.greeting')
+      expect(out).toEqual({
+        root: {
+          type: 'root',
+          version: 1,
+          format: '',
+          indent: 0,
+          direction: null,
+          children: [
+            {
+              type: 'paragraph',
+              version: 1,
+              format: '',
+              indent: 0,
+              direction: null,
+              textFormat: 0,
+              children: [
+                {
+                  type: 'text',
+                  version: 1,
+                  format: 0,
+                  text: 'Hello, friend.',
+                  detail: 0,
+                  mode: 'normal',
+                  style: '',
+                },
+              ],
+            },
+          ],
+        },
+      })
+    })
+
+    it('sets format=1 for bold text', () => {
+      const out = seedRichTextToLexical(
+        { _richText: true, paragraphs: [[{ text: 'shout', bold: true }]] },
+        'test.bold',
+      )
+      const child = out.root.children[0].children[0]
+      expect(child.type).toBe('text')
+      if (child.type === 'text') expect(child.format).toBe(1)
+    })
+
+    it('sets format=2 for italic text', () => {
+      const out = seedRichTextToLexical(
+        { _richText: true, paragraphs: [[{ text: 'emphasis', italic: true }]] },
+        'test.italic',
+      )
+      const child = out.root.children[0].children[0]
+      expect(child.type).toBe('text')
+      if (child.type === 'text') expect(child.format).toBe(2)
+    })
+
+    it('sets format=3 (bitmask) for bold+italic text', () => {
+      const out = seedRichTextToLexical(
+        {
+          _richText: true,
+          paragraphs: [[{ text: 'really shout', bold: true, italic: true }]],
+        },
+        'test.bold-italic',
+      )
+      const child = out.root.children[0].children[0]
+      expect(child.type).toBe('text')
+      if (child.type === 'text') expect(child.format).toBe(3)
+    })
+
+    it('emits a link node with version:3, linkType:custom, newTab:false, direction:null', () => {
+      const out = seedRichTextToLexical(
+        {
+          _richText: true,
+          paragraphs: [
+            [
+              { text: 'See ' },
+              { type: 'link', text: 'what we share', href: 'wm-app-config://privacyPolicyPage#what-we-share' },
+              { text: ' for details.' },
+            ],
+          ],
+        },
+        'test.link',
+      )
+      const children = out.root.children[0].children
+      expect(children).toHaveLength(3)
+      expect(children[0]).toMatchObject({ type: 'text', text: 'See ' })
+      expect(children[1]).toEqual({
+        type: 'link',
+        version: 3,
+        format: '',
+        indent: 0,
+        direction: null,
+        fields: {
+          linkType: 'custom',
+          url: 'wm-app-config://privacyPolicyPage#what-we-share',
+          newTab: false,
+        },
+        children: [
+          {
+            type: 'text',
+            version: 1,
+            format: 0,
+            text: 'what we share',
+            detail: 0,
+            mode: 'normal',
+            style: '',
+          },
+        ],
+      })
+      expect(children[2]).toMatchObject({ type: 'text', text: ' for details.' })
+    })
+
+    it('handles a link segment with bold formatting on the link text', () => {
+      const out = seedRichTextToLexical(
+        {
+          _richText: true,
+          paragraphs: [
+            [
+              { type: 'link', text: 'Terms', href: 'wm-app-config://termsAndConditionsPage', bold: true },
+            ],
+          ],
+        },
+        'test.bold-link',
+      )
+      const link = out.root.children[0].children[0]
+      expect(link.type).toBe('link')
+      if (link.type === 'link') {
+        expect(link.children[0].format).toBe(1)
+      }
+    })
+
+    it('emits multiple paragraphs in order', () => {
+      const out = seedRichTextToLexical(
+        {
+          _richText: true,
+          paragraphs: [[{ text: 'First.' }], [{ text: 'Second.' }], [{ text: 'Third.' }]],
+        },
+        'test.multi',
+      )
+      expect(out.root.children).toHaveLength(3)
+      expect(out.root.children[0].children[0]).toMatchObject({ text: 'First.' })
+      expect(out.root.children[1].children[0]).toMatchObject({ text: 'Second.' })
+      expect(out.root.children[2].children[0]).toMatchObject({ text: 'Third.' })
+    })
+
+    it('reproduces the consent_modal.body_intro shape end-to-end', () => {
+      // This mirrors the exact shape used in data.en.json for the
+      // post-first-meditation consent modal — sentence containing an
+      // inline "what we share" link to the privacy detail.
+      const out = seedRichTextToLexical(
+        {
+          _richText: true,
+          paragraphs: [
+            [
+              {
+                text:
+                  "With your permission, we'll share a few basic app usage and device details with Meta, Apple Search Ads and Google Ads, like app installs or completed sessions. (",
+              },
+              {
+                type: 'link',
+                text: 'what we share',
+                href: 'wm-app-config://privacyPolicyPage#what-we-share',
+              },
+              { text: ').' },
+            ],
+          ],
+        },
+        'onboarding_consent_modal.body_intro',
+      )
+      expect(out.root.children).toHaveLength(1)
+      expect(out.root.children[0].children).toHaveLength(3)
+      const link = out.root.children[0].children[1]
+      expect(link.type).toBe('link')
+      if (link.type === 'link') {
+        expect(link.fields.url).toBe('wm-app-config://privacyPolicyPage#what-we-share')
+      }
+    })
+
+    it('throws on link segment missing href', () => {
+      expect(() =>
+        seedRichTextToLexical(
+          {
+            _richText: true,
+            paragraphs: [[{ type: 'link', text: 'oops' } as never]],
+          },
+          'test.bad-link',
+        ),
+      ).toThrow(/missing href/)
+    })
+
+    it('throws on link segment missing text', () => {
+      expect(() =>
+        seedRichTextToLexical(
+          {
+            _richText: true,
+            paragraphs: [[{ type: 'link', href: 'wm-app-config://termsAndConditionsPage' } as never]],
+          },
+          'test.bad-link',
+        ),
+      ).toThrow(/missing text/)
+    })
+
+    it('throws on text segment without text field', () => {
+      expect(() =>
+        seedRichTextToLexical(
+          { _richText: true, paragraphs: [[{ bold: true } as never]] },
+          'test.bad-text',
+        ),
+      ).toThrow(/missing text/)
+    })
+
+    it('throws on empty paragraphs array', () => {
+      expect(() =>
+        seedRichTextToLexical({ _richText: true, paragraphs: [] }, 'test.empty'),
+      ).toThrow(/non-empty paragraphs/)
+    })
+
+    it('throws on an empty paragraph (zero segments)', () => {
+      expect(() =>
+        seedRichTextToLexical(
+          { _richText: true, paragraphs: [[]] },
+          'test.empty-para',
+        ),
+      ).toThrow(/non-empty array of segments/)
+    })
+
+    it('error messages include the leaf path and paragraph index', () => {
+      expect(() =>
+        seedRichTextToLexical(
+          {
+            _richText: true,
+            paragraphs: [
+              [{ text: 'OK' }],
+              [{ type: 'link', text: 'broken' } as never],
+            ],
+          },
+          'onboarding_welcome.legal_disclaimer',
+        ),
+      ).toThrow(/onboarding_welcome\.legal_disclaimer\[¶1\]\[0\]/)
+    })
+  })
+
+  describe('seedLeafToPayloadData', () => {
+    it('passes pure-string leaves through (stripping _meta keys)', () => {
+      const out = seedLeafToPayloadData('onboarding_name', {
+        title: "What's your name?",
+        placeholder: 'Your first name',
+        continue: 'Continue',
+        _source: 'documentation only — should be dropped',
+      } as never)
+      expect(out).toEqual({
+        title: "What's your name?",
+        placeholder: 'Your first name',
+        continue: 'Continue',
+      })
+    })
+
+    it('throws when a pure-string leaf has a non-string value', () => {
+      expect(() =>
+        seedLeafToPayloadData('bad_leaf', { good: 'ok', bad: 123 as unknown as string }),
+      ).toThrow(/has non-string value/)
+    })
+
+    it('shapes a mixed leaf as { strings, ...richKeys }', () => {
+      const out = seedLeafToPayloadData('onboarding_welcome', {
+        strings: { title: 'Welcome, friend', get_started: 'Get started' },
+        legal_disclaimer: {
+          _richText: true,
+          paragraphs: [
+            [
+              { text: 'By continuing, you agree to our ' },
+              { type: 'link', text: 'Terms', href: 'wm-app-config://termsAndConditionsPage' },
+            ],
+          ],
+        },
+      } as never)
+      expect((out as { strings: Record<string, string> }).strings).toEqual({
+        title: 'Welcome, friend',
+        get_started: 'Get started',
+      })
+      const richField = (out as Record<string, unknown>).legal_disclaimer as {
+        root: { children: unknown[] }
+      }
+      expect(richField.root.children).toHaveLength(1)
+    })
+
+    it('drops _source / _todo / other _-prefixed metadata at all levels', () => {
+      const out = seedLeafToPayloadData('mixed_leaf', {
+        _source: 'documentation',
+        _todo: 'TODO marker',
+        strings: { foo: 'bar' },
+        body: {
+          _richText: true,
+          _source: 'rich field doc',
+          _todo: 'rich field todo',
+          paragraphs: [[{ text: 'paragraph text' }]],
+        },
+      } as never)
+      const out_obj = out as Record<string, unknown>
+      expect(Object.keys(out_obj).sort()).toEqual(['body', 'strings'])
+      expect('_source' in out_obj).toBe(false)
+      expect('_todo' in out_obj).toBe(false)
+    })
+
+    it('throws when a sibling of "strings" is not a richText field', () => {
+      expect(() =>
+        seedLeafToPayloadData('bad_mixed', {
+          strings: { foo: 'bar' },
+          bad: 'this should be a richText field, not a string',
+        } as never),
+      ).toThrow(/is not a richText field/)
+    })
+  })
+
+  describe('collectSeedTodos', () => {
+    it('returns an empty array when no _todo markers exist', () => {
+      const seed: SeedFile = {
+        leaf_a: { foo: 'bar' },
+        leaf_b: { strings: { x: 'y' } },
+      }
+      expect(collectSeedTodos(seed)).toEqual([])
+    })
+
+    it('collects leaf-level _todo markers', () => {
+      const seed: SeedFile = {
+        leaf_a: { _todo: 'verify against Figma', foo: 'bar' },
+      }
+      expect(collectSeedTodos(seed)).toEqual(['leaf_a: verify against Figma'])
+    })
+
+    it('collects richText-field _todo markers', () => {
+      const seed: SeedFile = {
+        leaf_a: {
+          strings: { x: 'y' },
+          body: {
+            _richText: true,
+            _todo: 'confirm link target',
+            paragraphs: [[{ text: 'foo' }]],
+          },
+        },
+      }
+      expect(collectSeedTodos(seed)).toEqual(['leaf_a.body: confirm link target'])
+    })
+
+    it('collects both kinds in order', () => {
+      const seed: SeedFile = {
+        first_leaf: {
+          _todo: 'leaf-level todo',
+          strings: { foo: 'bar' },
+          rich_a: { _richText: true, _todo: 'rich todo 1', paragraphs: [[{ text: 'a' }]] },
+          rich_b: { _richText: true, paragraphs: [[{ text: 'b' }]] },
+        },
+        second_leaf: { _todo: 'second-leaf todo', foo: 'bar' },
+      }
+      expect(collectSeedTodos(seed)).toEqual([
+        'first_leaf: leaf-level todo',
+        'first_leaf.rich_a: rich todo 1',
+        'second_leaf: second-leaf todo',
+      ])
+    })
+
+    it('ignores the _meta envelope key', () => {
+      const seed: SeedFile = {
+        _meta: { _todo: 'this should NOT be collected — it is in _meta' },
+        actual_leaf: { _todo: 'this should', foo: 'bar' },
+      }
+      expect(collectSeedTodos(seed)).toEqual(['actual_leaf: this should'])
+    })
+  })
+})


### PR DESCRIPTION
## Summary

Implements all three phases of [#393](https://github.com/sydevs/SahajCloud/issues/393) — rich-text support in `wm-app-translations`, the schema rewrite that uses it, and the English seed import wired into the existing `pnpm seed` pipeline. Two commits, scoped to be reviewed independently if preferred.

- **Phase 1** — [`src/fields/translationsField.ts`](src/fields/translationsField.ts) gains a new `LeafPropertySchema = StringPropertySchema | RichTextPropertySchema` union. `buildTranslationTabs()` treats leaves like this:
  - **Pure-string leaf** (current behaviour, 33 of 40 leaves) → single JSON field rendered by `TranslationsTable`. Field name and shape unchanged — no breaking change.
  - **Mixed leaf** (≥ 1 richText property, 7 leaves) → wrapper Payload `group` field named after the leaf, containing one `strings` JSON sub-field + one stock Payload `richText` sub-field per richText property, each using the existing `basicRichTextEditor` preset (Bold, Italic, Link, InlineToolbar).
- **Phase 2** — [`src/globals/wemeditate-app/translationsSchema.json`](src/globals/wemeditate-app/translationsSchema.json) is rewritten to collapse 22 `*_prefix` / `*_link` / `*_suffix` triples into 7 richText fields, and convert 3 plain-string paragraphs to richText so the bold spans live in the translation rather than hardcoded Flutter styling. Description of every collapse and conversion is in the issue.
- **Types** regenerated via `pnpm generate:types`.
- **Tests** in `tests/int/translations-globals.int.spec.ts` — updated the `globalSlug` test to inspect both shapes; added two new assertions: one for the mixed-leaf wrapper-group shape (`onboarding_consent_modal`) and one for pure-string leaves staying flat (`onboarding_name`).

## Schema delta — concrete list

| Leaf | What changes |
|---|---|
| `onboarding.welcome` | 4 string keys (`legal_disclaimer_prefix/_and/_terms/_privacy_policy`) → 1 richText (`legal_disclaimer`) |
| `onboarding.user_type` | 3 string keys (`title_prefix/_brand/_suffix`) → 1 richText (`title`) |
| `onboarding.carousel` | 2 string keys (`page_true_self_prefix/_highlight`) → 1 richText (`page_true_self_title`) |
| `onboarding.consent_modal` | 3 string keys (`body_intro_prefix/_link/_suffix`) → 1 richText (`body_intro`); 2 plain-string paragraphs (`body_never_share`, `body_never_sell`) → richText |
| `auth.create_account` | 4 string keys (`consent_prefix/_terms/_and_acknowledge/_privacy`) → 1 richText (`consent_label`) |
| `meditation.footsoak` | 3 string keys (`description_prefix/_emphasis/_suffix`) → 1 richText (`description`) |
| `profile.privacy_advertising` | 3 string keys (`advertising_body_intro_prefix/_link/_suffix`) → 1 richText (`advertising_body_intro`); 1 plain-string paragraph (`advertising_body_never_share`) → richText |

**Totals:** 25 string keys consolidated into 10 richText fields. 458 plain-string keys remain unchanged. Schema goes from 483 → 468 total keys + 10 richText.

## ⚠ Migration required before merge

This PR does **not** include the D1 schema migration. Mixed leaves change from a single JSON column to one column per sub-field (one `strings` JSON column + N richText JSON columns per locale on `wm-app-translations_locales`).

Per [`.claude/rules/migrations.md`](.claude/rules/migrations.md), `pnpm db:migrations:create` must be run interactively — it hangs in agent shells. **@ardnived, please run:**

```bash
pnpm db:migrations:create
```

and use a name like `wm-app-translations-richtext`. The resulting `.ts` + `.json` pair under `src/migrations/` then commits on top of this branch. No `--augment` should be needed for this change — it's a clean column-additions migration.

Once the migration is in: `pnpm payload migrate` locally, eyeball the admin UI to confirm the 7 mixed-leaf tabs render the new richText editors below their `strings` table, then we're good to merge.

## Phase 3 — English seed import (commit `524fa30`)

Phase 3 is in this PR. New files under `seeds/wm-app-translations/`:

- **`data.en.json`** (734 lines, 36 KB) — the full English seed: 455 keys mapped from `sydevs/WeMeditateApp@main:assets/l10n/en.yaml`, 28 keys for consent surfaces sourced from Figma (node-ids 11564-91404 + 11571-40337), 10 keys for the LEGAL / Learn more sections from the Profile-tab Figma. 1 explicit `_todo` marker for `advertising_platforms_*` (below the screenshot fold).
- **`lexicalConverter.ts`** — pure-function converter from the human-readable paragraph/segment shape in the JSON to the Lexical JSON tree Payload's richText fields persist. Conventions match `seeds/lib/lexicalConverter.ts` (direction: null, link version: 3, `fields: { linkType: 'custom', url, newTab: false }`, text format bitmask for bold/italic). Exposed as a separate module for unit testing.
- **`import.ts`** — `WeMeditateAppTranslationsImporter extends BaseImporter`. Loads the JSON via the dual-mode loader (filesystem in dev, `raw.githubusercontent.com` in Workers), runs the segment→Lexical conversion for the 7 mixed leaves, issues a single `payload.updateGlobal()` call. Surfaces every `_todo` marker as a warning for editor follow-up.

Wired into the existing seed pipeline so it's targeted exactly like the other scripts:

```bash
pnpm seed wm-app-translations --dry-run                    # local preview
pnpm seed wm-app-translations                              # commit to local
SAHAJCLOUD_URL=https://cloud.sydevelopers.com pnpm seed wm-app-translations
```

Two glue files updated:
- `seeds/lib/expectedCounts.ts` — adds `'wm-app-translations'` to the `ScriptName` union. Empty `EXPECTED_COUNTS` + empty `COLLECTION_METADATA` entries (the script targets a global, not collections — `verifyCountsForScript` correctly passes by default).
- `src/app/(payload)/api/seed/[script]/route.ts` — adds the new script to `VALID_SCRIPTS`, a `getImporter()` switch case, and a no-op case in `getDatabaseCounts()` (the collection-counting path doesn't apply to a global).

Unit test coverage: **`tests/unit/wm-app-translations-lexical.spec.ts`** — 26 cases covering plain text, bold/italic format bitmask, link nodes, multi-paragraph trees, error paths (malformed link/text segments, empty paragraphs), leaf shaping (pure-string vs mixed), metadata-key stripping (`_source` / `_todo`), and TODO collection. Pure functions, no Payload bootstrap, ~7ms total.

## What's NOT in this PR

- **D1 schema migration** — see the **⚠ Migration required before merge** section above.
- **Per-locale migration of existing translation data.** Verified empty against prod via `GET /api/globals/wm-app-translations` — only `markReviewed` is currently set on the global. No live translation data to migrate.
- **WeMeditateApp Flutter changes.** Out of scope here per the ticket framing — owned by a separate team.

## Test Results

- `pnpm test:int` → **724 / 724 passing** (including 4 new tests added in commit `c7bc889`)
- `pnpm exec vitest run tests/unit/wm-app-translations-lexical.spec.ts` → **26 / 26 passing** (new converter unit tests, no Payload bootstrap, ~7ms total)
- `pnpm lint` → no new warnings (the existing `src/collections/content/Videos.ts` import-order warning is unrelated to this change)
- `pnpm tsc --noEmit -p tsconfig.json` → 0 errors in changed files
- **Dry-run against prod** with the standalone temp-script variant of the importer (validated before the seed-pipeline integration was written) → auth succeeded with the clients API key, `GET /api/globals/wm-app-translations` returned 200, diff showed all 40 leaves would be created (current global is empty except for `markReviewed`). The pipeline-integrated `pnpm seed wm-app-translations --dry-run` is gated on the migration step before it can be exercised locally.

## Test plan for reviewer

- [ ] Pull this branch, run `pnpm db:migrations:create` interactively, name it something like `wm-app-translations-richtext`
- [ ] Verify the generated `.ts` migration looks like clean column additions (no `_rels` rebuilds, no polymorphic FK renames)
- [ ] `pnpm payload migrate` against local D1
- [ ] `pnpm test:int` — confirm 724+ tests still pass
- [ ] Open `http://localhost:{PORT}/admin/globals/wm-app-translations` and confirm:
  - The 7 affected tabs (Onboarding → Welcome / User Type / Carousel / Consent Modal, Auth → Create Account, Meditation → Footsoak, Profile → Privacy Advertising) each show the rich-text editor for the new richText fields below their `strings` table
  - The `basicRichTextEditor` toolbar shows only Bold / Italic / Link / InlineToolbar (no headings, lists, blocks)
  - Pure-string leaves (Daily, Path steps, Auth Login, etc.) render identically to before — single JSON table per tab
- [ ] Confirm Review tab still works (this PR doesn't touch it)
- [ ] **Phase 3 sanity check:** with the dev server running, `pnpm seed wm-app-translations --dry-run` reports 40 leaf groups planned + 1 TODO. Then `pnpm seed wm-app-translations` (without `--dry-run`) writes successfully and the admin UI shows the seeded English copy across all 7 mixed-leaf tabs.

Once the migration is in and these check out, the whole PR ships together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


