### PR TITLE
fix(deploy): disable Wrangler OpenNext autoconfig

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
           version: 10
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - name: Cache Next.js build
@@ -59,4 +59,4 @@ jobs:
       - name: Generate Cloudflare worker types
         run: pnpm exec wrangler types # worker-configuration.d.ts is gitignored; next build typechecks against it
       - name: Package Worker (dry run)
-        run: WRANGLER_BUILD_CONDITIONS="" WRANGLER_BUILD_PLATFORM="node" pnpm exec wrangler deploy --dry-run --env="" --outdir /tmp/sahajcloud-worker-dry-run
+        run: WRANGLER_BUILD_CONDITIONS="" WRANGLER_BUILD_PLATFORM="node" pnpm exec wrangler deploy --experimental-autoconfig=false --dry-run --env="" --outdir /tmp/sahajcloud-worker-dry-run

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -117,10 +117,12 @@ This runs two commands in order:
 
 2. **deploy:app** - Deploys the Worker application:
    ```bash
-   pnpm exec wrangler deploy --env=""
+   pnpm exec wrangler deploy --experimental-autoconfig=false --env=""
    ```
 
    The explicit `--env=""` targets Wrangler's top-level production configuration.
+   `--experimental-autoconfig=false` keeps Wrangler on the configured Worker path so the
+   `[build]` command in `wrangler.toml` runs `opennextjs-cloudflare build` before upload.
 
 ### How Migrations Work
 

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "payload": "cross-env NODE_OPTIONS=--no-deprecation payload",
     "deploy:prod": "pnpm run deploy:database && pnpm run deploy:app",
     "deploy:database": "cross-env NODE_ENV=production CLOUDFLARE_ENV= PAYLOAD_SECRET=migration-only-dummy-secret-32chars payload migrate && wrangler d1 execute sahajcloud --command 'PRAGMA optimize' --remote",
-    "deploy:app": "wrangler deploy --env=\"\"",
+    "deploy:app": "wrangler deploy --experimental-autoconfig=false --env=\"\"",
     "db:create": "wrangler d1 create",
     "db:migrations:create": "cross-env NODE_OPTIONS=--no-deprecation payload migrate:create",
     "db:schema": "wrangler d1 execute sahajcloud --command '.schema' --remote"


### PR DESCRIPTION
## Summary
- disable Wrangler experimental autoconfig for production deploy/dry-run
- keep Wrangler on the configured Worker path so `[build]` runs `opennextjs-cloudflare build` before upload
- document the behavior and align the CI Cloudflare build job with Node 22

## Testing
- `git diff --check`
- parsed `package.json` with Node
- Cloudflare dry-run confirmed Wrangler ran `[custom build] ... opennextjs-cloudflare build`; local Next/Turbopack build was stopped after more than 10 minutes without additional output