### PR TITLE
fix(api): exempt live-preview reads from select/populate gate

### DIFF
--- a/.claude/rules/api-clients.md
+++ b/.claude/rules/api-clients.md
@@ -135,6 +135,19 @@ response and should not require every endpoint caller to enumerate internal
 fields with `select`, while rate limiting and usage tracking still see the
 authenticated client.
 
+### Live preview bypass
+
+Admin live preview loads the external We Meditate Web frontend, which fetches
+draft content back from this CMS as a client and forwards the
+`SAHAJCLOUD_PREVIEW_SECRET` in the `x-sahajcloud-preview-secret` header. A
+request carrying the valid secret renders the **whole** document, so requiring
+it to enumerate `select`/`populate` is meaningless — and forcing it 400s the
+preview. `validateClientQueryParamsHook` skips validation for such requests via
+`hasValidPreviewSecret(req)` from `src/lib/previewSecret.ts` (the same helper
+the access layer uses to unlock drafts in `createAccessConfig`). Rate limiting
+and usage tracking still apply. Without this, PR #294's gate breaks the
+meditations, pages, and wemeditate-web live previews.
+
 ## Usage monitoring
 
 - **Async tracking** via job queue (no in-request DB write).

--- a/src/lib/access/accessConfigs.ts
+++ b/src/lib/access/accessConfigs.ts
@@ -12,9 +12,9 @@
 import type { BypassPermissionFunction, ContentSlug, FieldAccessConfig } from './types'
 import type { AccessArgs, CollectionConfig, CollectionSlug, PayloadRequest } from 'payload'
 
-import { hasPermission } from './permissions'
+import { hasValidPreviewSecret } from '@/lib/previewSecret'
 
-const PREVIEW_SECRET_HEADER = 'x-sahajcloud-preview-secret'
+import { hasPermission } from './permissions'
 
 /**
  * Check if a collection has drafts enabled
@@ -61,7 +61,7 @@ export function createAccessConfig(
         operation === 'read' &&
         req.user?.collection === 'clients' &&
         collectionHasDrafts(req, collection) &&
-        req.headers?.get?.(PREVIEW_SECRET_HEADER) !== process.env.SAHAJCLOUD_PREVIEW_SECRET // External connections must use preview secret
+        !hasValidPreviewSecret(req) // External connections must use preview secret
       ) {
         // Restrict to published only unless all requirements are met.
         return { _status: { equals: 'published' } }

--- a/src/lib/previewSecret.ts
+++ b/src/lib/previewSecret.ts
@@ -1,0 +1,22 @@
+/**
+ * Live-preview secret check.
+ *
+ * The admin live-preview iframe loads the external We Meditate Web frontend
+ * with the shared `SAHAJCLOUD_PREVIEW_SECRET`. That frontend fetches draft
+ * content back from this CMS as an API client, forwarding the secret in the
+ * `x-sahajcloud-preview-secret` header. A request carrying the valid secret is
+ * a trusted preview request: it unlocks drafts (see `createAccessConfig`) and
+ * is exempt from the client `select`/`populate` gate (see
+ * `validateClientQueryParamsHook`).
+ */
+import type { PayloadRequest } from 'payload'
+
+import { serverEnv } from '@/lib/env'
+
+export const PREVIEW_SECRET_HEADER = 'x-sahajcloud-preview-secret'
+
+/** True when the request carries the valid live-preview secret header. */
+export function hasValidPreviewSecret(req: PayloadRequest): boolean {
+  const secret = req.headers?.get?.(PREVIEW_SECRET_HEADER)
+  return !!secret && secret === serverEnv.SAHAJCLOUD_PREVIEW_SECRET
+}

--- a/src/lib/usage/hooks.ts
+++ b/src/lib/usage/hooks.ts
@@ -16,6 +16,7 @@ import { APIError } from 'payload'
 import { z } from 'zod'
 
 import { serverEnv } from '@/lib/env'
+import { hasValidPreviewSecret } from '@/lib/previewSecret'
 
 import { RATE_LIMIT_MAX_REQUESTS, RATE_LIMIT_PERIOD_SECONDS } from './constants'
 
@@ -144,6 +145,11 @@ async function checkRateLimit(req: PayloadRequest): Promise<void> {
  * relationship/upload fields. Those reads carry a numeric `currentDepth`; they
  * are implementation details of the already-validated top-level request and
  * must not be rejected for lacking their own REST `select` parameter.
+ *
+ * Live-preview reads are also exempt: a request carrying the valid
+ * `SAHAJCLOUD_PREVIEW_SECRET` header (see `hasValidPreviewSecret`) renders the
+ * whole document, so forcing it to enumerate `select`/`populate` is meaningless
+ * and breaks the admin live preview.
  */
 export const validateClientQueryParamsHook: CollectionBeforeOperationHook = ({
   args,
@@ -158,6 +164,13 @@ export const validateClientQueryParamsHook: CollectionBeforeOperationHook = ({
   // opt out by setting this context flag — they shape their own response and
   // shouldn't have to enumerate every field via `select` on every internal call.
   if (req.context?.[SKIP_VALIDATION] === true) {
+    return
+  }
+
+  // Trusted live-preview reads (valid preview secret) render the whole document
+  // and must not be forced to enumerate select/populate. Same trust signal that
+  // already unlocks drafts in createAccessConfig.
+  if (hasValidPreviewSecret(req)) {
     return
   }
 

--- a/tests/int/client-query-validation.int.spec.ts
+++ b/tests/int/client-query-validation.int.spec.ts
@@ -235,6 +235,51 @@ describe('Client query parameter validation', () => {
     })
   })
 
+  // Live-preview reads carry the SAHAJCLOUD_PREVIEW_SECRET header. They render
+  // the whole document, so the select/populate gate is skipped (see
+  // hasValidPreviewSecret in src/lib/previewSecret.ts). Without this bypass the
+  // admin live preview 400s because it does not enumerate select — the breakage
+  // introduced by #294.
+  describe('live preview bypass', () => {
+    const previewClientReq = (): PayloadRequest => {
+      const req = clientReq()
+      req.headers.set('x-sahajcloud-preview-secret', process.env.SAHAJCLOUD_PREVIEW_SECRET || '')
+      return req
+    }
+
+    it('allows client find without select when the preview secret is present', async () => {
+      const result = await payload.find({
+        collection: 'narrators',
+        req: previewClientReq(),
+        overrideAccess: true,
+      })
+      expect(result.docs.length).toBeGreaterThan(0)
+    })
+
+    it('allows client findByID at depth > 1 without select or populate when the preview secret is present', async () => {
+      const result = await payload.findByID({
+        collection: 'narrators',
+        id: narrator.id,
+        depth: 2,
+        req: previewClientReq(),
+        overrideAccess: true,
+      })
+      expect(result.id).toBe(narrator.id)
+    })
+
+    it('still rejects when the preview secret is wrong', async () => {
+      const req = clientReq()
+      req.headers.set('x-sahajcloud-preview-secret', 'not-the-real-secret')
+      await expect(
+        payload.find({
+          collection: 'narrators',
+          req,
+          overrideAccess: true,
+        }),
+      ).rejects.toThrow(/select/)
+    })
+  })
+
   // These cases exercise the wire format (URL → qs.parse → sanitize → args) that
   // real REST clients hit, not just the SDK shape that the cases above exercise.
   // They guard against the regression in #199/#294 where the docs assumed


### PR DESCRIPTION
## Summary

The Meditations (and Pages / wemeditate-web) **live preview** broke with a 500 after #294 / #420 introduced the mandatory `select` + `populate` query-param gate for API client reads.

**Root cause:** The admin live-preview iframe loads the external We Meditate Web frontend with the shared `SAHAJCLOUD_PREVIEW_SECRET`. That frontend fetches the *draft* document back from this CMS as the `wemeditate-web` **client**, forwarding the secret in the `x-sahajcloud-preview-secret` header to unlock drafts. PR #294's `validateClientQueryParamsHook` (`beforeOperation` on every non-system collection) now **rejects that read with 400** because a preview fetch wants the whole document and doesn't enumerate `select`/`populate`. The frontend then surfaces a **500**. Payload's built-in preview machinery is fine — only the new gate is the problem.

**Fix:** Skip the `select`/`populate` validation when a request carries the valid preview secret — the same trust signal that already unlocks drafts in `createAccessConfig`. A full-document render can't meaningfully enumerate `select`, and the param requirement is a quota/perf guardrail, **not** a security boundary; preview traffic is low-volume.

- New `src/lib/previewSecret.ts` — `hasValidPreviewSecret(req)` + `PREVIEW_SECRET_HEADER`, a single source of truth for the secret check.
- `validateClientQueryParamsHook` early-returns for valid-preview-secret reads (rate limiting + usage tracking untouched).
- `accessConfigs.ts` de-duped to use the shared helper (was an inline header compare).
- Docs: hook JSDoc + `.claude/rules/api-clients.md`.

Fixes meditations, pages, and the wemeditate-web global preview in one place — no external-frontend change required.

## Test plan

- [x] `pnpm lint` — 0 errors
- [x] `pnpm exec vitest run tests/int/client-query-validation.int.spec.ts --config ./vitest.config.mts` — 27 passed (3 new: preview-secret bypasses the gate on `find`/`findByID`@depth=2; a wrong secret is still rejected)
- [ ] Manual: with the live preview pointed at a CMS carrying this change, confirm the meditation preview renders instead of 500ing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)