### PR TITLE
chore(infra): adopt Next.js output: 'standalone' on Railway/Railpack

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -38,10 +38,10 @@ The application is deployed to **Railway**, a modern platform for building and d
 **Build & Start**:
 
 - **Railpack** (Railway's native builder): Railway detects Node.js project and builds automatically
-- `railway.toml`: defines build and start commands
-  - `build.command = 'pnpm build'`
-  - `start.command = 'pnpm start'`
-- Migrations applied **in-process on server boot** via Payload `prodMigrations` hook (see [Database Migrations](#database-migrations))
+- `railway.toml`: `[build] builder = "RAILPACK"` and `[deploy] startCommand = "pnpm start"`
+  - `pnpm build` → `next build` (emits a self-contained `.next/standalone`, `output: 'standalone'`) followed by a postbuild step (`scripts/standalone-postbuild.mjs`) that copies `.next/static` + `public/` next to `server.js` — Next does not copy these automatically
+  - `pnpm start` → `node .next/standalone/server.js` (`HOSTNAME=0.0.0.0`): ships only traced production deps + a minimal server, not the full `node_modules` (much smaller runtime image)
+- Migrations applied **in-process on server boot** via Payload `prodMigrations` hook (see [Database Migrations](#database-migrations)) — the migration files are statically imported, so they trace into the standalone bundle and still run on boot
 - `Sentry` via `@sentry/nextjs` (wraps `next.config.mjs` with `withSentryConfig`)
 
 **Health Check**:
@@ -53,6 +53,8 @@ The application is deployed to **Railway**, a modern platform for building and d
 
 **next.config.mjs**:
 
+- `output: 'standalone'` — self-contained server bundle (see Build & Start above)
+- `outputFileTracingExcludes` — keeps dev-only `media/`/`seeds/`/tests out of the trace (mirrors `.railwayignore`); without it a local `pnpm build` balloons `.next/standalone` to many GB
 - Wrapped with `withSentryConfig` from `@sentry/nextjs`
 - Next.js configured with Cloudflare integration for image optimization
 
@@ -298,8 +300,8 @@ SENTRY_AUTH_TOKEN=<token>
 Railway automatically:
 
 1. Detects a git push to the deploy branch
-2. Builds the app via Railpack (`pnpm build`)
-3. Starts the app: `pnpm start`
+2. Builds the app via Railpack (`pnpm build` → `.next/standalone` + asset copy)
+3. Starts the app: `pnpm start` → `node .next/standalone/server.js`
 4. Payload **applies all pending migrations in-process on server boot** (via `prodMigrations` hook in `src/payload.config.ts`)
 5. Monitors `/api/health` until the server is ready (health checks passing)
 6. Routes traffic from Cloudflare edge proxy to the new instance

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -54,7 +54,7 @@ The application is deployed to **Railway**, a modern platform for building and d
 **next.config.mjs**:
 
 - `output: 'standalone'` — self-contained server bundle (see Build & Start above)
-- `outputFileTracingExcludes` — keeps dev-only `media/`/`seeds/`/tests out of the trace (mirrors `.railwayignore`); without it a local `pnpm build` balloons `.next/standalone` to many GB
+- `outputFileTracingExcludes` — keeps dev-only `media/`/`seeds/`/tests out of the trace (same intent as `.railwayignore`, different mechanism); without it a local `pnpm build` balloons `.next/standalone` to many GB
 - Wrapped with `withSentryConfig` from `@sentry/nextjs`
 - Next.js configured with Cloudflare integration for image optimization
 

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -14,7 +14,8 @@ const nextConfig = {
   // otherwise copies these (large) project dirs into `.next/standalone` — a local
   // `pnpm build` balloons to many GB via `media/` + `seeds/`. Prod stores uploads
   // in R2 (not local `media/`) and never runs seeds/tests, so excluding them is
-  // safe; this mirrors `.railwayignore`. See issue #471.
+  // safe — same intent as `.railwayignore` (drop dev-only/test artifacts), via a
+  // different mechanism (build trace vs. upload filter). See issue #471.
   outputFileTracingExcludes: {
     '*': [
       'media/**/*',

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -3,6 +3,28 @@ import { withSentryConfig } from '@sentry/nextjs'
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  // Self-hosted output: bundle only traced production deps + a minimal server
+  // into `.next/standalone` instead of shipping the full `node_modules`. Railpack
+  // runs `pnpm build`, then `scripts/standalone-postbuild.mjs` copies `.next/static`
+  // and `public/` next to `server.js` (Next does not copy these automatically).
+  // Migrations (`prodMigrations`) and the admin `importMap.js` are statically
+  // imported, so they trace into the bundle and still run on boot. See issue #471.
+  output: 'standalone',
+  // Keep dev-only and test artifacts out of the standalone trace. Next/Turbopack
+  // otherwise copies these (large) project dirs into `.next/standalone` — a local
+  // `pnpm build` balloons to many GB via `media/` + `seeds/`. Prod stores uploads
+  // in R2 (not local `media/`) and never runs seeds/tests, so excluding them is
+  // safe; this mirrors `.railwayignore`. See issue #471.
+  outputFileTracingExcludes: {
+    '*': [
+      'media/**/*',
+      'seeds/**/*',
+      'tests/**/*',
+      'playwright-report/**/*',
+      'test-results/**/*',
+      'coverage/**/*',
+    ],
+  },
   // Your Next.js config here
   webpack: (webpackConfig) => {
     webpackConfig.resolve.extensionAlias = {

--- a/package.json
+++ b/package.json
@@ -5,10 +5,10 @@
   "license": "MIT",
   "type": "module",
   "scripts": {
-    "build": "NODE_OPTIONS=--max-old-space-size=8000 next build",
+    "build": "NODE_OPTIONS=--max-old-space-size=8000 next build && node scripts/standalone-postbuild.mjs",
     "dev": "next dev",
     "devsafe": "rm -rf .next && next dev",
-    "start": "NODE_OPTIONS=--max-http-header-size=65536 next start",
+    "start": "HOSTNAME=0.0.0.0 NODE_OPTIONS=--max-http-header-size=65536 node .next/standalone/server.js",
     "lint": "eslint . --max-warnings 0",
     "typecheck": "tsc --noEmit",
     "postinstall": "node scripts/postinstall.cjs",

--- a/railway.toml
+++ b/railway.toml
@@ -3,6 +3,10 @@
 # Build: Railpack (Railway's native builder) — no Dockerfile. Railway exposes all
 # service variables to the build as real env, so `next build` reads them directly
 # (serverEnv validation + the CSP frame-src in next.config) with no ARG plumbing.
+# `pnpm build` emits a self-contained `.next/standalone` (output: 'standalone')
+# and a postbuild step copies `.next/static` + `public/` next to its server.js.
+# Serve: `pnpm start` runs `node .next/standalone/server.js` (HOSTNAME=0.0.0.0) —
+# only traced production deps, not the full node_modules.
 # Migrations: applied in-process on server boot via Payload's `prodMigrations`
 # (see src/payload.config.ts) — no preDeployCommand/CLI needed.
 

--- a/scripts/standalone-postbuild.mjs
+++ b/scripts/standalone-postbuild.mjs
@@ -1,0 +1,41 @@
+#!/usr/bin/env node
+// Postbuild step for `output: 'standalone'` (next.config.mjs).
+//
+// Next.js emits a minimal server at `.next/standalone/server.js` but does NOT
+// copy the static assets it serves. The standalone server resolves `.next/static`
+// and `public/` relative to itself, so we copy both next to `server.js`:
+//   .next/static  ->  .next/standalone/.next/static
+//   public/       ->  .next/standalone/public
+//
+// Runs as part of `pnpm build` (local + Railpack). See issue #471.
+
+import { cpSync, existsSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const root = join(dirname(fileURLToPath(import.meta.url)), '..')
+const standaloneDir = join(root, '.next', 'standalone')
+
+if (!existsSync(standaloneDir)) {
+  console.error(
+    "[standalone-postbuild] .next/standalone not found. Did `next build` run with `output: 'standalone'` in next.config.mjs?",
+  )
+  process.exit(1)
+}
+
+// `public/` is optional in Next.js; `.next/static` always exists after a build.
+const copies = [
+  [join(root, '.next', 'static'), join(standaloneDir, '.next', 'static')],
+  [join(root, 'public'), join(standaloneDir, 'public')],
+]
+
+for (const [src, dest] of copies) {
+  if (!existsSync(src)) {
+    console.log(`[standalone-postbuild] skip (absent): ${src}`)
+    continue
+  }
+  cpSync(src, dest, { recursive: true })
+  console.log(`[standalone-postbuild] copied ${src} -> ${dest}`)
+}
+
+console.log('[standalone-postbuild] done')


### PR DESCRIPTION
## Summary

- Adopt Next.js `output: 'standalone'` on Railway/Railpack: `pnpm build` now emits a self-contained `.next/standalone`, and `pnpm start` serves it via `node .next/standalone/server.js` — shipping only traced production deps instead of the full `node_modules`.
- **~10× smaller runtime payload**: standalone is ~97M locally vs the current ~1.1G `node_modules` (even leaner on Railway). Smaller image → faster deploys, cold starts, and `restartPolicy` recoveries.
- No behavior change to the app — admin, REST API, static/public assets, uploads path, and `prodMigrations`-on-boot all work against the standalone server.

## Changes

- `next.config.mjs` — `output: 'standalone'`; plus `outputFileTracingExcludes` to keep dev-only `media/`/`seeds/`/tests out of the trace (see _Notes_ — without it the trace balloons to ~19G).
- `scripts/standalone-postbuild.mjs` _(new)_ — copies `.next/static` + `public/` next to `server.js` (Next does **not** copy these for standalone). Runs as part of `pnpm build`.
- `package.json` — `build` chains the postbuild; `start` → `HOSTNAME=0.0.0.0 NODE_OPTIONS=--max-http-header-size=65536 node .next/standalone/server.js` (preserves the recent max-header-size bump; adds the `0.0.0.0` bind Railway needs).
- `railway.toml` / `DEPLOYMENT.md` — `startCommand` stays `pnpm start` (single source of truth in package.json); docs/comments updated.

## Test Results

- Lint: ✓ no errors
- Unit: ✓ 366 passed (28 files)
- Integration/E2E: N/A here — this is a build-output/serving change with no sensible Vitest surface; validated by a real standalone boot (below) + the Railway preview + CI.
- **Local standalone boot** (`node .next/standalone/server.js` against local Postgres):
  - `/api/health` → 200
  - `/admin` → 200 (47 KB HTML) and its referenced `/_next/static/.../*.js` chunk → 200 (postbuild copy works)
  - `/api/meditations` → 403 (correct unauthenticated access-control denial — route executed)
  - `/robots.txt` → 200 (from `public/`)
  - `prodMigrations` ran on first boot (`Migrated: 20260606_050852_initial_schema`) and **no-op'd on the next boot** ✓

## Manual verification (on the Railway PR preview)

The deploy-level acceptance criteria can only be confirmed on a real preview deploy — please verify on this PR's Railway preview:

1. Admin UI loads with styling/assets (no 404s in the network tab).
2. REST API responds (e.g. `/api/health`, an authed collection read).
3. An upload round-trips to R2 and Live Preview renders.
4. Boot logs show migrations no-op (already applied), and the build image is meaningfully smaller than the previous `next start` image.

## Notes for reviewer

- **Tracing over-copy (the one non-obvious bit):** with Turbopack, `output: 'standalone'` traced dev-only `media/` (16G) and `seeds/` (2.7G) into `.next/standalone`, making a local `pnpm build` ~19G. `outputFileTracingExcludes` drops these → 97M. `.railwayignore` already strips them from Railway's upload, so this mainly fixes the local-build experience and makes the size win not depend solely on `.railwayignore`.
- `payload`/`@payloadcms` are traced into `.next/standalone/node_modules/.pnpm` (the top-level `node_modules/payload` symlink is absent, but the bundled server resolves via `.pnpm` — confirmed working by the boot test above).
- **CI doesn't run `pnpm build`** (it's lint + unit + integration). The standalone build is exercised by the Railway preview deploy and its smoke specs — so a green CI here does **not** by itself prove the standalone build; the preview does.

Closes #471

🤖 Generated with [Claude Code](https://claude.com/claude-code)
