### PR TITLE
fix(endpoints): require active client auth on audience endpoints

### DIFF
--- a/src/endpoints/appCardsForAudience.ts
+++ b/src/endpoints/appCardsForAudience.ts
@@ -35,6 +35,13 @@ export const appCardsForAudience: Endpoint = {
   path: '/for-audience',
   method: 'get',
   handler: async (req) => {
+    if (req.user?.collection !== 'clients' || !req.user.active) {
+      return Response.json(
+        { errors: [{ message: 'You are not allowed to perform this action.' }] },
+        { status: 403 },
+      )
+    }
+
     const parsed = querySchema.safeParse(req.query)
 
     if (!parsed.success) {

--- a/src/endpoints/audiencesForUser.ts
+++ b/src/endpoints/audiencesForUser.ts
@@ -32,6 +32,13 @@ export const audiencesForUser: Endpoint = {
   path: '/for-user',
   method: 'get',
   handler: async (req) => {
+    if (req.user?.collection !== 'clients' || !req.user.active) {
+      return Response.json(
+        { errors: [{ message: 'You are not allowed to perform this action.' }] },
+        { status: 403 },
+      )
+    }
+
     const parsed = querySchema.safeParse(req.query)
 
     if (!parsed.success) {

--- a/src/endpoints/lecturesForAudience.ts
+++ b/src/endpoints/lecturesForAudience.ts
@@ -37,6 +37,13 @@ export const lecturesForAudience: Endpoint = {
   path: '/for-audience',
   method: 'get',
   handler: async (req) => {
+    if (req.user?.collection !== 'clients' || !req.user.active) {
+      return Response.json(
+        { errors: [{ message: 'You are not allowed to perform this action.' }] },
+        { status: 403 },
+      )
+    }
+
     const parsed = querySchema.safeParse(req.query)
 
     if (!parsed.success) {

--- a/src/endpoints/meditationLectures.ts
+++ b/src/endpoints/meditationLectures.ts
@@ -73,6 +73,13 @@ export const meditationLectures: Endpoint = {
   path: '/:id/related-lectures',
   method: 'get',
   handler: async (req) => {
+    if (req.user?.collection !== 'clients' || !req.user.active) {
+      return Response.json(
+        { errors: [{ message: 'You are not allowed to perform this action.' }] },
+        { status: 403 },
+      )
+    }
+
     const idParam = req.routeParams?.id as string | number | undefined
     if (idParam === undefined || idParam === null || idParam === '') {
       return Response.json({ errors: [{ message: 'Meditation ID required' }] }, { status: 400 })
@@ -112,7 +119,8 @@ export const meditationLectures: Endpoint = {
       | null
       | undefined
     const weights =
-      cachedWeights ?? (await recomputeWeightsForMeditation(req.payload, meditation, asTrustedReq(req)))
+      cachedWeights ??
+      (await recomputeWeightsForMeditation(req.payload, meditation, asTrustedReq(req)))
 
     const lectureWhere: Where = {
       audiences: { in: audienceIds },

--- a/tests/int/app-cards-for-audience.int.spec.ts
+++ b/tests/int/app-cards-for-audience.int.spec.ts
@@ -5,9 +5,10 @@ import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest'
 import { appCardsForAudience } from '@/endpoints'
 import type { AppCard, Audience, Client, Image } from '@/payload-types'
 
-
 import { testData } from '../utils/testData'
 import { createTestEnvironment } from '../utils/testHelpers'
+
+const DEFAULT_CLIENT_USER = { id: 0, collection: 'clients', active: true }
 
 // `audiences` is a required, non-empty comma-separated list of IDs.
 // Tests that don't exercise a specific eligibility scenario still need to
@@ -16,7 +17,7 @@ import { createTestEnvironment } from '../utils/testHelpers'
 async function callEndpoint(
   payload: Payload,
   query: Record<string, string | number | boolean>,
-  user?: { id: number | string; collection: string },
+  user?: { id: number | string; collection: string; active?: boolean } | null,
   options: { skipDefaultAudiences?: boolean; defaultAudiences?: string } = {},
 ): Promise<{ status: number; headers: Headers; body: unknown }> {
   const finalQuery = options.skipDefaultAudiences
@@ -27,7 +28,7 @@ async function callEndpoint(
     query: finalQuery,
     headers: new Headers(),
     routeParams: {},
-    user,
+    user: user === undefined ? DEFAULT_CLIENT_USER : user,
   } as unknown as PayloadRequest
 
   const response = (await appCardsForAudience.handler(req)) as Response
@@ -223,8 +224,9 @@ describe('appCardsForAudience endpoint', () => {
       _status: 'published',
     })
     // Store conditionAudienceB id on the card for assertions below
-    ;(cardWithMultipleConditions as AppCard & { _conditionAudienceBId: number })._conditionAudienceBId =
-      conditionAudienceB.id
+    ;(
+      cardWithMultipleConditions as AppCard & { _conditionAudienceBId: number }
+    )._conditionAudienceBId = conditionAudienceB.id
   })
 
   afterAll(async () => {
@@ -250,12 +252,9 @@ describe('appCardsForAudience endpoint', () => {
     })
 
     it('returns 400 when limit is missing', async () => {
-      const { status } = await callEndpoint(
-        payload,
-        { targetSection: 'hero' },
-        undefined,
-        { defaultAudiences: allEligible },
-      )
+      const { status } = await callEndpoint(payload, { targetSection: 'hero' }, undefined, {
+        defaultAudiences: allEligible,
+      })
       expect(status).toBe(400)
     })
 
@@ -296,6 +295,41 @@ describe('appCardsForAudience endpoint', () => {
         limit: 5,
       })
       expect(status).toBe(400)
+    })
+  })
+
+  describe('auth gate', () => {
+    it('rejects unauthenticated callers with 403', async () => {
+      const { status, body } = await callEndpoint(
+        payload,
+        { targetSection: 'hero', limit: 5 },
+        null,
+        { defaultAudiences: allEligible },
+      )
+      expect(status).toBe(403)
+      expect(body).toEqual({
+        errors: [{ message: 'You are not allowed to perform this action.' }],
+      })
+    })
+
+    it('rejects non-client users (managers) with 403', async () => {
+      const { status } = await callEndpoint(
+        payload,
+        { targetSection: 'hero', limit: 5 },
+        { id: adminUserId, collection: 'managers', active: true },
+        { defaultAudiences: allEligible },
+      )
+      expect(status).toBe(403)
+    })
+
+    it('rejects inactive clients with 403', async () => {
+      const { status } = await callEndpoint(
+        payload,
+        { targetSection: 'hero', limit: 5 },
+        { id: 999, collection: 'clients', active: false },
+        { defaultAudiences: allEligible },
+      )
+      expect(status).toBe(403)
     })
   })
 
@@ -380,46 +414,34 @@ describe('appCardsForAudience endpoint', () => {
   })
 
   it('excludes cards with empty audiences', async () => {
-    const { body } = await callEndpoint(
-      payload,
-      { targetSection: 'hero', limit: 20 },
-      undefined,
-      { defaultAudiences: allEligible },
-    )
+    const { body } = await callEndpoint(payload, { targetSection: 'hero', limit: 20 }, undefined, {
+      defaultAudiences: allEligible,
+    })
     const ids = (body as { docs: AppCard[] }).docs.map((c) => c.id)
     expect(ids).not.toContain(emptyAudiencesCard.id)
   })
 
   it('excludes cards whose audiences are not in the requested list', async () => {
     // Caller's resolved audiences don't include pathStartedAudience.
-    const { body } = await callEndpoint(
-      payload,
-      { targetSection: 'hero', limit: 20 },
-      undefined,
-      { defaultAudiences: openOnly },
-    )
+    const { body } = await callEndpoint(payload, { targetSection: 'hero', limit: 20 }, undefined, {
+      defaultAudiences: openOnly,
+    })
     const ids = (body as { docs: AppCard[] }).docs.map((c) => c.id)
     expect(ids).not.toContain(heroCardPathStarted.id)
   })
 
   it('includes cards whose audiences are in the requested list', async () => {
-    const { body } = await callEndpoint(
-      payload,
-      { targetSection: 'hero', limit: 20 },
-      undefined,
-      { defaultAudiences: allEligible },
-    )
+    const { body } = await callEndpoint(payload, { targetSection: 'hero', limit: 20 }, undefined, {
+      defaultAudiences: allEligible,
+    })
     const ids = (body as { docs: AppCard[] }).docs.map((c) => c.id)
     expect(ids).toContain(heroCardPathStarted.id)
   })
 
   it('includes cards attached to a null-rules audience when that ID is in the request', async () => {
-    const { body } = await callEndpoint(
-      payload,
-      { targetSection: 'hero', limit: 20 },
-      undefined,
-      { defaultAudiences: openOnly },
-    )
+    const { body } = await callEndpoint(payload, { targetSection: 'hero', limit: 20 }, undefined, {
+      defaultAudiences: openOnly,
+    })
     const ids = (body as { docs: AppCard[] }).docs.map((c) => c.id)
     expect(ids).toContain(nullRulesAudienceCard.id)
   })
@@ -524,12 +546,9 @@ describe('appCardsForAudience endpoint', () => {
   })
 
   it('respects the limit parameter', async () => {
-    const { body } = await callEndpoint(
-      payload,
-      { targetSection: 'hero', limit: 1 },
-      undefined,
-      { defaultAudiences: allEligible },
-    )
+    const { body } = await callEndpoint(payload, { targetSection: 'hero', limit: 1 }, undefined, {
+      defaultAudiences: allEligible,
+    })
     const docs = (body as { docs: AppCard[] }).docs
     expect(docs).toHaveLength(1)
   })
@@ -547,7 +566,7 @@ describe('appCardsForAudience endpoint', () => {
       const { status } = await callEndpoint(
         payload,
         { targetSection: 'hero', limit: 5 },
-        { id: client.id, collection: 'clients' },
+        { id: client.id, collection: 'clients', active: true },
         { defaultAudiences: allEligible },
       )
       expect(status).toBe(200)
@@ -570,12 +589,9 @@ describe('appCardsForAudience endpoint', () => {
   })
 
   it('populates relationships at depth 1', async () => {
-    const { body } = await callEndpoint(
-      payload,
-      { targetSection: 'hero', limit: 20 },
-      undefined,
-      { defaultAudiences: allEligible },
-    )
+    const { body } = await callEndpoint(payload, { targetSection: 'hero', limit: 20 }, undefined, {
+      defaultAudiences: allEligible,
+    })
     const docs = (body as { docs: AppCard[] }).docs
     const card = docs.find((c) => c.id === contentCard.id)
     expect(card).toBeDefined()

--- a/tests/int/audiences-for-user.int.spec.ts
+++ b/tests/int/audiences-for-user.int.spec.ts
@@ -5,7 +5,6 @@ import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest'
 import { audiencesForUser } from '@/endpoints'
 import type { Audience, Client } from '@/payload-types'
 
-
 import { testData } from '../utils/testData'
 import { createTestEnvironment } from '../utils/testHelpers'
 
@@ -17,12 +16,14 @@ const AUDIENCE_DEFAULTS = {
   country: 'US',
 }
 
+const DEFAULT_CLIENT_USER = { id: 0, collection: 'clients', active: true }
+
 async function callEndpoint(
   payload: Payload,
   query: Record<string, string | number | boolean>,
   options: {
     skipAudienceDefaults?: boolean
-    user?: { id: number | string; collection: string }
+    user?: { id: number | string; collection: string; active?: boolean } | null
   } = {},
 ): Promise<{ status: number; headers: Headers; body: { audiences?: number[]; errors?: unknown } }> {
   const finalQuery = options.skipAudienceDefaults ? query : { ...AUDIENCE_DEFAULTS, ...query }
@@ -31,7 +32,7 @@ async function callEndpoint(
     query: finalQuery,
     headers: new Headers(),
     routeParams: {},
-    user: options.user,
+    user: 'user' in options ? options.user : DEFAULT_CLIENT_USER,
   } as unknown as PayloadRequest
 
   const response = (await audiencesForUser.handler(req)) as Response
@@ -88,6 +89,34 @@ describe('audiencesForUser endpoint', () => {
     expect(body).toHaveProperty('errors')
   })
 
+  describe('auth gate', () => {
+    it('rejects unauthenticated callers with 403', async () => {
+      const { status, body } = await callEndpoint(payload, {}, { user: null })
+      expect(status).toBe(403)
+      expect(body).toEqual({
+        errors: [{ message: 'You are not allowed to perform this action.' }],
+      })
+    })
+
+    it('rejects non-client users (managers) with 403', async () => {
+      const { status } = await callEndpoint(
+        payload,
+        {},
+        { user: { id: adminUserId, collection: 'managers', active: true } },
+      )
+      expect(status).toBe(403)
+    })
+
+    it('rejects inactive clients with 403', async () => {
+      const { status } = await callEndpoint(
+        payload,
+        {},
+        { user: { id: 999, collection: 'clients', active: false } },
+      )
+      expect(status).toBe(403)
+    })
+  })
+
   it('returns progress audience IDs matching the supplied data', async () => {
     const { status, body } = await callEndpoint(payload, { pathProgress: 3 })
     expect(status).toBe(200)
@@ -127,9 +156,13 @@ describe('audiencesForUser endpoint', () => {
 
     const findSpy = vi.spyOn(payload, 'find')
     try {
-      const { status } = await callEndpoint(payload, { pathProgress: 0 }, {
-        user: { id: client.id, collection: 'clients' },
-      })
+      const { status } = await callEndpoint(
+        payload,
+        { pathProgress: 0 },
+        {
+          user: { id: client.id, collection: 'clients', active: true },
+        },
+      )
       expect(status).toBe(200)
 
       const audienceCall = findSpy.mock.calls.find(

--- a/tests/int/lectures-for-audience.int.spec.ts
+++ b/tests/int/lectures-for-audience.int.spec.ts
@@ -2,7 +2,6 @@ import type { Payload, PayloadRequest } from 'payload'
 
 import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest'
 
-
 import { lecturesForAudience } from '@/endpoints/lecturesForAudience'
 import type { LecturePlayerData } from '@/lib/lectureShape'
 import type { Audience, Client, Image, Lecture } from '@/payload-types'
@@ -29,6 +28,8 @@ vi.mock('@/lib/nirmalaVidyaApi', async (importOriginal) => {
   }
 })
 
+const DEFAULT_CLIENT_USER = { id: 0, collection: 'clients', active: true }
+
 // `audiences` is required by the endpoint's Zod schema. Tests that don't
 // exercise a specific eligibility scenario still need to pass a non-empty
 // list; pass `{ skipDefaultAudiences: true }` on the 400-validation cases
@@ -36,7 +37,7 @@ vi.mock('@/lib/nirmalaVidyaApi', async (importOriginal) => {
 async function callEndpoint(
   payload: Payload,
   query: Record<string, string | number | boolean>,
-  user?: { id: number | string; collection: string },
+  user?: { id: number | string; collection: string; active?: boolean } | null,
   options: { skipDefaultAudiences?: boolean; defaultAudiences?: string } = {},
 ): Promise<{ status: number; headers: Headers; body: { docs: LecturePlayerData[] } | unknown }> {
   const finalQuery = options.skipDefaultAudiences
@@ -47,7 +48,7 @@ async function callEndpoint(
     query: finalQuery,
     headers: new Headers(),
     routeParams: {},
-    user,
+    user: user === undefined ? DEFAULT_CLIENT_USER : user,
   } as unknown as PayloadRequest
 
   const response = (await lecturesForAudience.handler(req)) as Response
@@ -202,20 +203,19 @@ describe('lecturesForAudience endpoint', () => {
 
     it('returns 400 when limit is out of range', async () => {
       expect(
-        (await callEndpoint(payload, { limit: 0 }, undefined, { defaultAudiences: beginnerOnly })).status,
+        (await callEndpoint(payload, { limit: 0 }, undefined, { defaultAudiences: beginnerOnly }))
+          .status,
       ).toBe(400)
       expect(
-        (await callEndpoint(payload, { limit: 101 }, undefined, { defaultAudiences: beginnerOnly })).status,
+        (await callEndpoint(payload, { limit: 101 }, undefined, { defaultAudiences: beginnerOnly }))
+          .status,
       ).toBe(400)
     })
 
     it('returns 400 when audiences is missing', async () => {
-      const { status } = await callEndpoint(
-        payload,
-        { limit: 10 },
-        undefined,
-        { skipDefaultAudiences: true },
-      )
+      const { status } = await callEndpoint(payload, { limit: 10 }, undefined, {
+        skipDefaultAudiences: true,
+      })
       expect(status).toBe(400)
     })
 
@@ -230,14 +230,43 @@ describe('lecturesForAudience endpoint', () => {
     })
   })
 
-  describe('Cache headers', () => {
-    it('sets Cache-Control: public, max-age=600, s-maxage=600', async () => {
-      const { headers, status } = await callEndpoint(
+  describe('auth gate', () => {
+    it('rejects unauthenticated callers with 403', async () => {
+      const { status, body } = await callEndpoint(payload, { limit: 10 }, null, {
+        defaultAudiences: beginnerOnly,
+      })
+      expect(status).toBe(403)
+      expect(body).toEqual({
+        errors: [{ message: 'You are not allowed to perform this action.' }],
+      })
+    })
+
+    it('rejects non-client users (managers) with 403', async () => {
+      const { status } = await callEndpoint(
         payload,
         { limit: 10 },
-        undefined,
+        { id: adminUserId, collection: 'managers', active: true },
         { defaultAudiences: beginnerOnly },
       )
+      expect(status).toBe(403)
+    })
+
+    it('rejects inactive clients with 403', async () => {
+      const { status } = await callEndpoint(
+        payload,
+        { limit: 10 },
+        { id: 999, collection: 'clients', active: false },
+        { defaultAudiences: beginnerOnly },
+      )
+      expect(status).toBe(403)
+    })
+  })
+
+  describe('Cache headers', () => {
+    it('sets Cache-Control: public, max-age=600, s-maxage=600', async () => {
+      const { headers, status } = await callEndpoint(payload, { limit: 10 }, undefined, {
+        defaultAudiences: beginnerOnly,
+      })
       expect(status).toBe(200)
       expect(headers.get('Cache-Control')).toBe('public, max-age=600, s-maxage=600')
     })
@@ -253,8 +282,12 @@ describe('lecturesForAudience endpoint', () => {
       expect(a.status).toBe(200)
       expect(b.status).toBe(200)
 
-      const idsA = (a.body as { docs: LecturePlayerData[] }).docs.map((d) => d.id).sort((x, y) => x - y)
-      const idsB = (b.body as { docs: LecturePlayerData[] }).docs.map((d) => d.id).sort((x, y) => x - y)
+      const idsA = (a.body as { docs: LecturePlayerData[] }).docs
+        .map((d) => d.id)
+        .sort((x, y) => x - y)
+      const idsB = (b.body as { docs: LecturePlayerData[] }).docs
+        .map((d) => d.id)
+        .sort((x, y) => x - y)
       // Same eligible pool — random order but identical set.
       expect(idsA).toEqual(idsB)
     })
@@ -541,7 +574,7 @@ describe('lecturesForAudience endpoint', () => {
       expect(clip!.hlsUrl).toBe('https://example.com/stream.m3u8')
     })
 
-    it("falls back to parent.metadata.thumbnailUrl when clip has no own thumbnail", async () => {
+    it('falls back to parent.metadata.thumbnailUrl when clip has no own thumbnail', async () => {
       // Set up: a full parent (no editor thumbnail) + a clip with no thumbnail.
       const { fetchNirmalaVidyaVideo } = await import('@/lib/nirmalaVidyaApi')
       vi.mocked(fetchNirmalaVidyaVideo).mockResolvedValueOnce({
@@ -594,7 +627,7 @@ describe('lecturesForAudience endpoint', () => {
       expect(item!.thumbnailUrl).toBeTruthy()
     })
 
-    it("clip subtitle overrides merge with parent.metadata.subtitles", async () => {
+    it('clip subtitle overrides merge with parent.metadata.subtitles', async () => {
       const { fetchNirmalaVidyaVideo } = await import('@/lib/nirmalaVidyaApi')
       vi.mocked(fetchNirmalaVidyaVideo).mockResolvedValueOnce({
         title: 'Parent for subtitle merge',
@@ -694,34 +727,100 @@ describe('lecturesForAudience endpoint', () => {
       audienceD = await testData.createAudience(payload)
       audienceE = await testData.createAudience(payload)
 
-      lectureAPinned = await testData.createLecture(payload, {}, { audiences: [audienceA.id], priority: 5 })
-      lectureANormal1 = await testData.createLecture(payload, {}, { audiences: [audienceA.id], priority: 0 })
-      lectureANormal2 = await testData.createLecture(payload, {}, { audiences: [audienceA.id], priority: 0 })
-      lectureANormal3 = await testData.createLecture(payload, {}, { audiences: [audienceA.id], priority: 0 })
+      lectureAPinned = await testData.createLecture(
+        payload,
+        {},
+        { audiences: [audienceA.id], priority: 5 },
+      )
+      lectureANormal1 = await testData.createLecture(
+        payload,
+        {},
+        { audiences: [audienceA.id], priority: 0 },
+      )
+      lectureANormal2 = await testData.createLecture(
+        payload,
+        {},
+        { audiences: [audienceA.id], priority: 0 },
+      )
+      lectureANormal3 = await testData.createLecture(
+        payload,
+        {},
+        { audiences: [audienceA.id], priority: 0 },
+      )
       // Priority field omitted — defaultValue:0 applies, testing the "unset" path
       lectureAUnset = await testData.createLecture(payload, {}, { audiences: [audienceA.id] })
 
-      lectureBHigh = await testData.createLecture(payload, {}, { audiences: [audienceB.id], priority: 10 })
-      lectureBMid = await testData.createLecture(payload, {}, { audiences: [audienceB.id], priority: 5 })
-      lectureBLow = await testData.createLecture(payload, {}, { audiences: [audienceB.id], priority: 1 })
+      lectureBHigh = await testData.createLecture(
+        payload,
+        {},
+        { audiences: [audienceB.id], priority: 10 },
+      )
+      lectureBMid = await testData.createLecture(
+        payload,
+        {},
+        { audiences: [audienceB.id], priority: 5 },
+      )
+      lectureBLow = await testData.createLecture(
+        payload,
+        {},
+        { audiences: [audienceB.id], priority: 1 },
+      )
 
-      lectureCTie1 = await testData.createLecture(payload, {}, { audiences: [audienceC.id], priority: 5 })
-      lectureCTie2 = await testData.createLecture(payload, {}, { audiences: [audienceC.id], priority: 5 })
+      lectureCTie1 = await testData.createLecture(
+        payload,
+        {},
+        { audiences: [audienceC.id], priority: 5 },
+      )
+      lectureCTie2 = await testData.createLecture(
+        payload,
+        {},
+        { audiences: [audienceC.id], priority: 5 },
+      )
 
-      lectureDPinned1 = await testData.createLecture(payload, {}, { audiences: [audienceD.id], priority: 10 })
-      lectureDPinned2 = await testData.createLecture(payload, {}, { audiences: [audienceD.id], priority: 8 })
-      lectureDPinned3 = await testData.createLecture(payload, {}, { audiences: [audienceD.id], priority: 6 })
-      lectureDPinned4 = await testData.createLecture(payload, {}, { audiences: [audienceD.id], priority: 4 })
+      lectureDPinned1 = await testData.createLecture(
+        payload,
+        {},
+        { audiences: [audienceD.id], priority: 10 },
+      )
+      lectureDPinned2 = await testData.createLecture(
+        payload,
+        {},
+        { audiences: [audienceD.id], priority: 8 },
+      )
+      lectureDPinned3 = await testData.createLecture(
+        payload,
+        {},
+        { audiences: [audienceD.id], priority: 6 },
+      )
+      lectureDPinned4 = await testData.createLecture(
+        payload,
+        {},
+        { audiences: [audienceD.id], priority: 4 },
+      )
 
-      lectureENormal1 = await testData.createLecture(payload, {}, { audiences: [audienceE.id], priority: 0 })
-      lectureENormal2 = await testData.createLecture(payload, {}, { audiences: [audienceE.id], priority: 0 })
-      lectureENormal3 = await testData.createLecture(payload, {}, { audiences: [audienceE.id], priority: 0 })
+      lectureENormal1 = await testData.createLecture(
+        payload,
+        {},
+        { audiences: [audienceE.id], priority: 0 },
+      )
+      lectureENormal2 = await testData.createLecture(
+        payload,
+        {},
+        { audiences: [audienceE.id], priority: 0 },
+      )
+      lectureENormal3 = await testData.createLecture(
+        payload,
+        {},
+        { audiences: [audienceE.id], priority: 0 },
+      )
     })
 
     it('pinned lecture (priority > 0) always appears before all un-pinned lectures', async () => {
       const param = String(audienceA.id)
       for (let i = 0; i < 5; i++) {
-        const { body } = await callEndpoint(payload, { limit: 100 }, undefined, { defaultAudiences: param })
+        const { body } = await callEndpoint(payload, { limit: 100 }, undefined, {
+          defaultAudiences: param,
+        })
         const docs = (body as { docs: LecturePlayerData[] }).docs
         const pinnedIdx = docs.findIndex((d) => d.id === lectureAPinned.id)
         expect(pinnedIdx).toBe(0)
@@ -734,7 +833,9 @@ describe('lecturesForAudience endpoint', () => {
     it('lecture with higher priority always appears before lower-priority lecture', async () => {
       const param = String(audienceB.id)
       for (let i = 0; i < 5; i++) {
-        const { body } = await callEndpoint(payload, { limit: 100 }, undefined, { defaultAudiences: param })
+        const { body } = await callEndpoint(payload, { limit: 100 }, undefined, {
+          defaultAudiences: param,
+        })
         const docs = (body as { docs: LecturePlayerData[] }).docs
         const highIdx = docs.findIndex((d) => d.id === lectureBHigh.id)
         const midIdx = docs.findIndex((d) => d.id === lectureBMid.id)
@@ -749,7 +850,9 @@ describe('lecturesForAudience endpoint', () => {
       const orderings = new Set<string>()
 
       for (let i = 0; i < 20; i++) {
-        const { body } = await callEndpoint(payload, { limit: 100 }, undefined, { defaultAudiences: param })
+        const { body } = await callEndpoint(payload, { limit: 100 }, undefined, {
+          defaultAudiences: param,
+        })
         const docs = (body as { docs: LecturePlayerData[] }).docs
         const tie1Idx = docs.findIndex((d) => d.id === lectureCTie1.id)
         const tie2Idx = docs.findIndex((d) => d.id === lectureCTie2.id)
@@ -761,7 +864,9 @@ describe('lecturesForAudience endpoint', () => {
 
     it('lecture with default priority (unset → 0) participates in the normal pool, after pinned', async () => {
       const param = String(audienceA.id)
-      const { body } = await callEndpoint(payload, { limit: 100 }, undefined, { defaultAudiences: param })
+      const { body } = await callEndpoint(payload, { limit: 100 }, undefined, {
+        defaultAudiences: param,
+      })
       const docs = (body as { docs: LecturePlayerData[] }).docs
       const pinnedIdx = docs.findIndex((d) => d.id === lectureAPinned.id)
       const unsetIdx = docs.findIndex((d) => d.id === lectureAUnset.id)
@@ -770,7 +875,9 @@ describe('lecturesForAudience endpoint', () => {
 
     it('all-pinned pool is sorted by priority descending with no normal items appended', async () => {
       const param = String(audienceB.id)
-      const { body } = await callEndpoint(payload, { limit: 100 }, undefined, { defaultAudiences: param })
+      const { body } = await callEndpoint(payload, { limit: 100 }, undefined, {
+        defaultAudiences: param,
+      })
       const docs = (body as { docs: LecturePlayerData[] }).docs
       expect(docs).toHaveLength(3)
       expect(docs[0].id).toBe(lectureBHigh.id)
@@ -780,7 +887,9 @@ describe('lecturesForAudience endpoint', () => {
 
     it('when limit is smaller than the pinned pool, only the highest-priority lectures are returned', async () => {
       const param = String(audienceD.id)
-      const { body } = await callEndpoint(payload, { limit: 2 }, undefined, { defaultAudiences: param })
+      const { body } = await callEndpoint(payload, { limit: 2 }, undefined, {
+        defaultAudiences: param,
+      })
       const docs = (body as { docs: LecturePlayerData[] }).docs
       expect(docs).toHaveLength(2)
       const returnedIds = docs.map((d) => d.id)
@@ -792,7 +901,9 @@ describe('lecturesForAudience endpoint', () => {
 
     it('all-normal pool (no pinned lectures) returns all lectures', async () => {
       const param = String(audienceE.id)
-      const { body } = await callEndpoint(payload, { limit: 100 }, undefined, { defaultAudiences: param })
+      const { body } = await callEndpoint(payload, { limit: 100 }, undefined, {
+        defaultAudiences: param,
+      })
       const docs = (body as { docs: LecturePlayerData[] }).docs
       const returnedIds = docs.map((d) => d.id)
       expect(returnedIds).toContain(lectureENormal1.id)
@@ -815,7 +926,7 @@ describe('lecturesForAudience endpoint', () => {
         const { status } = await callEndpoint(
           payload,
           { limit: 5 },
-          { id: client.id, collection: 'clients' },
+          { id: client.id, collection: 'clients', active: true },
           { defaultAudiences: beginnerOnly },
         )
         expect(status).toBe(200)

--- a/tests/int/meditation-lectures.int.spec.ts
+++ b/tests/int/meditation-lectures.int.spec.ts
@@ -2,7 +2,6 @@ import type { Payload, PayloadRequest } from 'payload'
 
 import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest'
 
-
 import { meditationLectures } from '@/endpoints/meditationLectures'
 import { recomputeWeightsForMeditation } from '@/hooks/meditationHooks'
 import type { LecturePlayerData } from '@/lib/lectureShape'
@@ -33,6 +32,8 @@ vi.mock('@/lib/nirmalaVidyaApi', async (importOriginal) => {
   }
 })
 
+const DEFAULT_CLIENT_USER = { id: 0, collection: 'clients', active: true }
+
 // `audiences` is a required, non-empty comma-separated list of IDs. Tests
 // that don't exercise validation pass the resolved-audience ID through
 // `defaultAudiences`. Cases that want to omit it entirely set
@@ -44,7 +45,7 @@ async function callEndpoint(
   options: {
     skipDefaultAudiences?: boolean
     defaultAudiences?: string
-    user?: { id: number | string; collection: string }
+    user?: { id: number | string; collection: string; active?: boolean } | null
   } = {},
 ): Promise<{ status: number; headers: Headers; body: { docs: LecturePlayerData[] } | unknown }> {
   const finalQuery = options.skipDefaultAudiences
@@ -66,7 +67,7 @@ async function callEndpoint(
     // `{ en: '...' }` objects.
     locale: 'en',
     fallbackLocale: 'en',
-    user: options.user,
+    user: 'user' in options ? options.user : DEFAULT_CLIENT_USER,
   } as unknown as PayloadRequest
 
   const response = (await meditationLectures.handler(req)) as Response
@@ -264,9 +265,14 @@ describe('meditationLectures endpoint', () => {
   })
 
   it('returns lectures sorted by descending overlap weight', async () => {
-    const { status, body } = await callEndpoint(payload, meditation.id, { limit: 10 }, {
-      defaultAudiences: audienceFilter,
-    })
+    const { status, body } = await callEndpoint(
+      payload,
+      meditation.id,
+      { limit: 10 },
+      {
+        defaultAudiences: audienceFilter,
+      },
+    )
     expect(status).toBe(200)
     const docs = (body as { docs: LecturePlayerData[] }).docs
 
@@ -287,12 +293,22 @@ describe('meditationLectures endpoint', () => {
   })
 
   it('is deterministic across repeated calls', async () => {
-    const a = await callEndpoint(payload, meditation.id, { limit: 10 }, {
-      defaultAudiences: audienceFilter,
-    })
-    const b = await callEndpoint(payload, meditation.id, { limit: 10 }, {
-      defaultAudiences: audienceFilter,
-    })
+    const a = await callEndpoint(
+      payload,
+      meditation.id,
+      { limit: 10 },
+      {
+        defaultAudiences: audienceFilter,
+      },
+    )
+    const b = await callEndpoint(
+      payload,
+      meditation.id,
+      { limit: 10 },
+      {
+        defaultAudiences: audienceFilter,
+      },
+    )
     expect((a.body as { docs: LecturePlayerData[] }).docs.map((d) => d.id)).toEqual(
       (b.body as { docs: LecturePlayerData[] }).docs.map((d) => d.id),
     )
@@ -456,9 +472,14 @@ describe('meditationLectures endpoint', () => {
   })
 
   it('returns 404 for unknown meditation', async () => {
-    const { status, body } = await callEndpoint(payload, 999999, { limit: 10 }, {
-      defaultAudiences: audienceFilter,
-    })
+    const { status, body } = await callEndpoint(
+      payload,
+      999999,
+      { limit: 10 },
+      {
+        defaultAudiences: audienceFilter,
+      },
+    )
     expect(status).toBe(404)
     expect((body as { errors: Array<{ message: string }> }).errors[0].message).toContain(
       'Meditation not found',
@@ -500,6 +521,47 @@ describe('meditationLectures endpoint', () => {
     expect(status).toBe(400)
   })
 
+  describe('auth gate', () => {
+    it('rejects unauthenticated callers with 403', async () => {
+      const { status, body } = await callEndpoint(
+        payload,
+        meditation.id,
+        { limit: 10 },
+        { defaultAudiences: audienceFilter, user: null },
+      )
+      expect(status).toBe(403)
+      expect(body).toEqual({
+        errors: [{ message: 'You are not allowed to perform this action.' }],
+      })
+    })
+
+    it('rejects non-client users (managers) with 403', async () => {
+      const { status } = await callEndpoint(
+        payload,
+        meditation.id,
+        { limit: 10 },
+        {
+          defaultAudiences: audienceFilter,
+          user: { id: adminUserId, collection: 'managers', active: true },
+        },
+      )
+      expect(status).toBe(403)
+    })
+
+    it('rejects inactive clients with 403', async () => {
+      const { status } = await callEndpoint(
+        payload,
+        meditation.id,
+        { limit: 10 },
+        {
+          defaultAudiences: audienceFilter,
+          user: { id: 999, collection: 'clients', active: false },
+        },
+      )
+      expect(status).toBe(403)
+    })
+  })
+
   it('sets Cache-Control: public, max-age=600, s-maxage=600 on success', async () => {
     const { status, headers } = await callEndpoint(
       payload,
@@ -524,7 +586,7 @@ describe('meditationLectures endpoint', () => {
         { limit: 5 },
         {
           defaultAudiences: audienceFilter,
-          user: { id: client.id, collection: 'clients' },
+          user: { id: client.id, collection: 'clients', active: true },
         },
       )
       expect(status).toBe(200)
@@ -548,9 +610,14 @@ describe('meditationLectures endpoint', () => {
 
   it('treats unsorted/duplicated audiences as equivalent to the canonical sorted form', async () => {
     const messy = `${audience.id},${audience.id}`
-    const a = await callEndpoint(payload, meditation.id, { limit: 10 }, {
-      defaultAudiences: audienceFilter,
-    })
+    const a = await callEndpoint(
+      payload,
+      meditation.id,
+      { limit: 10 },
+      {
+        defaultAudiences: audienceFilter,
+      },
+    )
     const b = await callEndpoint(payload, meditation.id, { audiences: messy, limit: 10 })
     expect(a.status).toBe(200)
     expect(b.status).toBe(200)
@@ -560,9 +627,14 @@ describe('meditationLectures endpoint', () => {
   })
 
   it('emits the flat LecturePlayerData shape', async () => {
-    const { body } = await callEndpoint(payload, meditation.id, { limit: 1 }, {
-      defaultAudiences: audienceFilter,
-    })
+    const { body } = await callEndpoint(
+      payload,
+      meditation.id,
+      { limit: 1 },
+      {
+        defaultAudiences: audienceFilter,
+      },
+    )
     const docs = (body as { docs: LecturePlayerData[] }).docs
     expect(docs.length).toBe(1)
     const expectedKeys = [
@@ -598,9 +670,14 @@ describe('meditationLectures endpoint', () => {
     })) as Meditation
     expect(cleared.subtleSystemNodeWeights).toBeFalsy()
 
-    const { status, body } = await callEndpoint(payload, meditation.id, { limit: 5 }, {
-      defaultAudiences: audienceFilter,
-    })
+    const { status, body } = await callEndpoint(
+      payload,
+      meditation.id,
+      { limit: 5 },
+      {
+        defaultAudiences: audienceFilter,
+      },
+    )
     expect(status).toBe(200)
     const docs = (body as { docs: LecturePlayerData[] }).docs
     expect(docs.length).toBeGreaterThan(0)
@@ -635,11 +712,7 @@ describe('meditationLectures endpoint', () => {
 
     // Repoint frameA from mooladhara → kundalini. Cascade hook should
     // recompute weights on every meditation referencing frameA.
-    const nodeKundalini = await testData.createSubtleSystemNode(
-      payload,
-      {},
-      { slug: 'kundalini' },
-    )
+    const nodeKundalini = await testData.createSubtleSystemNode(payload, {}, { slug: 'kundalini' })
     await payload.update({
       collection: 'frames',
       id: frameA.id,
@@ -677,7 +750,11 @@ describe('meditationLectures endpoint', () => {
       parentForGating = await testData.createLecture(
         payload,
         {},
-        { title: 'Parent (gating eligible)', audiences: [audience.id], subtleSystemNodes: [nodeA.id] },
+        {
+          title: 'Parent (gating eligible)',
+          audiences: [audience.id],
+          subtleSystemNodes: [nodeA.id],
+        },
       )
       // Clip referencing eligible parent. Tagged with userChoice so the endpoint
       // includes it even at weight=0 (clips don't always inherit nodeA weight).
@@ -748,7 +825,11 @@ describe('meditationLectures endpoint', () => {
       const { body } = await callEndpoint(
         payload,
         meditation.id,
-        { audiences: `${audienceFilter},${separateAudienceId}`, limit: 100, userChoice: userChoice.id },
+        {
+          audiences: `${audienceFilter},${separateAudienceId}`,
+          limit: 100,
+          userChoice: userChoice.id,
+        },
         { skipDefaultAudiences: true },
       )
       const clip = (body as { docs: LecturePlayerData[] }).docs.find(


### PR DESCRIPTION
## Summary

- The four audience-resolving custom endpoints (`/api/audiences/for-user`, `/api/lectures/for-audience`, `/api/app-cards/for-audience`, `/api/meditations/:id/related-lectures`) were returning data to **any** caller — authenticated or not. They build their responses via `req.payload.find({ ..., req: asTrustedReq(req) })`, which inherits Payload's Local API default of `overrideAccess: true`. `asTrustedReq` only sets the `skipClientQueryValidation` context flag; it does not gate auth. So the endpoints worked even with no `Authorization` header.
- Adds an explicit top-of-handler check: `req.user?.collection !== 'clients' || !req.user.active` → 403 with the same error body Payload uses for built-in access denials, so the mobile app's existing error path catches it unchanged.
- Mirrors the inactive-client gate already in [bypassPermissions](src/lib/access/bypassPermissions.ts#L60).
- `framesByNarrator` is intentionally left alone — it's called by the admin `FrameEditor` component (managers), not the mobile app.

## Context

Discovered while debugging a separate production issue (mobile app 403s on every built-in REST endpoint). Root cause of the 403s was a `PAYLOAD_SECRET` rotation that invalidated the encrypted `apiKey` field and the HMAC `apiKeyIndex` in the DB — recovery is operational (restore secret or regenerate keys) and not part of this PR. The custom-endpoints leak surfaced because the user noticed those endpoints kept responding to unauthenticated callers. This PR closes that hole independently of the secret-rotation recovery.

## Test plan

- [x] `pnpm lint` clean
- [x] `pnpm exec vitest run tests/int/audiences-for-user.int.spec.ts --config ./vitest.config.mts` — 15/15
- [x] `pnpm exec vitest run tests/int/lectures-for-audience.int.spec.ts --config ./vitest.config.mts` — 42/42
- [x] `pnpm exec vitest run tests/int/app-cards-for-audience.int.spec.ts --config ./vitest.config.mts` — 28/28
- [x] `pnpm exec vitest run tests/int/meditation-lectures.int.spec.ts --config ./vitest.config.mts` — 28/28
- [ ] CI green
- [ ] After deploy: unauthenticated `curl https://cloud.sydevelopers.com/api/audiences/for-user?...` returns 403 (was 200)
- [ ] After deploy: authenticated mobile-app calls still return 200

Each endpoint's spec now has an `auth gate` describe block covering: unauthenticated → 403, non-client user → 403, inactive client → 403. The `callEndpoint` helpers default to an active client mock so existing happy-path tests continue to authenticate transparently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)