### PR TITLE
fix(videos): point url + admin thumbnail at Cloudflare Stream

### DIFF
--- a/src/collections/Videos/Videos.ts
+++ b/src/collections/Videos/Videos.ts
@@ -3,7 +3,13 @@ import type { CollectionConfig } from 'payload'
 import { mediaField } from '@/fields'
 import { subtitlesJsonSchema, validateSubtitles } from '@/lib/utilities/subtitles'
 import { restrictUploadToAdmin } from '@/plugins/access'
-import { hlsUrlField, mp4UrlField, previewUrlField } from '@/plugins/storage/urlFields'
+import { getCloudflareStreamThumbnailUrl } from '@/plugins/storage/cloudflareStreamAdapter'
+import {
+  hlsUrlField,
+  mixedMediaUrlField,
+  mp4UrlField,
+  previewUrlField,
+} from '@/plugins/storage/urlFields'
 
 export const Videos: CollectionConfig = {
   slug: 'videos',
@@ -17,6 +23,14 @@ export const Videos: CollectionConfig = {
   upload: {
     staticDir: 'media/videos',
     mimeTypes: ['video/mp4', 'video/webm', 'video/quicktime'],
+    // Point the admin preview thumbnail at the Cloudflare Stream poster.
+    // Without this, `thumbnailURL` is null and the admin edit view falls back
+    // to the `url` field's Payload file route (`/api/videos/file/<id>`), which
+    // 500s in production — the Stream adapter serves no bytes from Workers.
+    adminThumbnail: ({ doc }) => {
+      const filename = typeof doc.filename === 'string' ? doc.filename : null
+      return filename ? (getCloudflareStreamThumbnailUrl(filename, 320) ?? null) : null
+    },
   },
   admin: {
     group: 'Media',
@@ -24,6 +38,10 @@ export const Videos: CollectionConfig = {
     defaultColumns: ['title', 'tags', 'previewUrl'],
   },
   fields: [
+    // `url` resolves to the Stream MP4 download (mirrors Frames). This overrides
+    // Payload's default file-route url (`/api/videos/file/<id>`), which 500s in
+    // production because Cloudflare Stream serves the bytes, not the Worker.
+    mixedMediaUrlField({ collection: 'videos' }),
     hlsUrlField({ collection: 'videos' }),
     mp4UrlField({ collection: 'videos' }),
     previewUrlField({ collection: 'videos' }),

--- a/src/collections/Videos/Videos.ts
+++ b/src/collections/Videos/Videos.ts
@@ -27,10 +27,10 @@ export const Videos: CollectionConfig = {
     // Without this, `thumbnailURL` is null and the admin edit view falls back
     // to the `url` field's Payload file route (`/api/videos/file/<id>`), which
     // 500s in production — the Stream adapter serves no bytes from Workers.
-    adminThumbnail: ({ doc }) => {
-      const filename = typeof doc.filename === 'string' ? doc.filename : null
-      return filename ? (getCloudflareStreamThumbnailUrl(filename, 320) ?? null) : null
-    },
+    adminThumbnail: ({ doc }) =>
+      typeof doc.filename === 'string'
+        ? (getCloudflareStreamThumbnailUrl(doc.filename, 320) ?? null)
+        : null,
   },
   admin: {
     group: 'Media',

--- a/tests/int/videos.int.spec.ts
+++ b/tests/int/videos.int.spec.ts
@@ -96,7 +96,7 @@ describe('Videos Collection — custom behavior', () => {
       // A doc without a Stream UID must yield null — never a file-route URL that
       // would 500. The populated-UID path builds the Stream thumbnail URL via
       // getCloudflareStreamThumbnailUrl (covered in storage-utils.int.spec.ts).
-      const fn = adminThumbnail as (args: { doc: Record<string, unknown> }) => false | null | string
+      const fn = adminThumbnail as (args: { doc: Record<string, unknown> }) => string | null
       expect(fn({ doc: {} })).toBeNull()
       expect(fn({ doc: { filename: 123 } })).toBeNull()
     })

--- a/tests/int/videos.int.spec.ts
+++ b/tests/int/videos.int.spec.ts
@@ -68,4 +68,37 @@ describe('Videos Collection — custom behavior', () => {
       ).rejects.toThrow(/subtitles|startTimeMs/i)
     })
   })
+
+  describe('admin media URL wiring (#455)', () => {
+    // Videos live in Cloudflare Stream, not on the Worker filesystem. The admin
+    // edit view renders `thumbnailURL || url` as an <img>; if either resolves to
+    // Payload's default `/api/videos/file/<id>` route, that request 500s in
+    // production. Both must resolve to Cloudflare instead.
+
+    it('overrides `url` with a virtual field (Stream MP4, not the file route)', () => {
+      const urlField = payload.collections['videos'].config.fields.find(
+        (f) => 'name' in f && f.name === 'url',
+      )
+
+      expect(urlField).toBeDefined()
+      // Payload's base `url` field is not virtual; mixedMediaUrlField's is. A
+      // non-virtual `url` here means the override was dropped and the file-route
+      // 500 has returned.
+      expect(urlField).toHaveProperty('virtual', true)
+    })
+
+    it('wires `adminThumbnail` to the Stream poster and guards a missing UID', () => {
+      const { upload } = payload.collections['videos'].config
+      const adminThumbnail = typeof upload === 'object' ? upload.adminThumbnail : undefined
+
+      expect(typeof adminThumbnail).toBe('function')
+
+      // A doc without a Stream UID must yield null — never a file-route URL that
+      // would 500. The populated-UID path builds the Stream thumbnail URL via
+      // getCloudflareStreamThumbnailUrl (covered in storage-utils.int.spec.ts).
+      const fn = adminThumbnail as (args: { doc: Record<string, unknown> }) => false | null | string
+      expect(fn({ doc: {} })).toBeNull()
+      expect(fn({ doc: { filename: 123 } })).toBeNull()
+    })
+  })
 })


### PR DESCRIPTION
## Summary

Fixes the production 500 when viewing an uploaded video in the admin (`GET /api/videos/file/<id>` → 500).

Closes #455

## Root cause

Video bytes live in **Cloudflare Stream**, not on the Worker filesystem. The admin edit view (`StaticFileDetails`) renders `thumbnailURL || url` as an `<img>`:

- `thumbnailURL` was `null` (no `adminThumbnail` configured → Payload's `generateFilePathOrURL` returns `null`), so it fell back to `url`.
- The `videos` collection had **no `url` virtual field** — unlike `images` (`virtualUrlField`) and `frames` (`mixedMediaUrlField`). The Stream adapter defines no `generateURL`, so `url` stayed as Payload's default `/api/videos/file/<id>`.
- The `<img>` auto-fires that URL on page load. Because `videos` sets `disablePayloadAccessControl: true` and the Stream adapter has no `clientUploads`, the cloud-storage plugin **never registers the adapter's `staticHandler`**, so Payload's file route falls through to `fs.stat` — which fails on Workers → **500**.

Doesn't reproduce in dev (local file storage serves the bytes). `frames` avoids it because `mixedMediaUrlField` already overrides `url` to a Cloudflare URL.

## Fix

In `src/collections/Videos/Videos.ts`, mirroring the Images/Frames pattern:

1. **`mixedMediaUrlField({ collection: 'videos' })`** — `url` now resolves to the Cloudflare Stream MP4 download (local fallback in dev). Stops the auto-500 and makes the open/download link work.
2. **`upload.adminThumbnail`** — returns the Cloudflare Stream poster, so the editor shows the video frame instead of a broken image / file icon.

No schema change, no migration — virtual fields + an upload-config option only. `payload generate:types` produces no diff (`url` already exists as a base upload field). Verified via `mergeBaseFields` that the custom `url` field merges cleanly with Payload's base `url` (same as Images), so no bootstrap conflict.

## Testing

- `tests/int/videos.int.spec.ts` — new regression block guards that the `url` virtual field is mounted and `adminThumbnail` is wired (the env-gated URL construction is already covered in `storage-utils.int.spec.ts`).
- Lean gate green: `pnpm lint`, `pnpm test:unit` (375), `pnpm exec vitest run tests/int/videos.int.spec.ts` (6).

### Manual verification (production-only path)

The 500 only reproduces on Cloudflare Workers, so please confirm after deploy: upload a video, open it in the admin → no 500, poster renders once Stream finishes transcoding.

## Follow-up (out of scope)

`frames` and `files` also store video in Stream and have a `url` field (so they don't 500), but lack `adminThumbnail` — their admin edit-view video thumbnail shows a generic file icon. Cosmetic; worth a small follow-up to give them the same poster.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
