### PR TITLE
fix(lessons): remove panel-subtitles validator that enforced intro-audio shape

### DIFF
--- a/src/collections/content/Lessons.ts
+++ b/src/collections/content/Lessons.ts
@@ -78,8 +78,6 @@ export const Lessons: CollectionConfig = {
                     condition: (_, siblingData) => !!siblingData?.media,
                     description: 'Subtitles for video media (JSON format).',
                   },
-                  validate: validateSubtitles,
-                  typescriptSchema: [() => subtitlesJsonSchema],
                 },
               ],
             },


### PR DESCRIPTION
## Summary

- The panel `subtitles` field on a lesson stores per-video timed cues whose shape is a flat array of `{ startTimeMs, endTimeMs, durationMs?, content }` (read by the Flutter app's `PathStepPanelSubtitleDto`).
- `validateSubtitles` enforces the **intro-audio** shape `{ captions: [{ duration, content, startTime: string }] }` and was accidentally attached to this field in db24daff alongside the genuine intro-audio validator. The two shapes are incompatible at the top level (array vs object), so any non-empty panel subtitles JSON has been rejected at save since that commit landed (2026-04-30) — making it impossible for editors to populate Path-step video panels.
- This PR drops `validate` / `typescriptSchema` from the panel field only. The lesson-level `introSubtitles` field keeps the validator because its shape genuinely matches the Zod schema.

## Why no migration

The DB column is plain `text` (see `20260424_035639_initial_schema.ts` — `\`subtitles\` text,`), so removing a runtime validator does not change the schema. After merging, run `pnpm payload generate:types` in CI/locally to refresh the loosened TypeScript type for the panel field. No `payload migrate` step is needed.

## Test plan

- [ ] In the admin, open a Path Step lesson, add a panel with media, paste a flat-array subtitles JSON (e.g. `[{"startTimeMs":540,"endTimeMs":2100,"content":"There's an energy within us"}]`), and verify the save succeeds.
- [ ] Open the same lesson via the Payload REST/Local API and confirm the panel's `subtitles` field returns the flat array intact.
- [ ] Open a lesson in the WeMeditate Flutter app at Path Step 0 and confirm the Kundalini video panel renders subtitles from the CMS rather than falling back to the bundled copy.
- [ ] Edit a lesson's `Intro Subtitles` (audio) field with the existing `{ captions: [...] }` shape and confirm validation still works there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)