### PR TITLE
feat(lessons): expand unit options from 4 to 7

### DIFF
--- a/src/collections/content/Lessons.ts
+++ b/src/collections/content/Lessons.ts
@@ -149,7 +149,7 @@ export const Lessons: CollectionConfig = {
               name: 'unit',
               type: 'select',
               required: true,
-              options: Array.from({ length: 4 }, (_, i) => `Unit ${i + 1}`),
+              options: Array.from({ length: 7 }, (_, i) => `Unit ${i + 1}`),
             },
             {
               name: 'step',

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -753,7 +753,7 @@ export interface Lesson {
     };
     [k: string]: unknown;
   } | null;
-  unit: 'Unit 1' | 'Unit 2' | 'Unit 3' | 'Unit 4';
+  unit: 'Unit 1' | 'Unit 2' | 'Unit 3' | 'Unit 4' | 'Unit 5' | 'Unit 6' | 'Unit 7';
   /**
    * This will determine the order of the path steps
    */


### PR DESCRIPTION
## Summary

- Widen the Lessons (`Path Steps`) `unit` select from **Units 1–4** to **Units 1–7**, so later Path Steps that belong to Units 5–7 (steps 25–30) can be assigned their correct unit in the admin and via the API.
- Regenerate `payload-types.ts` for the expanded `unit` union (`'Unit 1' … 'Unit 7'`).

## Why

The Path content now spans 7 units, but the `unit` field only offered the first four. Production currently rejects Units 5–7, blocking upload of the later steps. This unblocks them.

## Scope / safety

- **One change only:** `Array.from({ length: 4 }, …)` → `length: 7` plus the regenerated type union. No other files touched.
- **No DB migration:** select options are validated in application code, not enforced as a D1 constraint — so existing rows and the schema are unaffected.

## Test plan

- [ ] CI: lint, build, integration + e2e suites pass
- [ ] Admin: the `unit` dropdown on a Path Step shows Unit 1 through Unit 7
- [ ] API: creating/updating a lesson with `unit: "Unit 5"` (and 6, 7) is accepted

🤖 Generated with [Claude Code](https://claude.com/claude-code)