### PR TITLE
perf(admin): batch thumbnail-cell relationship lookups (client-side N+1)

### DIFF
--- a/src/components/admin/ThumbnailCell/RelationshipThumbnailCell.tsx
+++ b/src/components/admin/ThumbnailCell/RelationshipThumbnailCell.tsx
@@ -1,17 +1,50 @@
 'use client'
 
+import type { RelationshipDoc } from './relationshipDocLoader'
 import type { DefaultCellComponentProps, UploadFieldClient } from 'payload'
 
-import { useDocumentDrawer, usePayloadAPI } from '@payloadcms/ui'
-import { useCallback } from 'react'
+import { useDocumentDrawer } from '@payloadcms/ui'
+import { useCallback, useEffect, useState } from 'react'
+
 
 import { BaseThumbnailCell } from './BaseThumbnailCell'
+import { relationshipDocLoader } from './relationshipDocLoader'
 
 /**
- * Thumbnail cell for upload relationship fields (e.g., photo -> images)
- * Fetches the related document via API since cellData contains just the ID
+ * Subscribes to the batched relationship-doc loader so every thumbnail cell on
+ * a list page resolves through one shared request instead of one fetch per row
+ * (the #460 N+1). Returns `undefined` while loading, then the doc or `null`.
+ */
+function useRelationshipDoc(
+  relationTo: string,
+  id: string | null,
+): RelationshipDoc | null | undefined {
+  const [doc, setDoc] = useState<RelationshipDoc | null | undefined>(undefined)
+
+  useEffect(() => {
+    if (id == null) {
+      setDoc(null)
+      return
+    }
+    let active = true
+    void relationshipDocLoader.load(relationTo, id).then((resolved) => {
+      if (active) setDoc(resolved)
+    })
+    return () => {
+      active = false
+    }
+  }, [relationTo, id])
+
+  return doc
+}
+
+/**
+ * Thumbnail cell for upload relationship fields (e.g., photo -> images).
+ * cellData is just the related document ID; the related image's
+ * url/mimeType/filename are resolved via the batched loader (one request per
+ * list page instead of one per row).
  *
- * Opens the related document in a drawer overlay when clicked
+ * Opens the related document in a drawer overlay when clicked.
  */
 export const RelationshipThumbnailCell: React.FC<DefaultCellComponentProps> = ({
   cellData,
@@ -44,24 +77,14 @@ export const RelationshipThumbnailCell: React.FC<DefaultCellComponentProps> = ({
     [openDrawer],
   )
 
-  const [{ data: relatedDoc }] = usePayloadAPI(relatedId ? `/api/${relationTo}` : '', {
-    initialParams: relatedId
-      ? {
-          where: { id: { equals: relatedId } },
-          limit: 1,
-          select: { url: true, mimeType: true, filename: true },
-        }
-      : undefined,
-  })
-
-  const doc = relatedDoc?.docs?.[0]
+  const doc = useRelationshipDoc(relationTo, relatedId)
 
   return (
     <>
       <BaseThumbnailCell
-        thumbnailUrl={doc?.url as string | undefined}
-        mimeType={doc?.mimeType as string | undefined}
-        filename={doc?.filename as string | undefined}
+        thumbnailUrl={doc?.url}
+        mimeType={doc?.mimeType}
+        filename={doc?.filename}
         cellData={cellData}
         collectionSlug={collectionSlug}
         rowData={rowData}

--- a/src/components/admin/ThumbnailCell/relationshipDocLoader.ts
+++ b/src/components/admin/ThumbnailCell/relationshipDocLoader.ts
@@ -1,0 +1,110 @@
+import * as qs from 'qs-esm'
+
+/**
+ * A related document resolved for a thumbnail cell. Only the fields a thumbnail
+ * needs are selected — the related collection (e.g. `images`) carries far more.
+ */
+export interface RelationshipDoc {
+  id: number | string
+  url?: string
+  mimeType?: string
+  filename?: string
+}
+
+/**
+ * Fetches a batch of related documents by ID from a single collection.
+ * Injected into the loader so tests can supply a fake.
+ */
+export type FetchRelationshipDocs = (
+  relationTo: string,
+  ids: Array<number | string>,
+) => Promise<RelationshipDoc[]>
+
+/**
+ * Default fetcher: one REST request to `/api/{relationTo}` selecting only the
+ * thumbnail fields. Mirrors `@payloadcms/ui`'s `requests.get` (cookie auth via
+ * `credentials: 'include'`). The selected fields aren't localized, so no locale
+ * is sent.
+ */
+export const fetchRelationshipDocs: FetchRelationshipDocs = async (relationTo, ids) => {
+  const query = qs.stringify(
+    {
+      depth: 0,
+      limit: ids.length,
+      select: { filename: true, mimeType: true, url: true },
+      where: { id: { in: ids } },
+    },
+    { addQueryPrefix: true },
+  )
+
+  const response = await fetch(`/api/${relationTo}${query}`, { credentials: 'include' })
+  if (response.status > 201) return []
+
+  const json = (await response.json()) as { docs?: RelationshipDoc[] }
+  return json.docs ?? []
+}
+
+interface PendingBatch {
+  ids: Set<number | string>
+  promise: Promise<Map<string, RelationshipDoc>>
+  resolve: (byId: Map<string, RelationshipDoc>) => void
+}
+
+/**
+ * Creates a request-batching loader for upload/relationship documents.
+ *
+ * Every `load()` call made within the same microtask tick — i.e. all the
+ * thumbnail cells on a list page, whose effects React flushes together — is
+ * coalesced into a single request per `relationTo`, collapsing the per-row N+1
+ * into one round-trip. See #460.
+ */
+export function createRelationshipDocLoader(
+  fetchDocs: FetchRelationshipDocs = fetchRelationshipDocs,
+) {
+  // One in-flight batch per related collection, keyed by `relationTo`.
+  const batches = new Map<string, PendingBatch>()
+
+  const flush = async (relationTo: string): Promise<void> => {
+    const batch = batches.get(relationTo)
+    if (!batch) return
+    // Detach the batch before awaiting so loads arriving during the fetch open
+    // a fresh batch rather than joining one that's already closed.
+    batches.delete(relationTo)
+
+    const byId = new Map<string, RelationshipDoc>()
+    try {
+      const docs = await fetchDocs(relationTo, [...batch.ids])
+      for (const doc of docs) byId.set(String(doc.id), doc)
+    } catch {
+      // Leave `byId` empty — each cell falls back to a placeholder thumbnail.
+    }
+    batch.resolve(byId)
+  }
+
+  /**
+   * Resolves the related document for `id`, or `null` if it wasn't returned
+   * (missing, trashed, or not readable by the current user).
+   */
+  const load = (relationTo: string, id: number | string): Promise<RelationshipDoc | null> => {
+    let batch = batches.get(relationTo)
+    if (!batch) {
+      let resolve!: (byId: Map<string, RelationshipDoc>) => void
+      const promise = new Promise<Map<string, RelationshipDoc>>((res) => {
+        resolve = res
+      })
+      batch = { ids: new Set(), promise, resolve }
+      batches.set(relationTo, batch)
+      queueMicrotask(() => {
+        void flush(relationTo)
+      })
+    }
+
+    batch.ids.add(id)
+    return batch.promise.then((byId) => byId.get(String(id)) ?? null)
+  }
+
+  return { load }
+}
+
+/** Shared loader instance used by the thumbnail cells. */
+export const relationshipDocLoader = createRelationshipDocLoader()

--- a/tests/unit/relationshipDocLoader.spec.ts
+++ b/tests/unit/relationshipDocLoader.spec.ts
@@ -1,0 +1,101 @@
+/**
+ * Tests for the thumbnail-cell request-batching loader (#460).
+ *
+ * The loader collapses the per-row N+1 — one `/api/images` request per list
+ * row — into a single batched request per collection. These tests pin the
+ * coalescing/dedupe/missing-id behaviour using an injected fake fetcher; the
+ * real fetcher is thin Payload REST plumbing and isn't worth a unit test.
+ */
+
+import { describe, expect, it, vi } from 'vitest'
+
+import type { RelationshipDoc } from '@/components/admin/ThumbnailCell/relationshipDocLoader'
+import { createRelationshipDocLoader } from '@/components/admin/ThumbnailCell/relationshipDocLoader'
+
+const doc = (id: number, extra: Partial<RelationshipDoc> = {}): RelationshipDoc => ({
+  id,
+  url: `https://cdn/${id}`,
+  mimeType: 'image/webp',
+  filename: `${id}.webp`,
+  ...extra,
+})
+
+const echoFetcher = () =>
+  vi.fn(async (_relationTo: string, ids: Array<number | string>) =>
+    ids.map((id) => doc(Number(id))),
+  )
+
+describe('relationshipDocLoader', () => {
+  it('coalesces same-tick loads for one collection into a single fetch', async () => {
+    const fetchDocs = echoFetcher()
+    const loader = createRelationshipDocLoader(fetchDocs)
+
+    const [a, b, c] = await Promise.all([
+      loader.load('images', 1),
+      loader.load('images', 2),
+      loader.load('images', 3),
+    ])
+
+    expect(fetchDocs).toHaveBeenCalledTimes(1)
+    expect(fetchDocs).toHaveBeenCalledWith('images', [1, 2, 3])
+    expect(a).toEqual(doc(1))
+    expect(b).toEqual(doc(2))
+    expect(c).toEqual(doc(3))
+  })
+
+  it('deduplicates repeated IDs within a batch', async () => {
+    const fetchDocs = echoFetcher()
+    const loader = createRelationshipDocLoader(fetchDocs)
+
+    const [a, b] = await Promise.all([loader.load('images', 7), loader.load('images', 7)])
+
+    expect(fetchDocs).toHaveBeenCalledTimes(1)
+    expect(fetchDocs).toHaveBeenCalledWith('images', [7])
+    expect(a).toEqual(doc(7))
+    expect(b).toEqual(doc(7))
+  })
+
+  it('resolves null for IDs the fetch does not return', async () => {
+    const fetchDocs = vi.fn(async () => [doc(1)]) // id 2 deliberately missing
+    const loader = createRelationshipDocLoader(fetchDocs)
+
+    const [found, missing] = await Promise.all([loader.load('images', 1), loader.load('images', 2)])
+
+    expect(found).toEqual(doc(1))
+    expect(missing).toBeNull()
+  })
+
+  it('keeps separate collections in separate requests', async () => {
+    const fetchDocs = echoFetcher()
+    const loader = createRelationshipDocLoader(fetchDocs)
+
+    await Promise.all([loader.load('images', 1), loader.load('files', 2)])
+
+    expect(fetchDocs).toHaveBeenCalledTimes(2)
+    expect(fetchDocs).toHaveBeenCalledWith('images', [1])
+    expect(fetchDocs).toHaveBeenCalledWith('files', [2])
+  })
+
+  it('opens a fresh batch after the previous one flushes', async () => {
+    const fetchDocs = echoFetcher()
+    const loader = createRelationshipDocLoader(fetchDocs)
+
+    await loader.load('images', 1)
+    await loader.load('images', 2)
+
+    expect(fetchDocs).toHaveBeenCalledTimes(2)
+    expect(fetchDocs).toHaveBeenNthCalledWith(1, 'images', [1])
+    expect(fetchDocs).toHaveBeenNthCalledWith(2, 'images', [2])
+  })
+
+  it('resolves null for every caller when the fetch rejects', async () => {
+    const fetchDocs = vi.fn(async () => {
+      throw new Error('network down')
+    })
+    const loader = createRelationshipDocLoader(fetchDocs)
+
+    const results = await Promise.all([loader.load('images', 1), loader.load('images', 2)])
+
+    expect(results).toEqual([null, null])
+  })
+})


### PR DESCRIPTION
## Summary

- Admin list views fired one `/api/{relationTo}` request **per row** to resolve each upload-relationship thumbnail (the client-side N+1 in #460). This collapses them into **one batched request per collection per list page**.
- A microtask-scoped loader coalesces every thumbnail cell's lookup into a single `/api/{relationTo}?where[id][in]=…&select[url,mimeType,filename]&depth=0` call; the cell reads the result via a small `useRelationshipDoc` hook.
- Fixes the N+1 on **every** list using `mediaField` — meditations, authors, videos, lessons, app-cards, lectures, albums — not just the reported Meditations list. Thumbnail rendering and click-to-open-drawer behaviour are unchanged.

## Changes

- `src/components/admin/ThumbnailCell/relationshipDocLoader.ts` (new) — pure, React-free batching loader (`createRelationshipDocLoader(fetchDocs?)` + singleton). Injectable fetcher; default fetcher mirrors `@payloadcms/ui`'s `requests.get` (`credentials: 'include'`).
- `src/components/admin/ThumbnailCell/RelationshipThumbnailCell.tsx` — swaps the per-row `usePayloadAPI` fetch for the batched loader via a local `useRelationshipDoc` hook.
- `tests/unit/relationshipDocLoader.spec.ts` (new) — coalescing, dedupe, missing-id, per-collection isolation, sequential batches, fetch-error fallback.

## Test Results

- Unit tests: **381 passed** (incl. 6 new loader specs)
- Integration tests: N/A — cell-level change only, no collection/endpoint/hook touched
- Lint: ✓ No errors (`--max-warnings 0`)
- Types: ✓ `tsc --noEmit` clean (0 errors project-wide)

## Manual verification

1. Open the Meditations list in admin (`/admin/collections/meditations`).
2. DevTools → Network, filter `images`: expect **one** `/api/images?where[id][in]=…` request for the whole page, not one per row.
3. Thumbnails render as before; clicking one still opens the image in a drawer overlay.

## Notes for reviewer

- The issue floated populating the thumbnail in the list query (`appendUploadSelectFields` / depth). That isn't achievable via config: Payload's admin list query is hardcoded to `depth: 0` (`@payloadcms/next/.../views/List/index.js`), and `appendUploadSelectFields` only forces a row's _own_ upload fields into the select — it does nothing for a relationship pointing at `images`. So the thumbnail is always a bare ID server-side, and **client-side batching** is the right lever (chosen over a server cell, which would reintroduce per-row server queries that #459/#463 just removed).
- No resolved-doc cache by design — avoids staleness after edits; the per-page request count is already 1.

Closes #460

🤖 Generated with [Claude Code](https://claude.com/claude-code)
