### PR TITLE
perf(meditations): skip per-row afterRead hooks in admin list

### DIFF
--- a/src/collections/Meditations/Meditations.ts
+++ b/src/collections/Meditations/Meditations.ts
@@ -104,7 +104,14 @@ export const Meditations: CollectionConfig = {
   admin: {
     group: 'Content',
     useAsTitle: 'label',
-    defaultColumns: ['label', 'thumbnail', '_status', 'type', 'durationMinutes'],
+    // Restrict the admin list query to the active columns' fields so the
+    // expensive per-row afterRead hooks on unselected fields (randomSongUrl,
+    // frames, tagAssignments) never run on a list load. See #459.
+    enableListViewSelectAPI: true,
+    // `duration` is hidden and never rendered as a column, but it must be
+    // selected so the `durationMinutes` virtual column — whose afterRead
+    // derives minutes from `duration` — still computes under the list select.
+    defaultColumns: ['label', 'thumbnail', '_status', 'type', 'durationMinutes', 'duration'],
     livePreview: {
       url: ({ data }) => {
         const baseURL = process.env.WEMEDITATE_WEB_URL
@@ -135,7 +142,9 @@ export const Meditations: CollectionConfig = {
       name: 'randomSongUrl',
       type: 'text',
       virtual: true,
-      admin: { hidden: true },
+      // afterRead runs 2 song queries per row — keep it out of the list view
+      // entirely so it can never be re-activated as a column/filter (#459).
+      admin: { hidden: true, disableListColumn: true, disableListFilter: true },
       hooks: {
         afterRead: [randomSongUrlAfterRead],
       },
@@ -318,6 +327,10 @@ export const Meditations: CollectionConfig = {
                 condition: ({ id }) => !!id,
                 description:
                   'Shows which categories use this meditation for each time of day. Managed from the Categories collection.',
+                // Each virtualJoinField subfield runs a user-choices query per
+                // row; keep the whole group out of the list view (#459).
+                disableListColumn: true,
+                disableListFilter: true,
               },
               fields: [
                 virtualJoinField({ name: 'asMorningMeditation', on: 'morningMeditation' }),
@@ -345,6 +358,10 @@ export const Meditations: CollectionConfig = {
                       name: 'frames',
                       type: 'json',
                       admin: {
+                        // afterRead runs a frames query per row to enrich the
+                        // keyframes — keep it out of the list view (#459).
+                        disableListColumn: true,
+                        disableListFilter: true,
                         components: {
                           Field: '@/components/admin/FrameEditor/FrameListManager',
                         },

--- a/src/collections/Meditations/Meditations.ts
+++ b/src/collections/Meditations/Meditations.ts
@@ -142,8 +142,7 @@ export const Meditations: CollectionConfig = {
       name: 'randomSongUrl',
       type: 'text',
       virtual: true,
-      // afterRead runs 2 song queries per row — keep it out of the list view
-      // entirely so it can never be re-activated as a column/filter (#459).
+      // afterRead runs 2 song queries per row.
       admin: { hidden: true, disableListColumn: true, disableListFilter: true },
       hooks: {
         afterRead: [randomSongUrlAfterRead],
@@ -327,8 +326,7 @@ export const Meditations: CollectionConfig = {
                 condition: ({ id }) => !!id,
                 description:
                   'Shows which categories use this meditation for each time of day. Managed from the Categories collection.',
-                // Each virtualJoinField subfield runs a user-choices query per
-                // row; keep the whole group out of the list view (#459).
+                // Each virtualJoinField subfield runs a user-choices query per row.
                 disableListColumn: true,
                 disableListFilter: true,
               },
@@ -358,8 +356,7 @@ export const Meditations: CollectionConfig = {
                       name: 'frames',
                       type: 'json',
                       admin: {
-                        // afterRead runs a frames query per row to enrich the
-                        // keyframes — keep it out of the list view (#459).
+                        // afterRead runs a frames query per row to enrich keyframes.
                         disableListColumn: true,
                         disableListFilter: true,
                         components: {

--- a/tests/int/meditations.int.spec.ts
+++ b/tests/int/meditations.int.spec.ts
@@ -616,18 +616,23 @@ describe('Meditations Collection', () => {
       } as Parameters<typeof testData.createUserChoice>[1])
     })
 
+    // The find the admin list view issues for this meditation (restricted to
+    // its active columns, like the real list).
+    const fetchListView = () =>
+      payload.find({
+        collection: 'meditations',
+        where: { id: { equals: listMeditation.id } },
+        depth: 0,
+        draft: true,
+        locale: 'en',
+        select: LIST_VIEW_SELECT,
+      })
+
     it('skips the expensive per-row afterRead hooks on a list-style find', async () => {
       const findSpy = vi.spyOn(payload, 'find')
       const countSpy = vi.spyOn(payload, 'count')
       try {
-        const result = await payload.find({
-          collection: 'meditations',
-          where: { id: { equals: listMeditation.id } },
-          depth: 0,
-          draft: true,
-          locale: 'en',
-          select: LIST_VIEW_SELECT,
-        })
+        const result = await fetchListView()
 
         const findCollections = findSpy.mock.calls.map((c) => c[0].collection)
         const countCollections = countSpy.mock.calls.map((c) => c[0].collection)
@@ -654,14 +659,7 @@ describe('Meditations Collection', () => {
       // audio-42s.mp3 → duration ~42s → ceil(42 / 60) = 1 minute. This only
       // works because `duration` is in the list select; drop it from
       // defaultColumns and the virtual column blanks.
-      const result = await payload.find({
-        collection: 'meditations',
-        where: { id: { equals: listMeditation.id } },
-        depth: 0,
-        draft: true,
-        locale: 'en',
-        select: LIST_VIEW_SELECT,
-      })
+      const result = await fetchListView()
       const doc = result.docs[0]
       expect(doc.label).toBeTruthy()
       expect(doc.durationMinutes).toBe(1)

--- a/tests/int/meditations.int.spec.ts
+++ b/tests/int/meditations.int.spec.ts
@@ -1,6 +1,6 @@
 import type { Payload } from 'payload'
 
-import { describe, it, beforeAll, afterAll, expect } from 'vitest'
+import { describe, it, beforeAll, afterAll, expect, vi } from 'vitest'
 
 import type { Meditation, Narrator, Image, SongTag, Album } from '@/payload-types'
 
@@ -568,6 +568,122 @@ describe('Meditations Collection', () => {
       })
 
       expect(med.title).toBe('Meditation for Right Channel')
+    })
+  })
+
+  describe('Admin list view select (#459)', () => {
+    // Mirrors the field `select` the admin list view builds when
+    // `enableListViewSelectAPI` is on: transformColumnsToSelect(defaultColumns)
+    // — label, thumbnail, _status, type, durationMinutes, duration — plus the
+    // upload thumbnail fields appended by appendUploadSelectFields. Replicated
+    // here because the select is assembled in @payloadcms/next's RSC List view,
+    // which an integration test can't invoke directly.
+    const LIST_VIEW_SELECT = {
+      label: true,
+      thumbnail: true,
+      _status: true,
+      type: true,
+      durationMinutes: true,
+      duration: true,
+      mimeType: true,
+      thumbnailURL: true,
+      url: true,
+    }
+
+    let listMeditation: Meditation
+
+    beforeAll(async () => {
+      // Give every expensive hook real work to do, so skipping it is
+      // observable: a matching song (randomSongUrl), a frame (frames
+      // enrichment), and a category referencing this meditation (tagAssignments
+      // join).
+      const tag = await testData.createSongTag(payload, { title: 'List Select Tag' })
+      await testData.createSong(payload, { album: testAlbum.id, tags: [tag.id] })
+      const frame = await testData.createFrame(payload)
+
+      listMeditation = await testData.createMeditation(
+        payload,
+        { narrator: testNarrator.id, thumbnail: testImageMedia.id },
+        { songTag: tag.id },
+      )
+      await payload.update({
+        collection: 'meditations',
+        id: listMeditation.id,
+        data: { frames: [{ id: frame.id, timestamp: 0 }] as unknown as Meditation['frames'] },
+      })
+      await testData.createUserChoice(payload, {
+        morningMeditation: listMeditation.id,
+      } as Parameters<typeof testData.createUserChoice>[1])
+    })
+
+    it('skips the expensive per-row afterRead hooks on a list-style find', async () => {
+      const findSpy = vi.spyOn(payload, 'find')
+      const countSpy = vi.spyOn(payload, 'count')
+      try {
+        const result = await payload.find({
+          collection: 'meditations',
+          where: { id: { equals: listMeditation.id } },
+          depth: 0,
+          draft: true,
+          locale: 'en',
+          select: LIST_VIEW_SELECT,
+        })
+
+        const findCollections = findSpy.mock.calls.map((c) => c[0].collection)
+        const countCollections = countSpy.mock.calls.map((c) => c[0].collection)
+
+        // None of the hook-driven sub-queries fire: randomSongUrl (songs count +
+        // find), tagAssignments (user-choices), frames enrichment (frames).
+        expect(findCollections).not.toContain('songs')
+        expect(findCollections).not.toContain('user-choices')
+        expect(findCollections).not.toContain('frames')
+        expect(countCollections).not.toContain('songs')
+
+        // ...and the unselected fields are stripped from the row entirely.
+        const doc = result.docs[0]
+        expect(doc.randomSongUrl).toBeUndefined()
+        expect(doc.frames).toBeUndefined()
+        expect(doc.tagAssignments).toBeUndefined()
+      } finally {
+        findSpy.mockRestore()
+        countSpy.mockRestore()
+      }
+    })
+
+    it('still renders the durationMinutes column (duration stays selected)', async () => {
+      // audio-42s.mp3 → duration ~42s → ceil(42 / 60) = 1 minute. This only
+      // works because `duration` is in the list select; drop it from
+      // defaultColumns and the virtual column blanks.
+      const result = await payload.find({
+        collection: 'meditations',
+        where: { id: { equals: listMeditation.id } },
+        depth: 0,
+        draft: true,
+        locale: 'en',
+        select: LIST_VIEW_SELECT,
+      })
+      const doc = result.docs[0]
+      expect(doc.label).toBeTruthy()
+      expect(doc.durationMinutes).toBe(1)
+    })
+
+    it('leaves a full read (REST / edit view) unchanged — all fields present', async () => {
+      // A read without the list select still computes every field, so the public
+      // REST API and the admin edit view are unaffected by the list-only flags.
+      const result = await payload.find({
+        collection: 'meditations',
+        where: { id: { equals: listMeditation.id } },
+        depth: 0,
+        draft: true,
+        locale: 'en',
+      })
+      const doc = result.docs[0]
+      expect(typeof doc.randomSongUrl).toBe('string')
+      expect(Array.isArray(doc.frames)).toBe(true)
+      expect((doc.frames as unknown[]).length).toBeGreaterThan(0)
+
+      const tagAssignments = doc.tagAssignments as { asMorningMeditation?: unknown[] } | undefined
+      expect(tagAssignments?.asMorningMeditation).toHaveLength(1)
     })
   })
 })


### PR DESCRIPTION
## Summary

Closes #459.

The admin **Meditations** list intermittently hung for minutes. Root cause: the list issued a `find` with **no field-level `select`**, so every field's `afterRead` ran on every row — even fields that aren't list columns:

| Field                                                                | Cost per row                                   | Shown in list? |
| -------------------------------------------------------------------- | ---------------------------------------------- | -------------- |
| `randomSongUrl`                                                      | 2 queries (`count` + offset `find` on `songs`) | No             |
| `tagAssignments.{asMorning,asAfternoon,asEvening,asNight}Meditation` | 4 queries to `user-choices`                    | No             |
| `frames` enrichment                                                  | 1 query to `frames`                            | No             |

≈ **7 D1 round-trips per row** that feed no displayed column. At the default page size that's ~70 serial round-trips in one Worker request; on a D1 cold start / load spike this blew the Worker budget and the request errored — the reported "temperamental" behaviour.

## Fix (Step 1 — native flags)

Admin-list only; the public REST API is unchanged for every field.

- **`enableListViewSelectAPI: true`** on the collection → the list query selects only its active columns, so unselected fields' `afterRead` hooks are skipped via Payload's `stripUnselectedFields`.
- **`disableListColumn: true` + `disableListFilter: true`** on `randomSongUrl`, `frames`, and the `tagAssignments` group → keeps them out of the list select and out of the column selector, so they can't be re-activated into the slow path.
- **`duration` added to `defaultColumns`** (it's `admin.hidden`, so it never renders as a column) → forces it into the list select so the `durationMinutes` virtual column — whose `afterRead` derives minutes from `duration` — still computes. This is the AC #4 fix.

## Verification

The select-stripping mechanism was confirmed against the compiled Payload source and an integration spike before writing the fix:

- `@payloadcms/next` List view: `select = enableListViewSelectAPI ? transformColumnsToSelect(getColumns(...)) : undefined` → an **include**-mode select built only from active columns.
- `stripUnselectedFields` deletes unselected fields and short-circuits their hook chain.
- `buildColumnState` / `filterFields` exclude `admin.hidden` + `disableListColumn` fields from rendering, so the hidden `duration` in `defaultColumns` lands in the **select** but never as a **visible column**.

Empirically (spike): a full read fires `user-choices`×4 + `frames` + `songs` find + `songs` count; the list-equivalent select fires **only** the top-level `meditations` query, and `durationMinutes` computes once `duration` is in the select.

## Tests

New `describe('Admin list view select (#459)')` in `tests/int/meditations.int.spec.ts`:

1. A list-style `find` (mirroring the admin list select) fires **no** `songs` / `user-choices` / `frames` sub-queries (spies on `payload.find`/`count`) and strips those fields from the row.
2. `durationMinutes` still computes under the list select (`duration` stays selected).
3. A full read (no select — REST / edit-view shape) is unchanged: `randomSongUrl`, `frames`, and `tagAssignments` are all populated.

Existing `meditations.int` + `meditationFrames.int` + `user-choices-by-timing.int` suites stay green (55 tests).

## Manual verification recommended

- [ ] Meditations admin list loads fast (no multi-minute hang).
- [ ] `durationMinutes` column still shows values in the list UI.
- [ ] Edit view still shows Category Assignments.
- [ ] `GET /api/meditations` response is unchanged (all fields present, `randomSongUrl` + enriched `frames` intact).

## Notes

- No schema change → **no migration**.
- `disableListFilter` is included alongside `disableListColumn` (it doesn't affect the per-row hook cost, but keeps these non-filterable fields out of the filter UI).
- Related: #249 (replace the `virtualJoinField` workaround with native join fields) should stay consistent with these flags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
