### PR TITLE
feat(admin): clearable pill for AddressSearchField + config

### DIFF
--- a/src/app/(payload)/custom.scss
+++ b/src/app/(payload)/custom.scss
@@ -70,6 +70,13 @@
   color: var(--theme-text);
 }
 
+/* The selected value renders as a single clearable pill inside a ReactSelect
+   control (chevron + clear-all removed). Force it full width so the control
+   matches the search box it replaces. */
+.field-type.address-search .react-select {
+  width: 100%;
+}
+
 /* ============================================================================
    5. STRING SELECT FIELD (StringSelectField — country/region dropdowns)
    ============================================================================ */

--- a/src/collections/Regions/Regions.ts
+++ b/src/collections/Regions/Regions.ts
@@ -44,6 +44,7 @@ export const Regions: CollectionConfig = {
     group: 'Classes',
     useAsTitle: 'name',
     defaultColumns: ['name', 'level'],
+    groupBy: true,
   },
   hooks: {
     // Inherit eventDefaults (language + timeZone) from the nearest ancestor when blank.
@@ -115,6 +116,10 @@ export const Regions: CollectionConfig = {
                   },
                   searchTypes: 'country,region,place,poi', // fallback if level unset
                   populateName: true,
+                  allowManual: true,
+                  // A country must be geocoded (no hand-entered coordinates).
+                  allowManualByValue: { country: false },
+                  placeholder: 'Search for location...',
                 },
                 description:
                   'Search for this place (country, region, city, or venue) to set its geographic identity, or "Enter manually" to provide your own coordinates.',

--- a/src/components/admin/AddressSearchField/AddressSearchField.tsx
+++ b/src/components/admin/AddressSearchField/AddressSearchField.tsx
@@ -2,7 +2,16 @@
 
 import type { TextFieldClientComponent } from 'payload'
 
-import { FieldLabel, useField, useForm } from '@payloadcms/ui'
+import {
+  Banner,
+  FieldDescription,
+  FieldError,
+  FieldLabel,
+  ReactSelect,
+  type ReactSelectOption,
+  useField,
+  useForm,
+} from '@payloadcms/ui'
 import dynamic from 'next/dynamic'
 import React, { useEffect, useState } from 'react'
 
@@ -37,6 +46,8 @@ interface MapboxTheme {
 interface MapboxSearchBoxProps {
   accessToken: string
   onRetrieve?: (res: MapboxRetrieveResponse) => void
+  value?: string
+  onChange?: (value: string) => void
   placeholder?: string
   options?: { language?: string; types?: string; country?: string }
   theme?: MapboxTheme
@@ -153,8 +164,9 @@ const MANUAL = 'manual'
  * `manual` sentinel — also the fallback when no `NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN`
  * is configured.
  */
-export const AddressSearchField: TextFieldClientComponent = ({ field, path }) => {
-  const { label, admin } = field
+export const AddressSearchField: TextFieldClientComponent = ({ field, path, readOnly }) => {
+  const { label, localized, required, admin } = field
+  const description = admin?.description
   // `searchTypes`: Mapbox Search Box `types` filter (default address+POI).
   // `populateAddress`: fill sibling address fields on retrieve (default off —
   // Regions use this in id-only mode, where there are no address siblings).
@@ -165,12 +177,20 @@ export const AddressSearchField: TextFieldClientComponent = ({ field, path }) =>
     populateName?: boolean
     searchTypesField?: string
     searchTypesByValue?: Record<string, string>
+    placeholder?: string
+    allowManual?: boolean
+    allowManualByValue?: Record<string, boolean>
   }
 
-  const { value, setValue } = useField<string>({ path })
+  const { value, setValue, showError } = useField<string>({ path })
   const { dispatchFields, getDataByPath } = useForm()
   const theme = usePayloadSearchTheme()
   const token = process.env.NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN
+
+  // Controlled search-box text. The box stays mounted (just hidden) while a
+  // value is selected, so clearing the pill returns to it without a remount
+  // flicker; resetting this empties the input on clear.
+  const [query, setQuery] = useState('')
 
   // Scope the Mapbox `types` filter to a sibling field's value when configured
   // (Regions narrow the search by `level`); read it reactively via useField so
@@ -183,6 +203,16 @@ export const AddressSearchField: TextFieldClientComponent = ({ field, path }) =>
     (config.searchTypesField ? config.searchTypesByValue?.[scopeValue ?? ''] : undefined) ??
     config.searchTypes ??
     'address,poi'
+
+  // Whether "Enter manually" is offered, resolved the same data-driven way as
+  // `searchTypes`: a per-scope override (e.g. Regions disallow it at `country`
+  // level) wins, then the static `allowManual`, then off. (Functions can't be
+  // passed through `admin.custom` — it's serialized to the client — so this is
+  // data, not a condition function.)
+  const manualAllowed =
+    (config.searchTypesField ? config.allowManualByValue?.[scopeValue ?? ''] : undefined) ??
+    config.allowManual ??
+    false
 
   // Only fill a sibling that isn't already populated, so a chosen result never
   // clobbers a value the user (or a prior selection) already set.
@@ -222,39 +252,80 @@ export const AddressSearchField: TextFieldClientComponent = ({ field, path }) =>
     setValue(feature.properties?.mapbox_id ?? MANUAL)
   }
 
+  const fieldClasses = [
+    'field-type',
+    'address-search',
+    showError && 'error',
+    readOnly && 'read-only',
+  ]
+    .filter(Boolean)
+    .join(' ')
+
   return (
-    <div className="field-type address-search">
-      <FieldLabel label={label} path={path} />
-      {token && theme ? (
-        // Mount only once the theme is resolved, and remount on light/dark
-        // toggle (key), so the search box always paints with the correct,
-        // concrete colors rather than Mapbox's default dark text.
-        <SearchBox
-          key={`${theme.variables?.colorText}:${searchTypes}`}
-          accessToken={token}
-          onRetrieve={handleRetrieve}
-          placeholder="Search for your address…"
-          options={{ types: searchTypes, language: 'en' }}
-          theme={theme}
-        />
-      ) : null}
-      {!value ? (
-        <button type="button" className="address-search__toggle" onClick={() => setValue(MANUAL)}>
-          Enter manually
-        </button>
-      ) : null}
-      {value && value !== MANUAL ? (
-        <div
-          style={{
-            marginTop: 'calc(var(--base) * 0.3)',
-            fontSize: 'calc(var(--base-body-size) * 1px * 0.85)',
-            color: 'var(--theme-elevation-400)',
-            opacity: 0.7,
-          }}
-        >
-          Mapbox ID: {value}
-        </div>
-      ) : null}
+    <div className={fieldClasses}>
+      <FieldLabel label={label} localized={localized} path={path} required={required} />
+      <div className="field-type__wrap">
+        <FieldError path={path} showError={showError} />
+        {/* Selected: the stored id (or the `manual` sentinel) shown as a single
+            pill inside an input-styled control — the same chip ReactSelect
+            renders, so it matches the rest of the admin. The dropdown chevron
+            and clear-all indicator are removed (no menu here); the pill's own ✕
+            clears it, which resets the value, re-reveals the search box, and
+            re-hides the dependent fields. */}
+        {value ? (
+          <ReactSelect
+            className="address-search__selected"
+            isMulti
+            isClearable={false}
+            isSearchable={false}
+            menuIsOpen={false}
+            disabled={readOnly}
+            options={[]}
+            value={
+              [
+                { label: value == MANUAL ? 'Manual' : value, value },
+              ] as unknown as ReactSelectOption[]
+            }
+            onChange={() => {
+              setQuery('')
+              setValue('')
+            }}
+            components={{
+              DropdownIndicator: () => null,
+              IndicatorSeparator: () => null,
+            }}
+          />
+        ) : null}
+        {/* Kept mounted (just hidden) while a value is selected so clearing the
+            pill returns to it without a remount flicker. Remounts only on
+            light/dark toggle or a search-scope change (key), so it always
+            paints with concrete colors rather than Mapbox's default dark text. */}
+        {token && theme && !readOnly ? (
+          <div style={value ? { display: 'none' } : undefined}>
+            <SearchBox
+              key={`${theme.variables?.colorText}:${searchTypes}`}
+              accessToken={token}
+              onRetrieve={handleRetrieve}
+              value={query}
+              onChange={setQuery}
+              placeholder={config.placeholder ?? 'Search for your address…'}
+              options={{ types: searchTypes, language: 'en' }}
+              theme={theme}
+            />
+          </div>
+        ) : null}
+        {!value && manualAllowed && !readOnly ? (
+          <button type="button" className="address-search__toggle" onClick={() => setValue(MANUAL)}>
+            Enter manually
+          </button>
+        ) : null}
+        {!value && !token && !manualAllowed && !readOnly ? (
+          <Banner type="error">
+            Address search needs a Mapbox access token, and manual entry isn’t available here.
+          </Banner>
+        ) : null}
+        <FieldDescription description={description} path={path} />
+      </div>
     </div>
   )
 }

--- a/src/components/admin/AddressSearchField/AddressSearchField.tsx
+++ b/src/components/admin/AddressSearchField/AddressSearchField.tsx
@@ -261,6 +261,11 @@ export const AddressSearchField: TextFieldClientComponent = ({ field, path, read
     .filter(Boolean)
     .join(' ')
 
+  // Empty-state affordances (the pill replaces these once a value is set).
+  const showManualButton = !value && manualAllowed && !readOnly
+  // Dead end: nothing can fill the field — no search box and no manual entry.
+  const showNoInputBanner = !value && !token && !manualAllowed && !readOnly
+
   return (
     <div className={fieldClasses}>
       <FieldLabel label={label} localized={localized} path={path} required={required} />
@@ -283,7 +288,7 @@ export const AddressSearchField: TextFieldClientComponent = ({ field, path, read
             options={[]}
             value={
               [
-                { label: value == MANUAL ? 'Manual' : value, value },
+                { label: value === MANUAL ? 'Manual' : value, value },
               ] as unknown as ReactSelectOption[]
             }
             onChange={() => {
@@ -314,12 +319,12 @@ export const AddressSearchField: TextFieldClientComponent = ({ field, path, read
             />
           </div>
         ) : null}
-        {!value && manualAllowed && !readOnly ? (
+        {showManualButton ? (
           <button type="button" className="address-search__toggle" onClick={() => setValue(MANUAL)}>
             Enter manually
           </button>
         ) : null}
-        {!value && !token && !manualAllowed && !readOnly ? (
+        {showNoInputBanner ? (
           <Banner type="error">
             Address search needs a Mapbox access token, and manual entry isn’t available here.
           </Banner>

--- a/src/fields/addressFields.ts
+++ b/src/fields/addressFields.ts
@@ -76,7 +76,7 @@ export function addressFields(options: AddressFieldsOptions = {}): Field {
               label: 'Address',
               admin: {
                 components: { Field: ADDRESS_SEARCH_FIELD },
-                custom: { searchTypes: 'address,poi', populateAddress: true },
+                custom: { searchTypes: 'address,poi', populateAddress: true, allowManual: true },
               },
             },
           ]


### PR DESCRIPTION
## Summary

Reworks the `AddressSearchField` (the Mapbox-backed location field used by the Events address and the Regions location) so a selected value reads like a normal Payload field, and makes the field configurable.

- **Selected value is now a clearable pill** rendered with `ReactSelect` (so it's visually identical to a built-in clearable `hasMany` select), replacing the low-contrast `Mapbox ID: …` line. The dropdown chevron and clear-all indicator are removed — only the pill's own ✕ clears it.
- **No clear flicker** — the Mapbox `SearchBox` stays mounted (hidden via `display: none`) while a value is set, and is controlled, so clearing the pill returns to a fresh empty search box without a remount.
- **Proper field markup** — wrapped in `FieldLabel` / `FieldError` / `FieldDescription`, and honours `readOnly`. The Regions field's description now actually renders.
- **New `admin.custom` options:**
  - `placeholder` — overrides the search-box placeholder (set to `Search for location...` in Regions).
  - `allowManual` — gates the "Enter manually" button (enabled for both the Events address and Regions).
  - `allowManualByValue` — per-scope override keyed off the same sibling field as `searchTypesByValue`; Regions disallows manual entry at `country` level (a country must be geocoded).
- **Dead-end guard** — when there's no Mapbox token *and* manual entry is disallowed, an error `Banner` explains the field can't be filled.

Also includes a small unrelated `admin.groupBy: true` on Regions (kept intentionally).

## Why

The previous selected state didn't match the rest of the admin UI, the configured Regions description was never shown, and manual entry / placeholder couldn't be tuned per field. `allowManual` is expressed as data (not a function) because `admin.custom` is serialized to the client field component, mirroring the existing `searchTypes` / `searchTypesByValue` pattern.

## Testing

- `pnpm lint` ✅
- `pnpm test:unit` ✅ (531 passed)
- Ran `/simplify` (named the empty-state guards, strict-equality on the `manual` label) and `/code-review` over the branch diff.

No automated test is added — this is a Mapbox-driven client field component with no existing test harness (consistent with the approved plan). Please verify manually:

- **Regions** create/edit: description renders; placeholder is `Search for location...`; `level = country` hides "Enter manually" (other levels show it); picking a result shows the pill (with `name` auto-filled); clearing the pill returns to the search box; saving empty shows the required error.
- **Events** offline address: "Enter manually" present; picking a result shows the pill and fills the sibling address fields.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
