### PR TITLE
feat(user-choices): allow icon replacement after creation

### DIFF
--- a/src/collections/tags/UserChoices.ts
+++ b/src/collections/tags/UserChoices.ts
@@ -61,7 +61,6 @@ export const UserChoices: CollectionConfig = {
   },
   upload: {
     staticDir: 'media/user-choices',
-    hideRemoveFile: true,
     mimeTypes: ['image/svg+xml'],
   },
   fields: [


### PR DESCRIPTION
## Summary
- Removes `hideRemoveFile: true` from the `UserChoices` upload config so admins can replace the SVG icon on an existing user choice via the Payload admin UI.
- The existing `restrictIconUploadToAdmin` `beforeChange` hook continues to block non-admin managers from uploading a replacement binary.
- Pure config change — no schema change, no migration required.

Closes #415

## Test plan
- [ ] `pnpm lint`
- [ ] `pnpm tsc --noEmit`
- [ ] `pnpm build`
- [ ] `pnpm test`
- [ ] Manual: as admin, open an existing user choice → "Remove File" button is visible → upload a new SVG → icon updates.
- [ ] Manual: as non-admin manager, attempt the same upload → `restrictIconUploadToAdmin` blocks with 403.

## Follow-up to consider
The hook only blocks uploads (`req.file` present). With the remove button now exposed, a non-admin could clear the icon without replacing it, leaving the choice iconless until an admin re-uploads. Analogous to the metadata-column risk the hook's docstring already accepts as low-risk; flagging in case we want to tighten the hook to also reject removals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)