### PR TITLE
chore(ci): add PR test+build workflow + targeted local tests

### DIFF
--- a/.claude/rules/testing-reqs.md
+++ b/.claude/rules/testing-reqs.md
@@ -16,23 +16,34 @@ paths:
 - **Single test process only** - Run `pnpm test` or `pnpm test:int` as a single sequential operation
 - Vitest handles internal parallelization efficiently - external parallelization causes CPU overload
 
+## Local vs CI
+
+CI (`.github/workflows/ci.yml`) runs the **full suite + the Cloudflare build** on every PR. Locally, default to **targeted** runs:
+
+- `pnpm test:unit` — fast unit lane (~1–2 s, no Payload bootstrap)
+- `pnpm exec vitest run tests/int/<file>.int.spec.ts --config ./vitest.config.mts` — a single integration spec for the area you touched
+- `pnpm exec vitest run tests/int/<file>.int.spec.ts -t "<case name>"` — a single test case
+
+Run the full `pnpm test:int` locally, or `check.sh --full` / `validate.sh --full` for CI parity (includes the Cloudflare build), **only** to reproduce a red CI check or when explicitly asked — otherwise let CI own those slower, cross-cutting checks.
+
 ## Test Commands
 
 ```bash
-pnpm test        # Run all tests (integration + E2E)
-pnpm test:int    # Run integration tests (Vitest)
-pnpm test:e2e    # Run E2E tests (Playwright)
+pnpm test:unit   # Unit lane only (fast — preferred locally)
+pnpm test        # Unit + integration (what CI runs)
+pnpm test:int    # Integration tests (Vitest)
+pnpm test:e2e    # E2E tests (Playwright — currently no specs, no-ops)
 ```
 
 ## Correct Usage
 
 ```bash
-# DO: Run tests sequentially
+# DO: targeted locally; sequential when you do run more than one
 pnpm lint
-pnpm build
-pnpm test
+pnpm test:unit
+pnpm exec vitest run tests/int/albums.int.spec.ts --config ./vitest.config.mts
 
-# DON'T: Run in parallel
+# DON'T: run multiple test/build commands in parallel
 pnpm lint & pnpm build & pnpm test  # BAD - CPU overload
 ```
 

--- a/.claude/rules/tests.md
+++ b/.claude/rules/tests.md
@@ -32,11 +32,11 @@ Rules for writing and running tests in this codebase.
 
 ## Test lanes (Vitest projects)
 
-| Lane | Files | Speed | When |
-|---|---|---|---|
-| **Unit** | `tests/unit/**/*.spec.ts` | ~1–2 s for ~200 cases | Pure functions, no Payload bootstrap. **No** `globalSetup`/`setupFiles`. |
+| Lane            | Files                        | Speed                   | When                                                                                  |
+| --------------- | ---------------------------- | ----------------------- | ------------------------------------------------------------------------------------- |
+| **Unit**        | `tests/unit/**/*.spec.ts`    | ~1–2 s for ~200 cases   | Pure functions, no Payload bootstrap. **No** `globalSetup`/`setupFiles`.              |
 | **Integration** | `tests/int/**/*.int.spec.ts` | ~8 s bootstrap per file | Calls `createTestEnvironment()`, exercises hooks/access/virtual fields/relationships. |
-| **E2E** | `tests/e2e/**/*.e2e.spec.ts` | Playwright | Full UI flows, file-based SQLite. |
+| **E2E**         | `tests/e2e/**/*.e2e.spec.ts` | Playwright              | Full UI flows, file-based SQLite.                                                     |
 
 ### When to put a test in `tests/unit/`
 
@@ -82,6 +82,19 @@ afterEach(() => {
 
 Examples: `tests/int/storage-utils.int.spec.ts`,
 `tests/int/cloudflare-stream-webhook.int.spec.ts`.
+
+## Running tests locally
+
+CI (`.github/workflows/ci.yml`) runs the full suite on every PR — locally, run **targeted**:
+
+```bash
+pnpm test:unit                                                                      # whole unit lane (fast)
+pnpm exec vitest run tests/int/albums.int.spec.ts --config ./vitest.config.mts      # one integration file
+pnpm exec vitest run tests/int/albums.int.spec.ts -t "creates an album"             # one case by name
+pnpm exec vitest run tests/unit/convert-vimeo.spec.ts --config ./vitest.config.mts  # one unit file
+```
+
+The `--config ./vitest.config.mts` flag is required — the config defines the `unit`/`int` projects and injects test env vars. Reserve the full `pnpm test:int` / `pnpm build` for reproducing a red CI check. See `.claude/rules/testing-reqs.md` for the local-vs-CI split.
 
 ## Verifying "coverage gap" claims
 
@@ -149,16 +162,16 @@ sequentially (`maxConcurrency: 1`) to prevent resource conflicts.
 
 ## Test file organization
 
-| File | Purpose |
-|---|---|
-| `collections-smoke.int.spec.ts` | **One reachability canary per content-bearing collection** (create + read + relationship populate). Before creating a dedicated `[collection].int.spec.ts`, check if the smoke file already covers your case. Only add a new file for collection-specific custom behavior. |
-| `client-hooks.int.spec.ts` | Client beforeChange/afterChange hooks |
-| `meditation-duration.int.spec.ts` | Audio duration extraction + `durationMinutes` virtual field |
-| `field-utils.int.spec.ts` | `processFile` utility |
-| `storage-utils.int.spec.ts` | URL field factories, R2 adapter |
-| `role-based-access.int.spec.ts` | `hasPermission`, `customResourceAccess`, locale permissions |
-| `usage-tracking.int.spec.ts` | API usage tracking job handlers |
-| `[collection].int.spec.ts` | **Collection-specific custom behavior only** — don't duplicate smoke coverage |
+| File                              | Purpose                                                                                                                                                                                                                                                                    |
+| --------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `collections-smoke.int.spec.ts`   | **One reachability canary per content-bearing collection** (create + read + relationship populate). Before creating a dedicated `[collection].int.spec.ts`, check if the smoke file already covers your case. Only add a new file for collection-specific custom behavior. |
+| `client-hooks.int.spec.ts`        | Client beforeChange/afterChange hooks                                                                                                                                                                                                                                      |
+| `meditation-duration.int.spec.ts` | Audio duration extraction + `durationMinutes` virtual field                                                                                                                                                                                                                |
+| `field-utils.int.spec.ts`         | `processFile` utility                                                                                                                                                                                                                                                      |
+| `storage-utils.int.spec.ts`       | URL field factories, R2 adapter                                                                                                                                                                                                                                            |
+| `role-based-access.int.spec.ts`   | `hasPermission`, `customResourceAccess`, locale permissions                                                                                                                                                                                                                |
+| `usage-tracking.int.spec.ts`      | API usage tracking job handlers                                                                                                                                                                                                                                            |
+| `[collection].int.spec.ts`        | **Collection-specific custom behavior only** — don't duplicate smoke coverage                                                                                                                                                                                              |
 
 ## Common testing patterns
 
@@ -201,8 +214,8 @@ disabled). This affects how you test:
 
 ```typescript
 // ❌ Direct check on sanitized config — property has been removed
-const field = payload.globals.config.find(g => g.slug === 'my-global')?.fields[0]
-expect(field.localized).toBe(true)  // FAILS
+const field = payload.globals.config.find((g) => g.slug === 'my-global')?.fields[0]
+expect(field.localized).toBe(true) // FAILS
 
 // ✅ Functional test — proves localization works
 await payload.updateGlobal({ slug: 'my-global', locale: 'en', data: { field: 'English value' } })
@@ -220,28 +233,25 @@ configured for localized-field tests to work properly.
 
 ## PayloadCMS field-behavior gotchas
 
-| Scenario | Wrong assumption | Correct behavior |
-|---|---|---|
-| `hasMany` select, no values | `null` / `undefined` | `[]` (empty array) |
-| Join field at `depth: 0` | `{ id: number }[]` | `number[]` (raw IDs) |
-| `payload.create()` + relationship | Returns raw ID | Returns populated object |
-| `filterOptions` fallback | Return `{}` | Return `true` |
+| Scenario                             | Wrong assumption                                 | Correct behavior                                                                                                                                                                                                                                             |
+| ------------------------------------ | ------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `hasMany` select, no values          | `null` / `undefined`                             | `[]` (empty array)                                                                                                                                                                                                                                           |
+| Join field at `depth: 0`             | `{ id: number }[]`                               | `number[]` (raw IDs)                                                                                                                                                                                                                                         |
+| `payload.create()` + relationship    | Returns raw ID                                   | Returns populated object                                                                                                                                                                                                                                     |
+| `filterOptions` fallback             | Return `{}`                                      | Return `true`                                                                                                                                                                                                                                                |
 | Mixed-collection response assertions | `.docs.map(d => d.id)` uniquely identifies a row | Each collection has its own auto-increment, so `lectures.id=3` and `lecture-clips.id=3` both exist. Filter by discriminator first (`d.type === 'lecture'`) or match on `title`/slug. Asserting raw numeric id against a mixed pool silently false-positives. |
 
 ```typescript
 // hasMany select with no values
-expect(tag.timings).toEqual([])  // not toBeFalsy() / toBeNull()
+expect(tag.timings).toEqual([]) // not toBeFalsy() / toBeNull()
 
 // Join at depth: 0
-const childIds = children.docs.map((c) =>
-  typeof c === 'number' ? c : c.id
-)
+const childIds = children.docs.map((c) => (typeof c === 'number' ? c : c.id))
 
 // payload.create() auto-populates
 const child = await payload.create({ collection: 'tags', data: { parent: parentTag.id } })
-const parentId = typeof child.parent === 'object' && child.parent !== null
-  ? child.parent.id
-  : child.parent
+const parentId =
+  typeof child.parent === 'object' && child.parent !== null ? child.parent.id : child.parent
 expect(parentId).toBe(parentTag.id)
 ```
 
@@ -278,12 +288,12 @@ E2E tests use a separate file-based SQLite DB at `tests/.e2e.sqlite`,
 isolated from the dev D1 database. Run on port 4567 (separate from dev
 server).
 
-| File | Purpose |
-|---|---|
-| `tests/setup/playwright.global-setup.ts` | Seeds test data before E2E tests |
-| `tests/setup/playwright.global-teardown.ts` | Optional cleanup |
-| `tests/config/e2e-payload.config.ts` | E2E-specific Payload config |
-| `tests/files/` | Sample audio/image files for seeding |
+| File                                        | Purpose                              |
+| ------------------------------------------- | ------------------------------------ |
+| `tests/setup/playwright.global-setup.ts`    | Seeds test data before E2E tests     |
+| `tests/setup/playwright.global-teardown.ts` | Optional cleanup                     |
+| `tests/config/e2e-payload.config.ts`        | E2E-specific Payload config          |
+| `tests/files/`                              | Sample audio/image files for seeding |
 
 ### Seeded test data
 
@@ -295,11 +305,11 @@ server).
 
 ### Env vars
 
-| Var | Purpose |
-|---|---|
-| `E2E_TEST=true` | Enables E2E mode (file-based SQLite, not D1) |
-| `CLEAN_E2E_DB=true` | Removes the E2E database after teardown |
-| `PAYLOAD_SECRET` | `e2e-test-secret-key` for E2E |
+| Var                 | Purpose                                      |
+| ------------------- | -------------------------------------------- |
+| `E2E_TEST=true`     | Enables E2E mode (file-based SQLite, not D1) |
+| `CLEAN_E2E_DB=true` | Removes the E2E database after teardown      |
+| `PAYLOAD_SECRET`    | `e2e-test-secret-key` for E2E                |
 
 The DB is reset at the start of every run to prevent `drizzle-kit push`
 from prompting on stale schemas (which would hang Playwright's

--- a/.claude/skills/implement-issue/SKILL.md
+++ b/.claude/skills/implement-issue/SKILL.md
@@ -124,24 +124,29 @@ See `test-plan-checklist.md` for what to test per change type. Reference `.claud
 
 ### 8. Validate
 
-Run validation **sequentially**. Per `.claude/rules/testing-reqs.md`: never run tests + build in parallel.
+Run the **lean local gate**. Per `.claude/rules/testing-reqs.md`: never run tests + build in parallel.
 
 ```bash
-.claude/skills/implement-issue/scripts/validate.sh
+.claude/skills/implement-issue/scripts/validate.sh          # lint + pnpm test:unit
+.claude/skills/implement-issue/scripts/validate.sh --full   # mirror CI: lint + full pnpm test + Cloudflare build
 ```
 
-Or manually:
+Or manually (lean gate):
 
 ```bash
-pnpm lint && pnpm build && pnpm test
+pnpm lint
+pnpm test:unit
+pnpm exec vitest run tests/int/<file>.int.spec.ts --config ./vitest.config.mts   # targeted to your change
 ```
 
-If anything fails:
+CI (`.github/workflows/ci.yml`) runs the full `pnpm test` suite + the Cloudflare build on the PR — that is the gate. Use `--full` locally only to reproduce a red CI check.
+
+If anything fails (locally or in CI):
 
 - Fix the failure
 - Commit the fix as a separate commit
 - Re-run validation
-- Do NOT proceed to PR creation while red
+- Do NOT mark the PR ready while CI is red
 
 ### 9. Push the branch
 
@@ -172,10 +177,10 @@ Output the PR URL to the user. Note any unchecked acceptance criteria the user s
 - **Never** skip hooks (`--no-verify`)
 - **Never** auto-run `pnpm db:migrations:create` — ask the user
 - **Never** commit secrets / `.env` / credentials
-- **Never** mark a PR ready while tests fail
+- **Never** mark a PR ready while CI is red
 - **Always** create commits incrementally; never one monolithic commit at the end
 - **Always** use `--body-file` for PR creation (preserves markdown)
-- **Always** verify tests pass before opening the PR
+- **Always** run the lean local gate before opening the PR; CI runs the full suite + Cloudflare build
 
 ## Edge cases
 

--- a/.claude/skills/implement-issue/scripts/validate.sh
+++ b/.claude/skills/implement-issue/scripts/validate.sh
@@ -1,20 +1,30 @@
 #!/bin/bash
 #
 # Validate that the current branch is ready to open a PR.
-# Runs lint, build, and tests SEQUENTIALLY (never in parallel — see
-# .claude/rules/testing-reqs.md).
 #
-# Usage: .claude/skills/implement-issue/scripts/validate.sh [--quick]
-#   --quick  Skip build (lint + test only)
+# Default (lean local gate): lint + the fast unit suite. Run the targeted
+# integration spec(s) for what you changed separately, e.g.
+#   pnpm exec vitest run tests/int/<file>.int.spec.ts --config ./vitest.config.mts
+# CI (.github/workflows/ci.yml) runs the full suite + Cloudflare build on the PR.
+#
+# --full: reproduce the CI checks locally (full `pnpm test` + the Cloudflare
+# build). Use to debug a red CI run. Runs SEQUENTIALLY (never in parallel —
+# see .claude/rules/testing-reqs.md).
+#
+# Usage:
+#   .claude/skills/implement-issue/scripts/validate.sh           # lean: lint + test:unit
+#   .claude/skills/implement-issue/scripts/validate.sh --full    # lint + full test + Cloudflare build
 
 set -u
 
 PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}"
-QUICK="${1:-}"
+MODE="${1:-}"
 
 cd "$PROJECT_DIR" || exit 1
 
-echo "=== 1/3: Lint ==="
+START_TIME=$(date +%s)
+
+echo "=== Lint ==="
 if ! pnpm lint; then
   echo
   echo "❌ Lint failed. Fix lint errors before continuing."
@@ -23,24 +33,47 @@ fi
 echo "✓ Lint passed"
 echo
 
-if [[ "$QUICK" != "--quick" ]]; then
-  echo "=== 2/3: Build ==="
-  if ! pnpm build; then
+if [[ "$MODE" == "--full" ]]; then
+  echo "=== Full test suite (CI parity) ==="
+  if ! pnpm test; then
     echo
-    echo "❌ Build failed. Fix build errors before continuing."
+    echo "❌ Tests failed. Fix failing tests before opening the PR."
     exit 1
   fi
-  echo "✓ Build passed"
+  echo "✓ Tests passed"
+  echo
+
+  echo "=== Cloudflare build (CI parity) ==="
+  if ! NODE_OPTIONS="--no-deprecation --max-old-space-size=8000" CLOUDFLARE_ENV= pnpm exec wrangler types; then
+    echo
+    echo "❌ wrangler types failed."
+    exit 1
+  fi
+  if ! NODE_OPTIONS="--no-deprecation --max-old-space-size=8000" CLOUDFLARE_ENV= \
+    WRANGLER_BUILD_CONDITIONS="" WRANGLER_BUILD_PLATFORM="node" \
+    pnpm exec opennextjs-cloudflare build; then
+    echo
+    echo "❌ Cloudflare build failed."
+    exit 1
+  fi
+  echo "✓ Cloudflare build passed"
+  echo
+else
+  echo "=== Unit tests ==="
+  if ! pnpm test:unit; then
+    echo
+    echo "❌ Unit tests failed. Fix them before continuing."
+    exit 1
+  fi
+  echo "✓ Unit tests passed"
+  echo
+  echo "ℹ Lean gate only. Run the targeted integration spec(s) for what you changed:"
+  echo "    pnpm exec vitest run tests/int/<file>.int.spec.ts --config ./vitest.config.mts"
+  echo "  CI runs the full suite + Cloudflare build on the PR. Use --full to mirror CI locally."
   echo
 fi
 
-echo "=== 3/3: Tests ==="
-if ! pnpm test; then
-  echo
-  echo "❌ Tests failed. Fix failing tests before opening the PR."
-  exit 1
-fi
-echo "✓ Tests passed"
-echo
+END_TIME=$(date +%s)
+ELAPSED=$((END_TIME - START_TIME))
 
-echo "=== ✓ All checks passed — branch is PR-ready ==="
+echo "=== ✓ Checks passed — ${ELAPSED}s ==="

--- a/.claude/skills/pr-prep/SKILL.md
+++ b/.claude/skills/pr-prep/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pr-prep
-description: Pre-PR validation — runs lint, build, and the test suite sequentially. Use before opening or marking a PR ready for review. Encapsulates the project's PR completion requirements.
+description: Pre-PR validation — runs the lean local gate (lint + unit suite) by default, with --full to reproduce the CI checks (full test suite + Cloudflare build) locally. Use before opening or marking a PR ready for review.
 allowed-tools: Bash, Read, Grep
 ---
 
@@ -8,23 +8,28 @@ allowed-tools: Bash, Read, Grep
 
 Validates that the current branch is PR-ready. Replaces the always-loaded `.claude/rules/pr-requirements.md` global rule with an explicit, on-demand skill.
 
+**The full test suite and the Cloudflare build run in CI on every PR** (`.github/workflows/ci.yml`). This skill's default is the **lean local gate**; CI owns the slower, cross-cutting checks.
+
 ## Quick start
 
 ```bash
-.claude/skills/pr-prep/check.sh
+.claude/skills/pr-prep/check.sh          # lean gate: lint + pnpm test:unit
+.claude/skills/pr-prep/check.sh --full   # reproduce CI locally: lint + full pnpm test + Cloudflare build
 ```
 
-Runs `pnpm lint && pnpm build && pnpm test` sequentially (per `.claude/rules/testing-reqs.md` — never in parallel).
+Sequential by design (per `.claude/rules/testing-reqs.md` — never run test/build commands in parallel).
 
-## Required checks before opening a PR
+## What to run before opening a PR
+
+**Locally (lean gate):**
 
 1. **Lint passes**: `pnpm lint` — 0 errors
-2. **Build succeeds**: `pnpm build`
-3. **Full test suite passes**: `pnpm test`
-   - 0 failures
-   - No skipped tests — fix them or remove with justification
-   - Fix pre-existing failures from `main` as part of the PR (see below)
+2. **Unit suite passes**: `pnpm test:unit`
+3. **Targeted integration spec(s)** for the area you changed:
+   `pnpm exec vitest run tests/int/<file>.int.spec.ts --config ./vitest.config.mts`
 4. **Types check** (if type changes): `pnpm tsc --noEmit`
+
+**In CI (automatic on the PR):** the full `pnpm test` suite and the Cloudflare build (`opennextjs-cloudflare build`). Don't block locally on these — run `check.sh --full` only to debug a red CI run. Pre-existing failures on `main` still get fixed in your PR (see below).
 
 ## Handling pre-existing test failures on `main`
 
@@ -51,15 +56,14 @@ Swaps just the single test file to its `main` version, re-runs it, then restores
 
 ## PR description format
 
-Include a Test Results section:
+Include a Test Results section. CI (`Lint & Test` + `Cloudflare Build` checks on the PR) is the source of truth for the full suite and build; summarize local + CI status:
 
 ```markdown
 ## Test Results
 
-- Integration tests: X passed
-- E2E tests: Y passed
-- Build: ✓ Success
 - Lint: ✓ No errors
+- Unit + targeted integration (local): ✓ passed
+- Full suite + Cloudflare build: ✓ via CI (see PR checks)
 ```
 
 ## Documentation sync for architectural / API PRs
@@ -79,5 +83,5 @@ If your PR changes architecture or APIs:
 
 ## When NOT to use this skill
 
-- During a focused implementation session — run `pnpm lint` / `pnpm test:int` directly for tighter feedback loops
+- During a focused implementation session — run `pnpm lint` / `pnpm test:unit` / a targeted `pnpm exec vitest run <file> --config ./vitest.config.mts` directly for tighter feedback loops
 - Use this skill specifically before opening / marking-ready a PR

--- a/.claude/skills/pr-prep/check.sh
+++ b/.claude/skills/pr-prep/check.sh
@@ -1,50 +1,78 @@
 #!/bin/bash
 #
-# Run pre-PR validation: lint → build → test (sequential).
+# Pre-PR validation.
+#
+# Default (lean local gate): lint + the fast unit suite. Run the targeted
+# integration spec(s) for what you changed separately, e.g.
+#   pnpm exec vitest run tests/int/<file>.int.spec.ts --config ./vitest.config.mts
+# CI (.github/workflows/ci.yml) runs the full suite + Cloudflare build on the PR.
+#
+# --full: reproduce the CI checks locally (full `pnpm test` + the Cloudflare
+# build). Use this to debug a red CI run. See .claude/rules/testing-reqs.md.
 #
 # Usage:
-#   .claude/skills/pr-prep/check.sh            # Full validation
-#   .claude/skills/pr-prep/check.sh --quick    # Lint + test only (skip build)
+#   .claude/skills/pr-prep/check.sh            # lean: lint + test:unit
+#   .claude/skills/pr-prep/check.sh --full     # lint + full test + Cloudflare build (mirrors CI)
 
 set -u
 
 PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}"
-QUICK="${1:-}"
+MODE="${1:-}"
 
 cd "$PROJECT_DIR" || exit 1
 
 START_TIME=$(date +%s)
 
-echo "=== 1/3: Lint ==="
+echo "=== Lint ==="
 if ! pnpm lint; then
   echo
-  echo "❌ Lint failed."
+  echo "❌ Lint failed. Fix lint errors before continuing."
   exit 1
 fi
 echo "✓ Lint passed"
 echo
 
-if [[ "$QUICK" != "--quick" ]]; then
-  echo "=== 2/3: Build ==="
-  if ! pnpm build; then
+if [[ "$MODE" == "--full" ]]; then
+  echo "=== Full test suite (CI parity) ==="
+  if ! pnpm test; then
     echo
-    echo "❌ Build failed."
+    echo "❌ Tests failed. Fix failing tests before opening the PR."
     exit 1
   fi
-  echo "✓ Build passed"
+  echo "✓ Tests passed"
   echo
-fi
 
-echo "=== 3/3: Tests ==="
-if ! pnpm test; then
+  echo "=== Cloudflare build (CI parity) ==="
+  if ! NODE_OPTIONS="--no-deprecation --max-old-space-size=8000" CLOUDFLARE_ENV= pnpm exec wrangler types; then
+    echo
+    echo "❌ wrangler types failed."
+    exit 1
+  fi
+  if ! NODE_OPTIONS="--no-deprecation --max-old-space-size=8000" CLOUDFLARE_ENV= \
+    WRANGLER_BUILD_CONDITIONS="" WRANGLER_BUILD_PLATFORM="node" \
+    pnpm exec opennextjs-cloudflare build; then
+    echo
+    echo "❌ Cloudflare build failed."
+    exit 1
+  fi
+  echo "✓ Cloudflare build passed"
   echo
-  echo "❌ Tests failed."
-  exit 1
+else
+  echo "=== Unit tests ==="
+  if ! pnpm test:unit; then
+    echo
+    echo "❌ Unit tests failed. Fix them before continuing."
+    exit 1
+  fi
+  echo "✓ Unit tests passed"
+  echo
+  echo "ℹ Lean gate only. Run the targeted integration spec(s) for what you changed:"
+  echo "    pnpm exec vitest run tests/int/<file>.int.spec.ts --config ./vitest.config.mts"
+  echo "  CI runs the full suite + Cloudflare build on the PR. Use --full to mirror CI locally."
+  echo
 fi
-echo "✓ Tests passed"
-echo
 
 END_TIME=$(date +%s)
 ELAPSED=$((END_TIME - START_TIME))
 
-echo "=== ✓ Branch is PR-ready — ${ELAPSED}s ==="
+echo "=== ✓ Checks passed — ${ELAPSED}s ==="

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,7 @@ name: CI
 
 on:
   pull_request:
+  workflow_dispatch:
 
 concurrency:
   group: ci-${{ github.head_ref || github.ref }}
@@ -14,6 +15,7 @@ jobs:
   test:
     name: Lint & Test
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
@@ -32,6 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       NODE_OPTIONS: "--no-deprecation --max-old-space-size=8000"
+      CLOUDFLARE_ENV: ""
       # Non-sensitive DUMMY values — only present so serverEnv (zod) validates at build/import time.
       PAYLOAD_SECRET: ci-build-dummy-secret-with-32plus-characters
       SAHAJCLOUD_PREVIEW_SECRET: ci-build-preview-secret-16plus

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,59 @@
+name: CI
+
+on:
+  pull_request:
+
+concurrency:
+  group: ci-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: Lint & Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm lint
+      - run: pnpm test # test:unit && test:int — vitest injects its own env
+
+  build:
+    name: Cloudflare Build
+    runs-on: ubuntu-latest
+    env:
+      NODE_OPTIONS: "--no-deprecation --max-old-space-size=8000"
+      # Non-sensitive DUMMY values — only present so serverEnv (zod) validates at build/import time.
+      PAYLOAD_SECRET: ci-build-dummy-secret-with-32plus-characters
+      SAHAJCLOUD_PREVIEW_SECRET: ci-build-preview-secret-16plus
+      WEMEDITATE_WEB_URL: http://localhost:5173
+      SAHAJATLAS_URL: http://localhost:5174
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - name: Cache Next.js build
+        uses: actions/cache@v4
+        with:
+          path: .next/cache
+          key: nextjs-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}-${{ hashFiles('src/**') }}
+          restore-keys: nextjs-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}-
+      - name: Generate Cloudflare worker types
+        run: pnpm exec wrangler types # worker-configuration.d.ts is gitignored; next build typechecks against it
+      - name: Build (OpenNext → Cloudflare)
+        run: WRANGLER_BUILD_CONDITIONS="" WRANGLER_BUILD_PLATFORM="node" pnpm exec opennextjs-cloudflare build

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,7 +51,10 @@ Manual fallback: `pnpm dev` (start), `pnpm devsafe` (clean dev — removes `.nex
 - `pnpm lint` — ESLint
 - `pnpm generate:types` — TypeScript types from Payload schema (after schema changes)
 - `pnpm generate:importmap` — admin-panel import map
+- `pnpm test:unit` — fast unit lane (~1–2 s, no Payload bootstrap)
 - `pnpm test` / `pnpm test:int` / `pnpm test:e2e` — full / integration / E2E
+
+**Local vs CI**: GitHub Actions runs the **full test suite + the Cloudflare build** on every PR (see [Continuous Integration](#continuous-integration)). Locally, default to **targeted** validation — lint, `pnpm test:unit`, and the specific integration spec(s) for the area you touched: `pnpm exec vitest run tests/int/<file>.int.spec.ts --config ./vitest.config.mts`. Don't routinely run the full `pnpm test:int` locally or `check.sh --full` / `validate.sh --full` — let CI catch the less-common, cross-cutting failures. Run them only to reproduce a red CI check or when explicitly asked.
 
 If wrapping any of these in `timeout` (only when actually needed — most one-shot runs don't need it), use these canonical values; other values will trigger a permission prompt:
 
@@ -118,7 +121,16 @@ Schema migrations live in `src/migrations/` — see `.claude/rules/migrations.md
 
 ## PR Requirements
 
-Before creating or marking a PR ready for review: full test suite passes, build succeeds, lint passes. Use the `/pr-prep` skill (`.claude/skills/pr-prep/`) for the full pre-PR validation workflow including handling pre-existing failures.
+Every PR is gated by CI (see [Continuous Integration](#continuous-integration)): it runs lint, the full `pnpm test` suite, and the Cloudflare build. Before marking a PR ready, validate **locally** with the lean gate — lint + `pnpm test:unit` + the targeted integration spec(s) for what you changed. Use the `/pr-prep` skill (`.claude/skills/pr-prep/`) for that workflow (its `--full` flag reproduces the CI checks locally when you need to debug a red run, and it documents handling pre-existing failures). Don't block on a local full-suite/build run — that's CI's job.
+
+## Continuous Integration
+
+GitHub Actions runs on every pull request (`.github/workflows/ci.yml`), in two parallel jobs:
+
+- **Lint & Test** — `pnpm lint`, then `pnpm test` (unit + integration). Vitest injects its own env, so no secrets are needed.
+- **Cloudflare Build** — `wrangler types`, then `opennextjs-cloudflare build` (the real deploy artifact; the `next build` inside it also type-checks and lints). Uses non-sensitive dummy env values — no GitHub Secrets.
+
+PR-only triggers; `concurrency: cancel-in-progress` cancels superseded runs on the same branch. CI **reports** status but does not block merges unless a branch-protection rule on `main` requires the `Lint & Test` and `Cloudflare Build` checks to pass.
 
 ## Deployment
 


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/ci.yml` — the project's first CI. Runs on **pull requests only**, in two parallel jobs:
  - **Lint & Test** — `pnpm lint` then `pnpm test` (unit + integration). No secrets needed (vitest injects its own env).
  - **Cloudflare Build** — `wrangler types` then `opennextjs-cloudflare build` (the real deploy artifact; the `next build` inside it also type-checks and lints). Uses non-sensitive dummy env values — **no GitHub Secrets**.
- Shifts Claude's local validation to **targeted** runs (lint + unit + the integration spec(s) for the touched area), delegating the full suite + Cloudflare build to CI. Updates `AGENTS.md`, the testing rules, and the `pr-prep` / `implement-issue` skills.
- Both `check.sh` and `validate.sh` gain a `--full` flag to reproduce the CI checks locally when debugging a red run.

## Why

The full integration suite (~5 min) and the Cloudflare build are slow to run on every change locally. Moving them to CI lets local loops stay fast (targeted tests) while CI catches the less-common, cross-cutting failures on every PR.

## Notes

- `concurrency: cancel-in-progress` cancels superseded runs on the same branch.
- Cost (private repo): ~14–16 billable Linux minutes per PR push; well within free allotments.
- **Verified locally**: the Cloudflare build completes clean in a fresh env with only the dummy vars (exit 0, worker emitted); the lean gate (`check.sh`) passes in ~7s (311 unit tests).

## Follow-up (not in this PR)

CI **reports** status but doesn't **block** merges until a branch-protection rule on `main` requires the `Lint & Test` and `Cloudflare Build` checks. Enable that in Settings → Branches once this lands and the checks have run once.

## Test plan

- [ ] Both CI jobs run and pass on this PR
- [ ] Push a commit that breaks a test → `Lint & Test` goes red; revert → green
- [ ] `.claude/skills/pr-prep/check.sh` (lean) passes; `--full` reproduces the CI checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)