### PR TITLE
feat(translations): live preview via Payload native Live Preview

### DIFF
--- a/.claude/docs/environment.md
+++ b/.claude/docs/environment.md
@@ -5,15 +5,18 @@
 Copy from `.env.example` and configure:
 
 ### Core Configuration
+
 - `PAYLOAD_SECRET` - Secret key for authentication
 - **Note**: Database (SQLite/D1) is configured via `payload.config.ts` using Wrangler - no DATABASE_URI needed
 
 ### Logging Configuration
+
 - `NEXT_PUBLIC_LOG_LEVEL` - Log level for both Payload's Pino logger and client-side logger
   - Levels: `'silent'` | `'error'` | `'warn'` | `'info'` | `'debug'`
   - Default: `undefined` (uses Pino defaults server-side, `'silent'` client-side)
 
 ### Email Configuration (Production)
+
 - `SMTP_HOST` - SMTP server host (default: smtp.gmail.com)
 - `SMTP_PORT` - SMTP server port (default: 587)
 - `SMTP_USER` - SMTP username
@@ -25,21 +28,25 @@ Copy from `.env.example` and configure:
 **Note**: The system uses Cloudflare-native services in production and automatically falls back to local file storage in development (no configuration needed for local development).
 
 #### Cloudflare Images & Stream (Image & Video Storage)
+
 - `CLOUDFLARE_ACCOUNT_ID` - Your Cloudflare account ID
 - `CLOUDFLARE_API_KEY` - Unified API token for both Cloudflare Images and Stream (set via `wrangler secret put`)
 - `CLOUDFLARE_IMAGES_DELIVERY_URL` - Full Images delivery URL (e.g., `https://imagedelivery.net/<hash>`)
 - `CLOUDFLARE_STREAM_DELIVERY_URL` - Full Stream delivery URL (e.g., `https://customer-<code>.cloudflarestream.com`)
 
 #### R2 Native Bindings (Audio & Files)
+
 - R2 bucket is configured via `wrangler.toml` bindings (no environment variables needed)
 - `CLOUDFLARE_R2_DELIVERY_URL` - Public URL for R2-stored assets (e.g., `https://assets.sydevelopers.com`)
 
 #### Rate Limiting Binding (API Rate Limiting)
+
 - Configured via `wrangler.toml` using modern `[[ratelimits]]` syntax
 - No environment variables needed - binding is accessed via `getCloudflareContext()`
 - Rate limiting is automatically disabled in development environment
 
 **Wrangler Configuration**:
+
 ```toml
 # Production (top-level)
 [[ratelimits]]
@@ -59,22 +66,34 @@ simple = { limit = 500, period = 60 }
 #### Finding Cloudflare Credentials
 
 **Account ID**:
+
 1. Go to Cloudflare Dashboard → Account Home
 2. Look in right sidebar under "Account ID"
 
 **Images Delivery URL**:
+
 1. Go to Images dashboard
 2. Look at any delivery URL: `https://imagedelivery.net/<hash>/<image-id>/public`
 3. Copy the base URL including the hash: `https://imagedelivery.net/<hash>`
 
 **Stream Delivery URL**:
+
 1. Go to Stream dashboard
 2. Look at any video player URL: `https://customer-<code>.cloudflarestream.com/...`
 3. Copy the base URL: `https://customer-<code>.cloudflarestream.com`
 
 ### Live Preview URLs
+
 - `WEMEDITATE_WEB_URL` - Preview URL for We Meditate Web frontend (required)
 - `SAHAJATLAS_URL` - Preview URL for Sahaj Atlas frontend (required)
+- `WEMEDITATE_APP_URL` - WeMeditate App (Flutter) hosted base URL for the
+  `wm-app-translations` **native Payload live preview** (`admin.livePreview.url`
+  on the global). The hosted page reimplements Payload's live-preview client
+  (`subscribe`/`ready`) and reads the `secret` to access unpublished drafts.
+  Optional until that page is deployed; its origin is added to the admin CSP
+  `frame-src` in `next.config.mjs`. **Railway:** must also be set at **build
+  time** — `headers()` (the CSP) is baked at build, so a runtime-only var leaves
+  `frame-src` missing the origin and the preview iframe is CSP-blocked.
 
 ## Environment Variable Validation
 
@@ -85,12 +104,14 @@ The application uses Zod for type-safe environment variable validation. All envi
 **Location**: `src/lib/env.ts`
 
 Exports two validated environment objects:
+
 - `serverEnv` - Server-only variables (secrets, API keys)
-- `clientEnv` - Client-accessible variables (NEXT_PUBLIC_* prefix)
+- `clientEnv` - Client-accessible variables (NEXT*PUBLIC*\* prefix)
 
 ### Usage Patterns
 
 **Server-side code**:
+
 ```typescript
 import { serverEnv } from '@/lib/env'
 
@@ -98,6 +119,7 @@ const accountId = serverEnv.CLOUDFLARE_ACCOUNT_ID // Type-safe, validated
 ```
 
 **Client-side code**:
+
 ```typescript
 import { clientEnv } from '@/lib/env'
 
@@ -105,6 +127,7 @@ const logLevel = clientEnv.NEXT_PUBLIC_LOG_LEVEL // Type-safe, validated
 ```
 
 **Cloudflare Workers bindings**:
+
 ```typescript
 import { requireBinding } from '@/lib/env'
 
@@ -133,6 +156,7 @@ const r2 = requireBinding<R2Bucket>(env.R2, 'R2')
 ### Error Messages
 
 When validation fails, Zod provides detailed error messages:
+
 ```
 Environment validation error:
 {
@@ -146,23 +170,27 @@ Environment validation error:
 Following Next.js best practices, environment variables are separated into two schemas:
 
 **Server Environment** (`serverEnv`):
+
 - All server-only variables (secrets, API keys)
-- NEXT_PUBLIC_* variables (needed for server-side usage)
+- NEXT*PUBLIC*\* variables (needed for server-side usage)
 - NODE_ENV for type safety
 
 **Client Environment** (`clientEnv`):
-- Only NEXT_PUBLIC_* variables (intentionally public)
+
+- Only NEXT*PUBLIC*\* variables (intentionally public)
 - Exposed to browser bundle
 
 ### Optional vs Required Strategy
 
 **Development (Local)**:
+
 - `PAYLOAD_SECRET` → Required (min 32 chars)
 - Cloudflare credentials → Optional (fallback to local file storage)
 - Email API → Optional (fallback to Ethereal Email)
 - Sentry DSN → Optional (error tracking disabled)
 
 **Production (Cloudflare Workers)**:
+
 - `PAYLOAD_SECRET` → Always required
 - Cloudflare credentials → Required when `env` binding is provided
 - Runtime validation via `requireBinding<T>()` helper for R2/D1 bindings
@@ -178,6 +206,7 @@ Following Next.js best practices, environment variables are separated into two s
 The application uses **Wrangler Environments** to manage different configurations for development and production.
 
 **Configuration File**: `wrangler.toml` contains both environments:
+
 - **Default (top-level)**: Production configuration with remote D1 database
 - **`[env.dev]`**: Development environment with local SQLite database
 
@@ -203,18 +232,21 @@ NEXT_PUBLIC_LOG_LEVEL = "debug"
 ### How Environment Selection Works
 
 **Development** (`pnpm dev`):
+
 - Automatically uses `[env.dev]` environment from `wrangler.toml`
 - Environment variable `CLOUDFLARE_ENV=dev` (set in `.env` file) tells `getPlatformProxy()` to use dev config
 - Uses local `.wrangler` database (D1 with `database_id = "local"`)
 - Development URLs (localhost:3000, localhost:5173, etc.)
 
 **Production** (deployment):
+
 - Uses default (top-level) configuration
 - Environment variable `CLOUDFLARE_ENV` is undefined (defaults to production)
 - Connects to remote D1 database when `remote = true`
 - Production URLs (cloud.sydevelopers.com, wemeditate.com, etc.)
 
 ### Key Files
+
 - `.env` - Sets `CLOUDFLARE_ENV=dev` for local development
 - `wrangler.toml` - Single source of truth for both environments
 - `src/payload.config.ts` - Uses `process.env.CLOUDFLARE_ENV` to select environment in `getPlatformProxy()`

--- a/.claude/rules/globals.md
+++ b/.claude/rules/globals.md
@@ -125,6 +125,21 @@ within SQL constraints.
 }
 ```
 
+### Orientation aids (Figma link) + live preview
+
+- **`<leaf>__screenshot`** → `TabScreenshot` — the "View in Figma" link, emitted
+  by `createScreenshotField` in `src/fields/translationsField.ts` above the
+  inputs when a leaf declares a `screenshot` URL in the schema.
+- **Live preview** uses Payload's **native live preview**, not a custom field:
+  `admin.livePreview.url` on the `wm-app-translations` global returns
+  `${WEMEDITATE_APP_URL}/${locale.code}/preview/wm-app-translations?secret=…`
+  (mirrors `Pages`/`Meditations`/`WeMeditateWebConfig`). The hosted WeMeditate
+  App page reimplements Payload's live-preview client (`subscribe`/`ready`) and
+  **auto-follows** whichever section the translator edits (no per-tab admin
+  code). `secret` (`SAHAJCLOUD_PREVIEW_SECRET`) lets that page read unpublished
+  drafts; `WEMEDITATE_APP_URL` must be in the CSP `frame-src` (and set at build
+  time on Railway). See `.claude/docs/environment.md`.
+
 ### Translation key naming
 
 - Lowercase only (no uppercase letters).

--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,12 @@ PAYLOAD_SECRET=your-payload-secret-key-here-minimum-32-characters
 WEMEDITATE_WEB_URL=http://localhost:5173
 SAHAJATLAS_URL=http://localhost:5174
 
+# WeMeditate App (Flutter) hosted URL — base for the wm-app-translations native
+# live preview. The hosted page reimplements Payload's live-preview client.
+# Optional until that page is deployed. On Railway, also set at build time
+# (the CSP frame-src in next.config.mjs is baked at build).
+# WEMEDITATE_APP_URL=http://localhost:5300
+
 # Shared secret for trusted preview requests to read draft content (min 16 chars)
 SAHAJCLOUD_PREVIEW_SECRET=your-preview-secret-here
 
@@ -58,6 +64,7 @@ RESEND_API_KEY=your-resend-api-key-here
 # Example:
 # WEMEDITATE_WEB_URL=https://wemeditate.com
 # SAHAJATLAS_URL=https://atlas.sydevelopers.com
+# WEMEDITATE_APP_URL=https://app.wemeditate.com
 
 # ============================================
 # CLOUDFLARE STORAGE (Production Only)

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -40,7 +40,11 @@ const nextConfig = {
       'https://app.usefathom.com',
       process.env.WEMEDITATE_WEB_URL || 'https://wemeditate.com',
       process.env.SAHAJATLAS_URL || 'https://atlas.sydevelopers.com',
-    ].join(' ')
+      // WeMeditate App hosted page for the translations live preview.
+      process.env.WEMEDITATE_APP_URL,
+    ]
+      .filter(Boolean)
+      .join(' ')
 
     return [
       {

--- a/src/fields/translationsField.ts
+++ b/src/fields/translationsField.ts
@@ -1,11 +1,4 @@
-import type {
-  Field,
-  GroupField,
-  JSONField,
-  RichTextField,
-  TabsField,
-  UIField,
-} from 'payload'
+import type { Field, GroupField, JSONField, RichTextField, TabsField, UIField } from 'payload'
 
 import { toWords } from 'payload/shared'
 
@@ -81,7 +74,6 @@ function isRichTextProp(prop: LeafPropertySchema | GroupSchema): prop is RichTex
 // ============================================================================
 // Helpers
 // ============================================================================
-
 
 function createScreenshotField(
   groupSlug: string,
@@ -212,8 +204,8 @@ function createLeafFields(
   const screenshot = createScreenshotField(leafSlug, group, globalSlug)
   const props = Object.entries(group.properties || {})
   const hasStringKeys = props.some(([, p]) => isStringProp(p))
-  const richTextEntries = props.filter(
-    (entry): entry is [string, RichTextPropertySchema] => isRichTextProp(entry[1]),
+  const richTextEntries = props.filter((entry): entry is [string, RichTextPropertySchema] =>
+    isRichTextProp(entry[1]),
   )
 
   const fields: Field[] = []
@@ -226,7 +218,6 @@ function createLeafFields(
 
   return [...(screenshot ? [screenshot] : []), ...fields]
 }
-
 
 // ============================================================================
 // Main: buildTranslationTabs
@@ -257,8 +248,8 @@ export function buildTranslationTabs(
     .filter(([groupSlug]) => groupSlug.trim().length > 0)
     .map(([groupSlug, groupSchema]) => {
       const groupProps = groupSchema.properties || {}
-      const subgroups = Object.entries(groupProps).filter(
-        (entry): entry is [string, GroupSchema] => isGroupSchema(entry[1]),
+      const subgroups = Object.entries(groupProps).filter((entry): entry is [string, GroupSchema] =>
+        isGroupSchema(entry[1]),
       )
 
       if (subgroups.length > 0) {

--- a/src/globals/WeMeditateAppTranslations/WeMeditateAppTranslations.ts
+++ b/src/globals/WeMeditateAppTranslations/WeMeditateAppTranslations.ts
@@ -8,6 +8,22 @@ export const WeMeditateAppTranslations: GlobalConfig = {
   slug: 'wm-app-translations',
   admin: {
     group: 'WeMeditate App',
+    livePreview: {
+      // Payload's native live preview. The hosted WeMeditate App page
+      // reimplements Payload's live-preview client (subscribe/ready) and
+      // renders the screen for whichever section the translator is editing
+      // (auto-follow). `secret` lets that page read unpublished drafts via the
+      // API (see src/lib/utilities/previewSecret.ts).
+      //
+      // Needs WEMEDITATE_APP_URL — and on Railway it must be present at BUILD
+      // time too, since `headers()` (the CSP frame-src) is baked at build.
+      url: ({ locale }) => {
+        const baseURL = process.env.WEMEDITATE_APP_URL
+        if (!baseURL) return ''
+        return `${baseURL}/${locale.code}/preview/wm-app-translations?secret=${process.env.SAHAJCLOUD_PREVIEW_SECRET}`
+      },
+      breakpoints: [{ name: 'mobile', label: 'Mobile', width: 390, height: 800 }],
+    },
   },
   versions: {
     max: 10,

--- a/src/lib/env/server.ts
+++ b/src/lib/env/server.ts
@@ -134,6 +134,13 @@ const ServerEnvSchema = ClientEnvSchema.extend({
   WEMEDITATE_WEB_URL: z.url(),
 
   /**
+   * We Meditate App (Flutter) hosted URL for the translations live preview.
+   * Optional until the preview page is deployed. On Railway it must also be set
+   * at build time, since the CSP frame-src in next.config.mjs is baked at build.
+   */
+  WEMEDITATE_APP_URL: z.url().optional(),
+
+  /**
    * Shared secret that allows trusted server-side preview requests to read drafts.
    * This should match the web frontend's SAHAJCLOUD_PREVIEW_SECRET value.
    */

--- a/tests/unit/translation-preview-config.spec.ts
+++ b/tests/unit/translation-preview-config.spec.ts
@@ -1,0 +1,45 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import { WeMeditateAppTranslations } from '@/globals/WeMeditateAppTranslations/WeMeditateAppTranslations'
+
+/**
+ * Contract for the wm-app-translations native live-preview config. The hosted
+ * WeMeditate App page consumes this URL (Payload's built-in live preview), so
+ * the locale + secret shape must stay stable. `url` reads process.env at call
+ * time, so we swap env per case rather than re-importing.
+ */
+const livePreview = WeMeditateAppTranslations.admin?.livePreview
+if (!livePreview || typeof livePreview.url !== 'function') {
+  throw new Error('Expected admin.livePreview.url on wm-app-translations')
+}
+const urlFn = livePreview.url as (args: {
+  locale: { code: string }
+  data: Record<string, unknown>
+}) => string
+
+describe('wm-app-translations — live preview config', () => {
+  const originalEnv = { ...process.env }
+  beforeEach(() => {
+    process.env = { ...originalEnv }
+  })
+  afterEach(() => {
+    process.env = originalEnv
+  })
+
+  it('exposes a mobile breakpoint for the native preview frame', () => {
+    expect(livePreview.breakpoints?.some((b) => b.name === 'mobile')).toBe(true)
+  })
+
+  it('builds the WeMeditate App preview URL with the locale path + secret', () => {
+    process.env.WEMEDITATE_APP_URL = 'https://app.example.com'
+    process.env.SAHAJCLOUD_PREVIEW_SECRET = 'test-secret-0123456789'
+    expect(urlFn({ locale: { code: 'fr' }, data: {} })).toBe(
+      'https://app.example.com/fr/preview/wm-app-translations?secret=test-secret-0123456789',
+    )
+  })
+
+  it('returns an empty url when WEMEDITATE_APP_URL is unset (graceful)', () => {
+    delete process.env.WEMEDITATE_APP_URL
+    expect(urlFn({ locale: { code: 'en' }, data: {} })).toBe('')
+  })
+})


### PR DESCRIPTION
## What & why

Adds a **live preview** to the `wm-app-translations` editor so translators see the real WeMeditate App screen render with their copy as they type — using **Payload's built-in Live Preview** (not a custom mechanism), per CTO review.

This PR is the small **Payload side**. The rendering lives in a hosted Flutter Web page that reimplements Payload's live-preview client (see *Companion* below).

## Changes (SahajCloud)

- **`WeMeditateAppTranslations`**: `admin.livePreview.url → ${WEMEDITATE_APP_URL}/${locale.code}/preview/wm-app-translations?secret=${SAHAJCLOUD_PREVIEW_SECRET}` + a mobile breakpoint. Mirrors `Pages` / `Meditations` / `WeMeditateWebConfig`.
- **`WEMEDITATE_APP_URL`** added to `env/server.ts` (optional) and the admin CSP `frame-src` in `next.config.mjs`.
- Unit test asserting the `livePreview` URL contract; docs updated (`environment.md`, `.env.example`, `globals.md`).

No schema/migration changes. `SAHAJCLOUD_PREVIEW_SECRET` (already shared) flows through the URL so the preview page can read unpublished drafts.

## Companion (separate repo)

`WeMeditateApp/translation_preview` — a Flutter Web page that:
- reimplements Payload's client: posts `{type:'payload-live-preview',ready:true}` and consumes the admin's `{type,data,globalSlug,locale}` document stream;
- **auto-follows** — renders the screen for whichever section the translator just edited (no per-tab admin code);
- renders the **real** app screens (depends on `we_meditate_app` via `path:`).

## Deploy

1. Host the Flutter page at `WEMEDITATE_APP_URL` with **SPA fallback** (`/<locale>/preview/wm-app-translations` must serve `index.html`).
2. Set `WEMEDITATE_APP_URL` in SahajCloud — **on Railway, at build time too** (`headers()`/CSP is baked at build, else the iframe is CSP-blocked).

## Verification

- Admin renders Payload's native Live Preview with the correct iframe URL.
- The Flutter client renders the real screen from a `payload-live-preview` message and **auto-switches** screens when a different section changes (Welcome → Name confirmed).
- `pnpm lint` + `pnpm test:unit` (384) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
