### PR TITLE
feat(storage): per-env Cloudflare Images/Stream/R2 isolation for previews

### DIFF
--- a/.claude/rules/storage.md
+++ b/.claude/rules/storage.md
@@ -41,13 +41,17 @@ implemented in `previewIsolation.ts` and a **no-op in production**:
 | R2                | `preview-` prefix on the object key (filename)  | refuse keys without the prefix      |
 | Cloudflare Stream | `meta.env=preview` tag (UIDs aren't caller-set) | GET the video, refuse unless tagged |
 
-**"Is this production?" is origin-based, not `NODE_ENV`-based.** Railway previews
-run with `NODE_ENV=production`, so they can't be told apart from prod that way.
-`isProductionDeployment()` is true only when `SAHAJCLOUD_URL`'s host is the
-canonical prod origin (`cloud.sydevelopers.com`). It **fails safe**: any
-unrecognized / unset origin is treated as non-production, so the guard stays
-active and prod assets stay protected. **Production must set `SAHAJCLOUD_URL` to
-its public origin** (already required for CSRF) so its own deletes work.
+**"Is this production?" keys off the Railway environment name, not `NODE_ENV`
+and not the origin.** Railway previews run with `NODE_ENV=production`, AND they
+inherit the shared `SAHAJCLOUD_URL` service variable (so the origin is identical
+on a preview and on prod) — neither can tell them apart. Instead,
+`isProductionDeployment()` is true only when the platform-injected
+`RAILWAY_ENVIRONMENT_NAME` (fallback `RAILWAY_ENVIRONMENT`) equals `production`;
+PR previews are `pr-<number>` (see RAILWAY_RUNBOOK.md). It **fails safe**: any
+other / unknown environment name is treated as non-production, so the guard
+stays active and prod assets stay protected. The only failure mode is prod
+self-isolating if its environment were misnamed — loud (prod can't delete its
+own assets), never destructive.
 
 **The delete guard is the safety mechanism.** In non-prod, each adapter's
 `handleDelete` refuses any asset that doesn't carry the preview marker — so a

--- a/.claude/rules/storage.md
+++ b/.claude/rules/storage.md
@@ -23,6 +23,59 @@ Filenames are sanitized to URL-safe slugs with random 6-char suffixes.
 Development falls back to local file storage when Cloudflare credentials
 are unset — no setup required.
 
+## Preview / non-production isolation
+
+Cloudflare **Images** and **Stream** are account-scoped, and R2 is a single
+shared bucket — so **every deployment (production, Railway PR previews, staging,
+dev) reads and writes the same namespaces**. Preview databases are sanitized
+clones of production and therefore reference real prod asset IDs. Without a
+guard, a preview deploy could upload into the prod namespace or — far worse —
+**delete a production asset** (issue #432).
+
+Isolation is "namespacing within the single account" (issue #432, Option B),
+implemented in `previewIsolation.ts` and a **no-op in production**:
+
+| Backend           | Non-prod upload marker                          | Delete guard (non-prod)             |
+| ----------------- | ----------------------------------------------- | ----------------------------------- |
+| Cloudflare Images | `preview-` prefix on the custom ID              | refuse IDs without the prefix       |
+| R2                | `preview-` prefix on the object key (filename)  | refuse keys without the prefix      |
+| Cloudflare Stream | `meta.env=preview` tag (UIDs aren't caller-set) | GET the video, refuse unless tagged |
+
+**"Is this production?" is origin-based, not `NODE_ENV`-based.** Railway previews
+run with `NODE_ENV=production`, so they can't be told apart from prod that way.
+`isProductionDeployment()` is true only when `SAHAJCLOUD_URL`'s host is the
+canonical prod origin (`cloud.sydevelopers.com`). It **fails safe**: any
+unrecognized / unset origin is treated as non-production, so the guard stays
+active and prod assets stay protected. **Production must set `SAHAJCLOUD_URL` to
+its public origin** (already required for CSRF) so its own deletes work.
+
+**The delete guard is the safety mechanism.** In non-prod, each adapter's
+`handleDelete` refuses any asset that doesn't carry the preview marker — so a
+preview can never delete a cloned prod asset. Production short-circuits the guard
+and behaves exactly as before (no prefix, no extra API calls). Proven by
+`tests/unit/storageIsolationGuard.spec.ts`; the Image upload path is smoke-tested
+in `tests/e2e/images.e2e.spec.ts`.
+
+**Cleanup.** Preview uploads accumulate in the shared account/bucket, so a daily
+GitHub Actions job (`.github/workflows/cleanup-preview-assets.yml` →
+`scripts/cleanup-preview-assets.ts`) reaps preview-marked assets older than 7
+days across all three backends. The reap predicate (`isReapablePreviewAsset`)
+only deletes assets that are **both** marked **and** past the cutoff; the script
+defaults to a dry run (`--apply` to delete). Required GitHub secrets:
+`CLOUDFLARE_ACCOUNT_ID`, `CLOUDFLARE_API_KEY`, and (for R2) `R2_BUCKET`,
+`R2_ACCESS_KEY_ID`, `R2_SECRET_ACCESS_KEY` [, `R2_S3_ENDPOINT`].
+
+### Manual safety verification (one-time, per #432 AC)
+
+Run once against a real preview to confirm the guard end-to-end:
+
+1. In the preview admin, find an image whose `filename` has **no** `preview-`
+   prefix (a row cloned from prod).
+2. Delete it from the preview admin.
+3. Confirm the underlying Cloudflare image still resolves at
+   `https://imagedelivery.net/<hash>/<id>/public` — the local admin row is gone,
+   but the shared prod asset must survive.
+
 ## Module layout (`src/plugins/storage/`)
 
 | File                         | Purpose                                                                        |

--- a/.github/workflows/cleanup-preview-assets.yml
+++ b/.github/workflows/cleanup-preview-assets.yml
@@ -1,0 +1,57 @@
+name: Cleanup preview assets
+
+# Reaps preview-namespaced Cloudflare Images / Stream / R2 assets older than the
+# cutoff (issue #432). Non-prod deploys mark every upload with a `preview-`
+# prefix (Images/R2) or `meta.env=preview` tag (Stream); this job deletes the
+# stale ones so preview test uploads don't accumulate in the shared account.
+# Only preview-marked assets are ever deleted — see scripts/cleanup-preview-assets.ts.
+
+on:
+  schedule:
+    - cron: '0 4 * * *' # daily at 04:00 UTC
+  workflow_dispatch:
+    inputs:
+      days:
+        description: 'Delete preview assets older than this many days'
+        required: false
+        default: '7'
+      apply:
+        description: 'Actually delete (leave unchecked for a dry run)'
+        type: boolean
+        required: false
+        default: false
+
+permissions:
+  contents: read
+
+concurrency:
+  group: cleanup-preview-assets
+  cancel-in-progress: false
+
+jobs:
+  cleanup:
+    name: Reap preview-namespaced storage assets
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+      CLOUDFLARE_API_KEY: ${{ secrets.CLOUDFLARE_API_KEY }}
+      R2_BUCKET: ${{ secrets.R2_BUCKET }}
+      R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+      R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+      R2_S3_ENDPOINT: ${{ secrets.R2_S3_ENDPOINT }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      # Scheduled runs always delete. Manual runs delete only when `apply` is
+      # checked; otherwise they print a dry-run report.
+      - name: Cleanup preview assets
+        run: >-
+          pnpm tsx scripts/cleanup-preview-assets.ts
+          --days ${{ github.event.inputs.days || '7' }}
+          ${{ (github.event_name == 'schedule' || github.event.inputs.apply == 'true') && '--apply' || '' }}

--- a/.github/workflows/cleanup-preview-assets.yml
+++ b/.github/workflows/cleanup-preview-assets.yml
@@ -50,6 +50,11 @@ jobs:
       - run: pnpm install --frozen-lockfile
       # Scheduled runs always delete. Manual runs delete only when `apply` is
       # checked; otherwise they print a dry-run report.
+      #
+      # This job is inert until the Cloudflare/R2 secrets are added (the script
+      # exits early without them). Before relying on the scheduled --apply, run
+      # this workflow once via "Run workflow" with `apply` UNCHECKED and review
+      # the dry-run output against real data.
       - name: Cleanup preview assets
         run: >-
           pnpm tsx scripts/cleanup-preview-assets.ts

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -601,6 +601,7 @@ The migration is **complete and live**: `cloud.sydevelopers.com` is served from 
 - **Storage** — R2 reached via the S3 API (`@aws-sdk/client-s3`); Cloudflare Images + Stream kept. Uploads verified end-to-end (R2 + Images).
 - **Cutover** — `cloud.sydevelopers.com` repointed to Railway and **proxied** through Cloudflare (edge cache + WAF retained; SSL Full). The Stream webhook was re-registered to the Railway URL and its secret set.
 - **Per-PR previews** — Railway PR environments with CI smoke tests; `scripts/get-railway-preview-url.ts` discovers the preview URL from the Railway-posted GitHub commit status (via `GITHUB_TOKEN`) and the smoke specs self-seed the admin. Validated end-to-end.
+- **Preview storage isolation** — Cloudflare Images, Stream, and R2 are shared across every environment, so non-production deploys namespace uploads with a `preview-` marker (Stream uses `meta.env=preview`) and refuse to delete any unmarked (cloned-from-prod) asset. A daily `cleanup-preview-assets` workflow reaps old preview-marked assets; it needs the GitHub secrets `CLOUDFLARE_ACCOUNT_ID`, `CLOUDFLARE_API_KEY`, `R2_BUCKET`, `R2_ACCESS_KEY_ID`, `R2_SECRET_ACCESS_KEY`. Detail: `.claude/rules/storage.md` § "Preview / non-production isolation" (#432).
 
 ### Remaining (gated)
 

--- a/scripts/cleanup-preview-assets.ts
+++ b/scripts/cleanup-preview-assets.ts
@@ -1,0 +1,327 @@
+#!/usr/bin/env node
+/**
+ * Scheduled cleanup of preview-namespaced storage assets (issue #432).
+ *
+ * Non-production deployments (Railway PR previews, staging) namespace every
+ * upload with a `preview-` marker — an object-ID/key prefix for Cloudflare
+ * Images + R2, and a `meta.env=preview` tag for Cloudflare Stream (see
+ * `src/plugins/storage/previewIsolation.ts`). This script reaps those marked
+ * assets once they are older than `--days`, so preview test uploads don't pile
+ * up in the shared Cloudflare account / R2 bucket.
+ *
+ * SAFETY: an asset is deleted only when it is BOTH preview-marked AND older than
+ * the cutoff (`isReapablePreviewAsset`). Production assets carry no marker and
+ * are never touched. The script defaults to a DRY RUN; pass `--apply` to delete.
+ *
+ * Usage:
+ *   pnpm tsx scripts/cleanup-preview-assets.ts                  # dry run, 7-day cutoff
+ *   pnpm tsx scripts/cleanup-preview-assets.ts --apply          # actually delete
+ *   pnpm tsx scripts/cleanup-preview-assets.ts --days 3 --apply
+ *
+ * Env required (Images + Stream):
+ *   CLOUDFLARE_ACCOUNT_ID
+ *   CLOUDFLARE_API_KEY        (token with Images:Edit + Stream:Edit)
+ * Env required for R2 cleanup (R2 step is skipped when any is unset):
+ *   R2_BUCKET, R2_ACCESS_KEY_ID, R2_SECRET_ACCESS_KEY  [, R2_S3_ENDPOINT]
+ */
+import { DeleteObjectCommand, ListObjectsV2Command, S3Client } from '@aws-sdk/client-s3'
+import { z } from 'zod'
+
+import {
+  isPreviewOwnedKey,
+  isPreviewOwnedVideoMeta,
+  isReapablePreviewAsset,
+} from '../src/plugins/storage/previewIsolation'
+
+const DEFAULT_MAX_AGE_DAYS = 7
+const CF_API_BASE = 'https://api.cloudflare.com/client/v4'
+
+interface Args {
+  apply: boolean
+  days: number
+}
+
+interface ReapSummary {
+  backend: string
+  scanned: number
+  reaped: number
+}
+
+function parseArgs(argv: string[]): Args {
+  const args: Args = { apply: false, days: DEFAULT_MAX_AGE_DAYS }
+  for (let i = 2; i < argv.length; i++) {
+    const arg = argv[i]
+    if (arg === '--apply' || arg === '--force') {
+      args.apply = true
+    } else if (arg === '--days') {
+      const value = Number(argv[++i])
+      if (!Number.isFinite(value) || value < 0) {
+        console.error('--days must be a non-negative number')
+        process.exit(1)
+      }
+      args.days = value
+    } else if (arg === '--help' || arg === '-h') {
+      printUsage()
+      process.exit(0)
+    } else {
+      console.error(`Unknown argument: ${arg}`)
+      printUsage()
+      process.exit(1)
+    }
+  }
+  return args
+}
+
+function printUsage(): void {
+  console.error(
+    [
+      'Usage:',
+      '  pnpm tsx scripts/cleanup-preview-assets.ts [--days <n>] [--apply]',
+      '',
+      'Defaults to a dry run (no deletes). Pass --apply to delete.',
+      'Env: CLOUDFLARE_ACCOUNT_ID, CLOUDFLARE_API_KEY [, R2_BUCKET, R2_ACCESS_KEY_ID, R2_SECRET_ACCESS_KEY, R2_S3_ENDPOINT]',
+    ].join('\n'),
+  )
+}
+
+function requireEnv(name: string): string {
+  const value = process.env[name]
+  if (!value || value.length === 0) {
+    console.error(`Missing required env var: ${name}`)
+    process.exit(1)
+  }
+  return value
+}
+
+/** Parse a Cloudflare ISO timestamp, returning null when absent/invalid. */
+function parseDate(value: string | undefined): Date | null {
+  if (!value) return null
+  const date = new Date(value)
+  return Number.isNaN(date.getTime()) ? null : date
+}
+
+const ImagesListSchema = z.object({
+  success: z.boolean(),
+  errors: z.array(z.object({ code: z.number().optional(), message: z.string() })).default([]),
+  result: z
+    .object({
+      images: z.array(z.object({ id: z.string(), uploaded: z.string().optional() })).default([]),
+    })
+    .nullish(),
+})
+
+const StreamListSchema = z.object({
+  success: z.boolean(),
+  errors: z.array(z.object({ code: z.number().optional(), message: z.string() })).default([]),
+  result: z
+    .array(
+      z.object({
+        uid: z.string(),
+        created: z.string().optional(),
+        meta: z.record(z.string(), z.string()).optional(),
+      }),
+    )
+    .default([]),
+})
+
+async function cfFetch(method: 'GET' | 'DELETE', path: string, apiKey: string): Promise<unknown> {
+  const response = await fetch(`${CF_API_BASE}${path}`, {
+    method,
+    headers: { Authorization: `Bearer ${apiKey}` },
+  })
+  return response.json()
+}
+
+/**
+ * Reap preview-marked Cloudflare Images older than the cutoff. Images expose a
+ * caller-chosen custom ID, so the marker is the `preview-` ID prefix.
+ */
+async function reapImages(
+  accountId: string,
+  apiKey: string,
+  now: Date,
+  days: number,
+  apply: boolean,
+): Promise<ReapSummary> {
+  let page = 1
+  let scanned = 0
+  let reaped = 0
+  const perPage = 100
+
+  for (;;) {
+    const json = await cfFetch(
+      'GET',
+      `/accounts/${accountId}/images/v1?page=${page}&per_page=${perPage}`,
+      apiKey,
+    )
+    const parsed = ImagesListSchema.parse(json)
+    if (!parsed.success) {
+      throw new Error(
+        `Cloudflare Images list failed: ${parsed.errors.map((e) => e.message).join(', ')}`,
+      )
+    }
+    const images = parsed.result?.images ?? []
+    scanned += images.length
+
+    for (const image of images) {
+      if (
+        !isReapablePreviewAsset(isPreviewOwnedKey(image.id), parseDate(image.uploaded), now, days)
+      ) {
+        continue
+      }
+      console.log(
+        `  [images] ${apply ? 'delete' : 'would delete'} ${image.id} (uploaded ${image.uploaded ?? '?'})`,
+      )
+      if (apply) {
+        await cfFetch('DELETE', `/accounts/${accountId}/images/v1/${image.id}`, apiKey)
+      }
+      reaped += 1
+    }
+
+    if (images.length < perPage) break
+    page += 1
+  }
+
+  return { backend: 'Cloudflare Images', scanned, reaped }
+}
+
+/**
+ * Reap preview-marked Cloudflare Stream videos older than the cutoff. Stream
+ * UIDs are assigned by Cloudflare, so the marker lives in `meta.env=preview`.
+ *
+ * Note: `GET /stream` returns the most recent ~1000 videos; preview video
+ * uploads are rare (smoke tests don't upload video), so a single listing is
+ * sufficient. A warning is logged if the cap is reached.
+ */
+async function reapStream(
+  accountId: string,
+  apiKey: string,
+  now: Date,
+  days: number,
+  apply: boolean,
+): Promise<ReapSummary> {
+  const json = await cfFetch('GET', `/accounts/${accountId}/stream`, apiKey)
+  const parsed = StreamListSchema.parse(json)
+  if (!parsed.success) {
+    throw new Error(
+      `Cloudflare Stream list failed: ${parsed.errors.map((e) => e.message).join(', ')}`,
+    )
+  }
+
+  const videos = parsed.result
+  if (videos.length >= 1000) {
+    console.warn(
+      '  [stream] listing hit the ~1000-video cap; some old preview videos may be skipped this run',
+    )
+  }
+
+  let reaped = 0
+  for (const video of videos) {
+    if (
+      !isReapablePreviewAsset(
+        isPreviewOwnedVideoMeta(video.meta),
+        parseDate(video.created),
+        now,
+        days,
+      )
+    ) {
+      continue
+    }
+    console.log(
+      `  [stream] ${apply ? 'delete' : 'would delete'} ${video.uid} (created ${video.created ?? '?'})`,
+    )
+    if (apply) {
+      await cfFetch('DELETE', `/accounts/${accountId}/stream/${video.uid}`, apiKey)
+    }
+    reaped += 1
+  }
+
+  return { backend: 'Cloudflare Stream', scanned: videos.length, reaped }
+}
+
+/**
+ * Reap preview-marked R2 objects older than the cutoff. R2 keys are
+ * `<collection>/<filename>`; the marker is the `preview-` prefix on the
+ * filename segment.
+ */
+async function reapR2(now: Date, days: number, apply: boolean): Promise<ReapSummary | null> {
+  const bucket = process.env.R2_BUCKET
+  const accessKeyId = process.env.R2_ACCESS_KEY_ID
+  const secretAccessKey = process.env.R2_SECRET_ACCESS_KEY
+  if (!bucket || !accessKeyId || !secretAccessKey) {
+    console.log('  [r2] skipped (R2_BUCKET / R2_ACCESS_KEY_ID / R2_SECRET_ACCESS_KEY not set)')
+    return null
+  }
+
+  const accountId = process.env.CLOUDFLARE_ACCOUNT_ID
+  const client = new S3Client({
+    region: 'auto',
+    endpoint: process.env.R2_S3_ENDPOINT || `https://${accountId}.r2.cloudflarestorage.com`,
+    credentials: { accessKeyId, secretAccessKey },
+  })
+
+  let continuationToken: string | undefined
+  let scanned = 0
+  let reaped = 0
+
+  do {
+    const list = await client.send(
+      new ListObjectsV2Command({ Bucket: bucket, ContinuationToken: continuationToken }),
+    )
+    const objects = list.Contents ?? []
+    scanned += objects.length
+
+    for (const object of objects) {
+      const key = object.Key
+      if (!key) continue
+      const basename = key.split('/').pop() ?? key
+      const createdAt = object.LastModified ?? null
+      if (!isReapablePreviewAsset(isPreviewOwnedKey(basename), createdAt, now, days)) {
+        continue
+      }
+      console.log(
+        `  [r2] ${apply ? 'delete' : 'would delete'} ${key} (modified ${createdAt?.toISOString() ?? '?'})`,
+      )
+      if (apply) {
+        await client.send(new DeleteObjectCommand({ Bucket: bucket, Key: key }))
+      }
+      reaped += 1
+    }
+
+    continuationToken = list.IsTruncated ? list.NextContinuationToken : undefined
+  } while (continuationToken)
+
+  return { backend: 'R2', scanned, reaped }
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv)
+  const accountId = requireEnv('CLOUDFLARE_ACCOUNT_ID')
+  const apiKey = requireEnv('CLOUDFLARE_API_KEY')
+  const now = new Date()
+
+  console.log(
+    `Preview asset cleanup — cutoff ${args.days} day(s), ${args.apply ? 'APPLY (deleting)' : 'DRY RUN (no deletes)'}`,
+  )
+
+  const summaries: ReapSummary[] = []
+  summaries.push(await reapImages(accountId, apiKey, now, args.days, args.apply))
+  summaries.push(await reapStream(accountId, apiKey, now, args.days, args.apply))
+  const r2Summary = await reapR2(now, args.days, args.apply)
+  if (r2Summary) summaries.push(r2Summary)
+
+  console.log('\nSummary:')
+  for (const summary of summaries) {
+    console.log(
+      `  ${summary.backend}: scanned ${summary.scanned}, ${args.apply ? 'deleted' : 'reapable'} ${summary.reaped}`,
+    )
+  }
+  if (!args.apply) {
+    console.log('\nDry run complete. Re-run with --apply to delete the assets listed above.')
+  }
+}
+
+main().catch((error) => {
+  console.error(error)
+  process.exit(1)
+})

--- a/scripts/cleanup-preview-assets.ts
+++ b/scripts/cleanup-preview-assets.ts
@@ -55,8 +55,8 @@ function parseArgs(argv: string[]): Args {
       args.apply = true
     } else if (arg === '--days') {
       const value = Number(argv[++i])
-      if (!Number.isFinite(value) || value < 0) {
-        console.error('--days must be a non-negative number')
+      if (!Number.isInteger(value) || value < 0) {
+        console.error('--days must be a non-negative integer')
         process.exit(1)
       }
       args.days = value
@@ -200,7 +200,9 @@ async function reapStream(
   days: number,
   apply: boolean,
 ): Promise<ReapSummary> {
-  const json = await cfFetch('GET', `/accounts/${accountId}/stream`, apiKey)
+  // Oldest-first (`asc=true`) so a single page reaches the reapable (aged)
+  // videos even when the account exceeds the ~1000-video listing cap.
+  const json = await cfFetch('GET', `/accounts/${accountId}/stream?asc=true`, apiKey)
   const parsed = StreamListSchema.parse(json)
   if (!parsed.success) {
     throw new Error(

--- a/src/plugins/storage/cloudflareImagesAdapter.ts
+++ b/src/plugins/storage/cloudflareImagesAdapter.ts
@@ -12,6 +12,7 @@ import { serverEnv } from '@/lib/env'
 
 import { CloudflareImagesResponseSchema } from './cloudflareSchemas'
 import { applyFilename, generateCloudflareImageId } from './filenameUtils'
+import { applyPreviewPrefix, isPreviewOwnedKey, isStorageIsolationActive } from './previewIsolation'
 import { validateFileUpload } from './uploadValidation'
 
 /**
@@ -71,7 +72,10 @@ export const cloudflareImagesAdapter = (config: CloudflareImagesConfig): Adapter
         // Use a human-readable slug as the Cloudflare Image ID so the delivery
         // URL (.../<id>/public) is debuggable. CF rejects duplicate IDs; the
         // random suffix baked into the slug makes collisions negligible.
-        const customId = generateCloudflareImageId(file.filename)
+        // In non-prod, prefix the ID so the asset is namespaced to this
+        // deployment and the delete guard / cleanup can recognize it as
+        // preview-owned (see previewIsolation). No-op in production.
+        const customId = applyPreviewPrefix(generateCloudflareImageId(file.filename))
         const originalFilename = file.filename
 
         const formData = new FormData()
@@ -149,6 +153,17 @@ export const cloudflareImagesAdapter = (config: CloudflareImagesConfig): Adapter
     },
 
     handleDelete: async ({ filename: imageId }) => {
+      // Preview isolation: a non-production deployment must never delete a
+      // production image. Cloned preview DBs reference real prod image IDs,
+      // which carry no preview marker — refuse them here. No-op in production.
+      if (isStorageIsolationActive() && !isPreviewOwnedKey(imageId)) {
+        // eslint-disable-next-line no-console
+        console.warn(
+          `[Cloudflare Images] Refusing to delete non-preview image "${imageId}" from a non-production deployment`,
+        )
+        return
+      }
+
       try {
         const response = await fetch(
           `https://api.cloudflare.com/client/v4/accounts/${config.accountId}/images/v1/${imageId}`,

--- a/src/plugins/storage/cloudflareImagesAdapter.ts
+++ b/src/plugins/storage/cloudflareImagesAdapter.ts
@@ -12,7 +12,11 @@ import { serverEnv } from '@/lib/env'
 
 import { CloudflareImagesResponseSchema } from './cloudflareSchemas'
 import { applyFilename, generateCloudflareImageId } from './filenameUtils'
-import { applyPreviewPrefix, isPreviewOwnedKey, isStorageIsolationActive } from './previewIsolation'
+import {
+  applyPreviewPrefix,
+  isPreviewOwnedKey,
+  shouldRefusePreviewDelete,
+} from './previewIsolation'
 import { validateFileUpload } from './uploadValidation'
 
 /**
@@ -154,13 +158,13 @@ export const cloudflareImagesAdapter = (config: CloudflareImagesConfig): Adapter
 
     handleDelete: async ({ filename: imageId }) => {
       // Preview isolation: a non-production deployment must never delete a
-      // production image. Cloned preview DBs reference real prod image IDs,
-      // which carry no preview marker — refuse them here. No-op in production.
-      if (isStorageIsolationActive() && !isPreviewOwnedKey(imageId)) {
-        // eslint-disable-next-line no-console
-        console.warn(
-          `[Cloudflare Images] Refusing to delete non-preview image "${imageId}" from a non-production deployment`,
+      // production image (cloned preview DBs reference real prod image IDs,
+      // which carry no preview marker). No-op in production.
+      if (
+        await shouldRefusePreviewDelete('Cloudflare Images', imageId, () =>
+          isPreviewOwnedKey(imageId),
         )
+      ) {
         return
       }
 

--- a/src/plugins/storage/cloudflareStreamAdapter.ts
+++ b/src/plugins/storage/cloudflareStreamAdapter.ts
@@ -13,6 +13,12 @@ import { serverEnv } from '@/lib/env'
 
 import { CloudflareStreamResponseSchema } from './cloudflareSchemas'
 import { applyFilename } from './filenameUtils'
+import {
+  isPreviewOwnedVideoMeta,
+  isStorageIsolationActive,
+  PREVIEW_STREAM_META_KEY,
+  PREVIEW_STREAM_META_VALUE,
+} from './previewIsolation'
 import { validateFileUpload } from './uploadValidation'
 
 /**
@@ -82,6 +88,29 @@ export interface CloudflareStreamConfig {
  * })
  * ```
  */
+/**
+ * Whether a Cloudflare Stream video is preview-owned, read from its `meta` via
+ * GET. Used by the non-production delete guard. Fails safe: any error, missing
+ * video, or missing marker → `false` (refuse the delete), so a transient API
+ * hiccup can never delete a production video.
+ */
+const isPreviewOwnedStreamVideo = async (
+  config: CloudflareStreamConfig,
+  videoId: string,
+): Promise<boolean> => {
+  try {
+    const response = await fetch(
+      `https://api.cloudflare.com/client/v4/accounts/${config.accountId}/stream/${videoId}`,
+      { headers: { Authorization: `Bearer ${config.apiKey}` } },
+    )
+    if (!response.ok) return false
+    const result = CloudflareStreamResponseSchema.parse(await response.json())
+    return isPreviewOwnedVideoMeta(result.result?.meta)
+  } catch {
+    return false
+  }
+}
+
 export const cloudflareStreamAdapter = (config: CloudflareStreamConfig): Adapter => {
   return () => ({
     name: 'cloudflare-stream',
@@ -128,6 +157,35 @@ export const cloudflareStreamAdapter = (config: CloudflareStreamConfig): Adapter
 
         req.payload.logger.info({ msg: 'Video uploaded successfully', videoId })
 
+        // Preview isolation: in non-prod, tag the video as preview-owned so the
+        // delete guard + scheduled cleanup can identify it. Stream UIDs are
+        // assigned by Cloudflare (not caller-chosen), so the marker lives in
+        // `meta`. Best-effort — a tagging failure only means this video won't be
+        // auto-reaped; it must never break the (already-succeeded) upload.
+        if (isStorageIsolationActive()) {
+          try {
+            await fetch(
+              `https://api.cloudflare.com/client/v4/accounts/${config.accountId}/stream/${videoId}`,
+              {
+                method: 'POST',
+                headers: {
+                  Authorization: `Bearer ${config.apiKey}`,
+                  'Content-Type': 'application/json',
+                },
+                body: JSON.stringify({
+                  meta: { [PREVIEW_STREAM_META_KEY]: PREVIEW_STREAM_META_VALUE },
+                }),
+              },
+            )
+          } catch (error) {
+            req.payload.logger.warn({
+              msg: 'Failed to tag preview video; it will not be auto-reaped',
+              videoId,
+              error: error instanceof Error ? error.message : String(error),
+            })
+          }
+        }
+
         // Note: MP4 downloads are enabled asynchronously via a Cloudflare Stream webhook
         // once the video finishes transcoding. See src/app/(payload)/api/webhooks/cloudflare-stream/
         // and .claude/rules/storage.md.
@@ -168,6 +226,18 @@ export const cloudflareStreamAdapter = (config: CloudflareStreamConfig): Adapter
     },
 
     handleDelete: async ({ filename: videoId }) => {
+      // Preview isolation: a non-production deployment must never delete a
+      // production video. Stream UIDs aren't caller-chosen, so read the video's
+      // `meta` (GET) and refuse anything not marked preview-owned. The extra GET
+      // runs only in non-prod — production's delete path is unchanged.
+      if (isStorageIsolationActive() && !(await isPreviewOwnedStreamVideo(config, videoId))) {
+        // eslint-disable-next-line no-console
+        console.warn(
+          `[Cloudflare Stream] Refusing to delete non-preview video "${videoId}" from a non-production deployment`,
+        )
+        return
+      }
+
       try {
         const response = await fetch(
           `https://api.cloudflare.com/client/v4/accounts/${config.accountId}/stream/${videoId}`,

--- a/src/plugins/storage/cloudflareStreamAdapter.ts
+++ b/src/plugins/storage/cloudflareStreamAdapter.ts
@@ -165,7 +165,7 @@ export const cloudflareStreamAdapter = (config: CloudflareStreamConfig): Adapter
         // auto-reaped; it must never break the (already-succeeded) upload.
         if (isStorageIsolationActive()) {
           try {
-            await fetch(
+            const tagResponse = await fetch(
               `https://api.cloudflare.com/client/v4/accounts/${config.accountId}/stream/${videoId}`,
               {
                 method: 'POST',
@@ -178,8 +178,18 @@ export const cloudflareStreamAdapter = (config: CloudflareStreamConfig): Adapter
                 }),
               },
             )
+            // error-level (not warn) so a systematically broken tagger is
+            // visible: untagged preview videos are never auto-reaped, silently
+            // accumulating in the shared account.
+            if (!tagResponse.ok) {
+              req.payload.logger.error({
+                msg: 'Failed to tag preview video; it will not be auto-reaped',
+                videoId,
+                status: tagResponse.status,
+              })
+            }
           } catch (error) {
-            req.payload.logger.warn({
+            req.payload.logger.error({
               msg: 'Failed to tag preview video; it will not be auto-reaped',
               videoId,
               error: error instanceof Error ? error.message : String(error),

--- a/src/plugins/storage/cloudflareStreamAdapter.ts
+++ b/src/plugins/storage/cloudflareStreamAdapter.ts
@@ -18,6 +18,7 @@ import {
   isStorageIsolationActive,
   PREVIEW_STREAM_META_KEY,
   PREVIEW_STREAM_META_VALUE,
+  shouldRefusePreviewDelete,
 } from './previewIsolation'
 import { validateFileUpload } from './uploadValidation'
 
@@ -227,14 +228,14 @@ export const cloudflareStreamAdapter = (config: CloudflareStreamConfig): Adapter
 
     handleDelete: async ({ filename: videoId }) => {
       // Preview isolation: a non-production deployment must never delete a
-      // production video. Stream UIDs aren't caller-chosen, so read the video's
-      // `meta` (GET) and refuse anything not marked preview-owned. The extra GET
-      // runs only in non-prod — production's delete path is unchanged.
-      if (isStorageIsolationActive() && !(await isPreviewOwnedStreamVideo(config, videoId))) {
-        // eslint-disable-next-line no-console
-        console.warn(
-          `[Cloudflare Stream] Refusing to delete non-preview video "${videoId}" from a non-production deployment`,
+      // production video. Stream UIDs aren't caller-chosen, so the ownership
+      // check reads the video's `meta` via GET — deferred by the guard so it
+      // runs only in non-prod (production's delete path is unchanged).
+      if (
+        await shouldRefusePreviewDelete('Cloudflare Stream', videoId, () =>
+          isPreviewOwnedStreamVideo(config, videoId),
         )
+      ) {
         return
       }
 

--- a/src/plugins/storage/previewIsolation.ts
+++ b/src/plugins/storage/previewIsolation.ts
@@ -25,17 +25,18 @@
  */
 
 /**
- * Canonical production public origin host. Production is the ONLY deployment
- * served from this host; Railway PR previews use per-PR `*.railway.app` domains
- * and local/dev use localhost.
+ * Name of the production Railway environment.
  *
- * We key "is this real production?" off the origin rather than `NODE_ENV`
- * because Railway previews also run with `NODE_ENV=production` — so `NODE_ENV`
- * cannot tell a preview apart from prod. The same host is already hardcoded for
- * the Stream webhook + admin CSP, and `package.json`'s `seed:prod` pins
- * `SAHAJCLOUD_URL=https://cloud.sydevelopers.com`.
+ * Production is detected by the platform-injected Railway environment name —
+ * NOT by `NODE_ENV` (Railway previews also run `NODE_ENV=production`) and NOT by
+ * `SAHAJCLOUD_URL` (a shared service variable that Railway PR previews INHERIT
+ * from production, so the origin is identical on a preview and on prod and
+ * cannot tell them apart). Railway injects `RAILWAY_ENVIRONMENT(_NAME)` per
+ * environment: production is `production`; PR previews are `pr-<number>` (see
+ * RAILWAY_RUNBOOK.md). These vars are present at build + runtime (see
+ * `scripts/postinstall.cjs`).
  */
-export const PRODUCTION_ORIGIN_HOST = 'cloud.sydevelopers.com'
+export const PRODUCTION_ENVIRONMENT_NAME = 'production'
 
 /**
  * Marker prepended to Cloudflare Images custom IDs and R2 object keys in
@@ -56,29 +57,27 @@ export const PREVIEW_STREAM_META_KEY = 'env'
 export const PREVIEW_STREAM_META_VALUE = 'preview'
 
 /**
- * Pure origin check, split out so it can be unit-tested without touching the
- * environment. Returns true only when `url`'s host is the canonical prod host.
- * Fail-safe: missing or unparseable URLs return `false`.
+ * The current Railway environment name, or `undefined` off-Railway (local, CI,
+ * test). Reads `process.env` directly so the result reflects the live env and
+ * stays trivially testable — the pattern `payload.config.ts` uses for
+ * `process.env.NODE_ENV`. Prefers `RAILWAY_ENVIRONMENT_NAME`, falling back to
+ * the legacy `RAILWAY_ENVIRONMENT` (`scripts/postinstall.cjs` confirms the
+ * latter is set on Railway).
  */
-export const isProductionOrigin = (url: string | null | undefined): boolean => {
-  if (!url) return false
-  try {
-    return new URL(url).host === PRODUCTION_ORIGIN_HOST
-  } catch {
-    return false
-  }
-}
+export const railwayEnvironmentName = (): string | undefined =>
+  process.env.RAILWAY_ENVIRONMENT_NAME ?? process.env.RAILWAY_ENVIRONMENT
 
 /**
- * True only when this deployment is the canonical production origin.
+ * True only when this deployment is the production Railway environment.
  *
- * Reads `process.env.SAHAJCLOUD_URL` directly (not the validated `serverEnv`
- * proxy) so the result reflects the live env and stays trivially testable —
- * the same pattern `payload.config.ts` uses for `process.env.NODE_ENV`.
- * Fail-safe: any unrecognized / unset / unparseable origin → `false` → the
- * isolation guard stays ACTIVE, which protects production assets.
+ * Fail-safe: any other / unknown environment name (a `pr-*` preview, staging,
+ * local, CI, test) → `false` → the isolation guard stays ACTIVE, protecting
+ * production assets. The only failure mode is prod self-isolating if its
+ * environment were misnamed — loud (prod can't delete its own assets), never
+ * destructive.
  */
-export const isProductionDeployment = (): boolean => isProductionOrigin(process.env.SAHAJCLOUD_URL)
+export const isProductionDeployment = (): boolean =>
+  railwayEnvironmentName() === PRODUCTION_ENVIRONMENT_NAME
 
 /**
  * Whether storage isolation (upload prefixing + delete guard) is active for

--- a/src/plugins/storage/previewIsolation.ts
+++ b/src/plugins/storage/previewIsolation.ts
@@ -37,7 +37,18 @@
  */
 export const PRODUCTION_ORIGIN_HOST = 'cloud.sydevelopers.com'
 
-/** Marker prepended to Cloudflare Images custom IDs and R2 object keys in non-prod. */
+/**
+ * Marker prepended to Cloudflare Images custom IDs and R2 object keys in
+ * non-prod. Ownership is detected via `startsWith(PREVIEW_ASSET_PREFIX)`.
+ *
+ * KNOWN LIMITATION (inherent to Option B's policy-based marking — see #432): a
+ * production asset whose generated ID/key legitimately begins with `preview-`
+ * (e.g. a prod upload named "preview-banner.jpg") is classified as
+ * preview-owned. The cleanup job's marker-AND-age condition bounds the blast
+ * radius, but such an asset could in principle be deleted from a preview. If
+ * this surfaces in practice, harden the marker to a token the slug generator
+ * (lowercased `[a-z0-9-]`) cannot produce.
+ */
 export const PREVIEW_ASSET_PREFIX = 'preview-'
 
 /** Cloudflare Stream `meta` key/value stamped on non-prod video uploads. */

--- a/src/plugins/storage/previewIsolation.ts
+++ b/src/plugins/storage/previewIsolation.ts
@@ -1,0 +1,130 @@
+/**
+ * Preview / non-production storage isolation (Cloudflare Images, Stream, R2).
+ *
+ * Images, Stream, and R2 are account/bucket-scoped resources shared by EVERY
+ * deployment of this app: production, Railway per-PR previews, staging, and
+ * local dev all talk to the same Cloudflare account + R2 bucket. Cloned preview
+ * databases reference real production asset IDs, so without isolation a preview
+ * deploy could upload into — or, far worse, DELETE from — the production
+ * namespace (issue #432).
+ *
+ * Strategy ("Option B" — namespacing within the single account):
+ *  - Non-production uploads carry a `preview-` marker: an object-ID/key prefix
+ *    for Images + R2, and a `meta.env=preview` tag for Stream (whose UIDs are
+ *    assigned by Cloudflare, not the caller).
+ *  - Non-production deletes are GUARDED — an adapter refuses to delete any asset
+ *    that does not carry the marker, so a preview can never destroy a prod asset.
+ *  - A scheduled job (`scripts/cleanup-preview-assets.ts`) reaps marked assets.
+ *
+ * Production is untouched: every helper here is a no-op when
+ * `isProductionDeployment()` is true, honouring the "no new code paths in the
+ * production data plane" constraint — prod keeps its exact existing behaviour
+ * (no prefix, no guard, no extra API calls).
+ *
+ * See `.claude/rules/storage.md` § "Preview / non-production isolation".
+ */
+
+/**
+ * Canonical production public origin host. Production is the ONLY deployment
+ * served from this host; Railway PR previews use per-PR `*.railway.app` domains
+ * and local/dev use localhost.
+ *
+ * We key "is this real production?" off the origin rather than `NODE_ENV`
+ * because Railway previews also run with `NODE_ENV=production` — so `NODE_ENV`
+ * cannot tell a preview apart from prod. The same host is already hardcoded for
+ * the Stream webhook + admin CSP, and `package.json`'s `seed:prod` pins
+ * `SAHAJCLOUD_URL=https://cloud.sydevelopers.com`.
+ */
+export const PRODUCTION_ORIGIN_HOST = 'cloud.sydevelopers.com'
+
+/** Marker prepended to Cloudflare Images custom IDs and R2 object keys in non-prod. */
+export const PREVIEW_ASSET_PREFIX = 'preview-'
+
+/** Cloudflare Stream `meta` key/value stamped on non-prod video uploads. */
+export const PREVIEW_STREAM_META_KEY = 'env'
+export const PREVIEW_STREAM_META_VALUE = 'preview'
+
+/**
+ * Pure origin check, split out so it can be unit-tested without touching the
+ * environment. Returns true only when `url`'s host is the canonical prod host.
+ * Fail-safe: missing or unparseable URLs return `false`.
+ */
+export const isProductionOrigin = (url: string | null | undefined): boolean => {
+  if (!url) return false
+  try {
+    return new URL(url).host === PRODUCTION_ORIGIN_HOST
+  } catch {
+    return false
+  }
+}
+
+/**
+ * True only when this deployment is the canonical production origin.
+ *
+ * Reads `process.env.SAHAJCLOUD_URL` directly (not the validated `serverEnv`
+ * proxy) so the result reflects the live env and stays trivially testable —
+ * the same pattern `payload.config.ts` uses for `process.env.NODE_ENV`.
+ * Fail-safe: any unrecognized / unset / unparseable origin → `false` → the
+ * isolation guard stays ACTIVE, which protects production assets.
+ */
+export const isProductionDeployment = (): boolean => isProductionOrigin(process.env.SAHAJCLOUD_URL)
+
+/**
+ * Whether storage isolation (upload prefixing + delete guard) is active for
+ * this deployment. Active everywhere EXCEPT canonical production.
+ */
+export const isStorageIsolationActive = (): boolean => !isProductionDeployment()
+
+/**
+ * Prefix a Cloudflare Images custom ID or R2 object key with the preview marker
+ * when isolation is active. No-op in production; idempotent (never
+ * double-prefixes a key that is already marked).
+ */
+export const applyPreviewPrefix = (baseName: string): string => {
+  if (!isStorageIsolationActive()) return baseName
+  if (baseName.startsWith(PREVIEW_ASSET_PREFIX)) return baseName
+  return `${PREVIEW_ASSET_PREFIX}${baseName}`
+}
+
+/**
+ * Whether an Images custom ID / R2 object key was created by a non-production
+ * deployment (i.e. carries the preview marker). The delete guard only permits
+ * deleting assets for which this is true.
+ */
+export const isPreviewOwnedKey = (idOrKey: string): boolean =>
+  idOrKey.startsWith(PREVIEW_ASSET_PREFIX)
+
+/**
+ * Whether a Cloudflare Stream video's `meta` marks it as preview-owned.
+ * Stream UIDs are assigned by Cloudflare, so the marker lives in `meta` rather
+ * than the ID.
+ */
+export const isPreviewOwnedVideoMeta = (meta: Record<string, string> | null | undefined): boolean =>
+  meta?.[PREVIEW_STREAM_META_KEY] === PREVIEW_STREAM_META_VALUE
+
+/**
+ * Whether a stored asset is safe to reap in the scheduled preview cleanup
+ * (`scripts/cleanup-preview-assets.ts`).
+ *
+ * This is the single most safety-critical predicate in the cleanup path — a bug
+ * here could delete a production asset — so it is deliberately conservative and
+ * pure (no I/O), making it exhaustively unit-testable:
+ *  - NEVER reap an asset that is not preview-owned (a production asset).
+ *  - NEVER reap an asset of unknown age (`createdAt == null`).
+ *  - Only reap preview-owned assets at least `maxAgeDays` old, so an in-flight
+ *    preview's freshly-uploaded assets are left alone.
+ *
+ * @param isPreviewOwned - result of `isPreviewOwnedKey` / `isPreviewOwnedVideoMeta`
+ * @param createdAt - the asset's upload/create time (`null` when unknown)
+ */
+export const isReapablePreviewAsset = (
+  isPreviewOwned: boolean,
+  createdAt: Date | null,
+  now: Date,
+  maxAgeDays: number,
+): boolean => {
+  if (!isPreviewOwned) return false
+  if (!createdAt) return false
+  const maxAgeMs = maxAgeDays * 24 * 60 * 60 * 1000
+  return now.getTime() - createdAt.getTime() >= maxAgeMs
+}

--- a/src/plugins/storage/previewIsolation.ts
+++ b/src/plugins/storage/previewIsolation.ts
@@ -103,6 +103,34 @@ export const isPreviewOwnedVideoMeta = (meta: Record<string, string> | null | un
   meta?.[PREVIEW_STREAM_META_KEY] === PREVIEW_STREAM_META_VALUE
 
 /**
+ * Shared non-production delete guard for the storage adapters. Returns `true`
+ * (and logs a warning) when this deployment must REFUSE to delete `key` because
+ * it isn't preview-owned — protecting cloned production assets.
+ *
+ * The isolation check short-circuits BEFORE `isPreviewOwned` runs, so:
+ *  - production pays nothing (the guard is a no-op), and
+ *  - a backend whose ownership check is an API call (Stream reads `meta` via a
+ *    GET) never makes that call in production.
+ *
+ * `isPreviewOwned` is a thunk so the (possibly async, possibly remote) check is
+ * deferred until isolation is known to be active. Usage:
+ * `if (await shouldRefusePreviewDelete('R2', key, () => isPreviewOwnedKey(key))) return`.
+ */
+export const shouldRefusePreviewDelete = async (
+  backendLabel: string,
+  key: string,
+  isPreviewOwned: () => boolean | Promise<boolean>,
+): Promise<boolean> => {
+  if (!isStorageIsolationActive()) return false
+  if (await isPreviewOwned()) return false
+  // eslint-disable-next-line no-console
+  console.warn(
+    `[${backendLabel}] Refusing to delete non-preview asset "${key}" from a non-production deployment`,
+  )
+  return true
+}
+
+/**
  * Whether a stored asset is safe to reap in the scheduled preview cleanup
  * (`scripts/cleanup-preview-assets.ts`).
  *

--- a/src/plugins/storage/r2FilenameHook.ts
+++ b/src/plugins/storage/r2FilenameHook.ts
@@ -2,6 +2,7 @@ import type { CollectionBeforeOperationHook } from 'payload'
 
 import { generateR2Key } from './filenameUtils'
 import { getMimeCategory } from './mimeUtils'
+import { applyPreviewPrefix } from './previewIsolation'
 
 export const R2_PREASSIGNED_FILENAME_CONTEXT_KEY = '_r2PreassignedFilename'
 
@@ -33,7 +34,9 @@ export const createR2FilenameBeforeOperationHook = (
       return args
     }
 
-    file.name = generateR2Key(file.name)
+    // In non-prod, prefix the key so the asset is namespaced to this deployment
+    // (the R2 adapter's delete guard + cleanup recognize it). No-op in prod.
+    file.name = applyPreviewPrefix(generateR2Key(file.name))
     args.req.context = args.req.context ?? {}
     args.req.context[R2_PREASSIGNED_FILENAME_CONTEXT_KEY] = true
 

--- a/src/plugins/storage/r2NativeAdapter.ts
+++ b/src/plugins/storage/r2NativeAdapter.ts
@@ -16,6 +16,7 @@ import { DeleteObjectCommand, GetObjectCommand, PutObjectCommand } from '@aws-sd
 import { serverEnv } from '@/lib/env'
 
 import { applyFilename, generateR2Key } from './filenameUtils'
+import { applyPreviewPrefix, isPreviewOwnedKey, isStorageIsolationActive } from './previewIsolation'
 import { R2_PREASSIGNED_FILENAME_CONTEXT_KEY } from './r2FilenameHook'
 
 /**
@@ -65,7 +66,12 @@ export const r2NativeAdapter = (config: R2NativeConfig): Adapter => {
 
     handleUpload: (async ({ data, file, req }) => {
       const filenamePreassigned = Boolean(req.context?.[R2_PREASSIGNED_FILENAME_CONTEXT_KEY])
-      const finalFilename = filenamePreassigned ? file.filename : generateR2Key(file.filename)
+      // When not preassigned by r2FilenameHook, generate the key here and (in
+      // non-prod) prefix it so the asset is namespaced to this deployment. When
+      // preassigned, the hook already applied the prefix.
+      const finalFilename = filenamePreassigned
+        ? file.filename
+        : applyPreviewPrefix(generateR2Key(file.filename))
 
       applyFilename(file, data, req, finalFilename)
 
@@ -98,6 +104,17 @@ export const r2NativeAdapter = (config: R2NativeConfig): Adapter => {
     }) as HandleUpload,
 
     handleDelete: async ({ filename }) => {
+      // Preview isolation: a non-production deployment must never delete a
+      // production object. Cloned preview DBs reference real prod filenames,
+      // which carry no preview marker — refuse them here. No-op in production.
+      if (isStorageIsolationActive() && !isPreviewOwnedKey(filename)) {
+        // eslint-disable-next-line no-console
+        console.warn(
+          `[R2] Refusing to delete non-preview object "${filename}" from a non-production deployment`,
+        )
+        return
+      }
+
       const key = prefix ? `${prefix}/${filename}` : filename
       try {
         await client.send(new DeleteObjectCommand({ Bucket: bucket, Key: key }))

--- a/src/plugins/storage/r2NativeAdapter.ts
+++ b/src/plugins/storage/r2NativeAdapter.ts
@@ -16,7 +16,11 @@ import { DeleteObjectCommand, GetObjectCommand, PutObjectCommand } from '@aws-sd
 import { serverEnv } from '@/lib/env'
 
 import { applyFilename, generateR2Key } from './filenameUtils'
-import { applyPreviewPrefix, isPreviewOwnedKey, isStorageIsolationActive } from './previewIsolation'
+import {
+  applyPreviewPrefix,
+  isPreviewOwnedKey,
+  shouldRefusePreviewDelete,
+} from './previewIsolation'
 import { R2_PREASSIGNED_FILENAME_CONTEXT_KEY } from './r2FilenameHook'
 
 /**
@@ -105,13 +109,9 @@ export const r2NativeAdapter = (config: R2NativeConfig): Adapter => {
 
     handleDelete: async ({ filename }) => {
       // Preview isolation: a non-production deployment must never delete a
-      // production object. Cloned preview DBs reference real prod filenames,
-      // which carry no preview marker — refuse them here. No-op in production.
-      if (isStorageIsolationActive() && !isPreviewOwnedKey(filename)) {
-        // eslint-disable-next-line no-console
-        console.warn(
-          `[R2] Refusing to delete non-preview object "${filename}" from a non-production deployment`,
-        )
+      // production object (cloned preview DBs reference real prod filenames,
+      // which carry no preview marker). No-op in production.
+      if (await shouldRefusePreviewDelete('R2', filename, () => isPreviewOwnedKey(filename))) {
         return
       }
 

--- a/tests/e2e/images.e2e.spec.ts
+++ b/tests/e2e/images.e2e.spec.ts
@@ -1,0 +1,51 @@
+import { readFileSync } from 'node:fs'
+
+import { expect, test } from '@playwright/test'
+
+import { authHeaders, ensureAdmin } from './_helpers/preview'
+import { runId } from './_helpers/runId'
+
+type Doc = { id: number | string; filename?: string }
+
+const image = readFileSync('tests/files/image-1050x700.png')
+
+// Exercises the Cloudflare Images upload path in smoke (issue #432 AC) and
+// verifies the preview/non-prod namespace end-to-end: an image uploaded against
+// a Railway preview should land with the `preview-` marker so the delete guard
+// and scheduled cleanup recognize it, and the preview can delete its own upload.
+test('upload + delete an Image against preview, namespaced for isolation', async ({
+  request,
+}, testInfo) => {
+  const token = await ensureAdmin(request)
+  const headers = authHeaders(token)
+
+  const label = `smoke-${runId()}-image-r${testInfo.retry}`
+  const createRes = await request.post('/api/images', {
+    headers,
+    multipart: {
+      _payload: JSON.stringify({ alt: label }),
+      file: { name: `${label}.png`, mimeType: 'image/png', buffer: image },
+    },
+  })
+  expect(createRes.ok(), `create failed: ${createRes.status()} ${await createRes.text()}`).toBe(
+    true,
+  )
+  const created = (await createRes.json()) as { doc: Doc }
+  const id = created.doc.id
+  const filename = created.doc.filename ?? ''
+
+  // Cloudflare Images IDs carry no file extension; the local-storage fallback
+  // (no Cloudflare credentials) keeps ".png". Only assert the preview namespace
+  // when the upload actually went to Cloudflare Images — the path #432 isolates.
+  if (!filename.endsWith('.png')) {
+    expect(filename, 'Cloudflare Images upload should be preview-namespaced').toMatch(/^preview-/)
+  }
+
+  // The preview may delete its OWN (preview-marked) upload; the guard only
+  // blocks deletes of unmarked, cloned-from-prod assets.
+  const deleteRes = await request.delete(`/api/images/${id}`, { headers })
+  expect(deleteRes.ok()).toBe(true)
+
+  const after = await request.get(`/api/images/${id}`, { headers })
+  expect(after.status()).toBe(404)
+})

--- a/tests/int/storage-utils.int.spec.ts
+++ b/tests/int/storage-utils.int.spec.ts
@@ -593,16 +593,16 @@ describe('Filename Utilities', () => {
 })
 
 describe('R2 filename preassignment hook', () => {
-  // Pin to the prod origin so storage isolation is OFF — these assert the
-  // baseline R2 key the hook preassigns (no preview prefix). Non-prod prefixing
-  // is covered in tests/unit/previewIsolation.spec.ts.
-  const originalSahajcloudUrl = process.env.SAHAJCLOUD_URL
+  // Pin to the production Railway environment so storage isolation is OFF —
+  // these assert the baseline R2 key the hook preassigns (no preview prefix).
+  // Non-prod prefixing is covered in tests/unit/previewIsolation.spec.ts.
+  const originalEnvName = process.env.RAILWAY_ENVIRONMENT_NAME
   beforeEach(() => {
-    process.env.SAHAJCLOUD_URL = 'https://cloud.sydevelopers.com'
+    process.env.RAILWAY_ENVIRONMENT_NAME = 'production'
   })
   afterEach(() => {
-    if (originalSahajcloudUrl === undefined) delete process.env.SAHAJCLOUD_URL
-    else process.env.SAHAJCLOUD_URL = originalSahajcloudUrl
+    if (originalEnvName === undefined) delete process.env.RAILWAY_ENVIRONMENT_NAME
+    else process.env.RAILWAY_ENVIRONMENT_NAME = originalEnvName
   })
 
   const callR2Hook = async (
@@ -667,10 +667,10 @@ describe('Storage Adapter handleUpload', () => {
       CLOUDFLARE_IMAGES_DELIVERY_URL: 'https://imagedelivery.net/test-hash',
       CLOUDFLARE_STREAM_DELIVERY_URL: 'https://customer-test.cloudflarestream.com',
       CLOUDFLARE_R2_DELIVERY_URL: 'https://assets.test',
-      // Pin to the prod origin so storage isolation is OFF — these assert the
-      // baseline (production) upload behaviour. Non-prod prefixing/tagging is
-      // covered in tests/unit/{previewIsolation,storageIsolationGuard}.spec.ts.
-      SAHAJCLOUD_URL: 'https://cloud.sydevelopers.com',
+      // Pin to the production Railway environment so storage isolation is OFF —
+      // these assert the baseline (production) upload behaviour. Non-prod
+      // prefixing/tagging is covered in the unit specs.
+      RAILWAY_ENVIRONMENT_NAME: 'production',
     }
   })
 
@@ -990,9 +990,9 @@ describe('storagePlugin R2 filename hook wiring', () => {
       R2_BUCKET: 'test-bucket',
       R2_ACCESS_KEY_ID: 'test-access-key-id',
       R2_SECRET_ACCESS_KEY: 'test-secret-access-key',
-      // Pin to the prod origin so storage isolation is OFF — this verifies the
-      // baseline hook→adapter key contract (no preview prefix).
-      SAHAJCLOUD_URL: 'https://cloud.sydevelopers.com',
+      // Pin to the production Railway environment so storage isolation is OFF —
+      // this verifies the baseline hook→adapter key contract (no preview prefix).
+      RAILWAY_ENVIRONMENT_NAME: 'production',
     }
   })
 

--- a/tests/int/storage-utils.int.spec.ts
+++ b/tests/int/storage-utils.int.spec.ts
@@ -593,6 +593,18 @@ describe('Filename Utilities', () => {
 })
 
 describe('R2 filename preassignment hook', () => {
+  // Pin to the prod origin so storage isolation is OFF — these assert the
+  // baseline R2 key the hook preassigns (no preview prefix). Non-prod prefixing
+  // is covered in tests/unit/previewIsolation.spec.ts.
+  const originalSahajcloudUrl = process.env.SAHAJCLOUD_URL
+  beforeEach(() => {
+    process.env.SAHAJCLOUD_URL = 'https://cloud.sydevelopers.com'
+  })
+  afterEach(() => {
+    if (originalSahajcloudUrl === undefined) delete process.env.SAHAJCLOUD_URL
+    else process.env.SAHAJCLOUD_URL = originalSahajcloudUrl
+  })
+
   const callR2Hook = async (
     mode: 'always' | 'other-only',
     req: Record<string, unknown>,
@@ -655,6 +667,10 @@ describe('Storage Adapter handleUpload', () => {
       CLOUDFLARE_IMAGES_DELIVERY_URL: 'https://imagedelivery.net/test-hash',
       CLOUDFLARE_STREAM_DELIVERY_URL: 'https://customer-test.cloudflarestream.com',
       CLOUDFLARE_R2_DELIVERY_URL: 'https://assets.test',
+      // Pin to the prod origin so storage isolation is OFF — these assert the
+      // baseline (production) upload behaviour. Non-prod prefixing/tagging is
+      // covered in tests/unit/{previewIsolation,storageIsolationGuard}.spec.ts.
+      SAHAJCLOUD_URL: 'https://cloud.sydevelopers.com',
     }
   })
 
@@ -974,6 +990,9 @@ describe('storagePlugin R2 filename hook wiring', () => {
       R2_BUCKET: 'test-bucket',
       R2_ACCESS_KEY_ID: 'test-access-key-id',
       R2_SECRET_ACCESS_KEY: 'test-secret-access-key',
+      // Pin to the prod origin so storage isolation is OFF — this verifies the
+      // baseline hook→adapter key contract (no preview prefix).
+      SAHAJCLOUD_URL: 'https://cloud.sydevelopers.com',
     }
   })
 

--- a/tests/unit/previewIsolation.spec.ts
+++ b/tests/unit/previewIsolation.spec.ts
@@ -5,66 +5,72 @@ import {
   isPreviewOwnedKey,
   isPreviewOwnedVideoMeta,
   isProductionDeployment,
-  isProductionOrigin,
   isReapablePreviewAsset,
   isStorageIsolationActive,
   PREVIEW_ASSET_PREFIX,
-  PRODUCTION_ORIGIN_HOST,
+  PRODUCTION_ENVIRONMENT_NAME,
+  railwayEnvironmentName,
 } from '@/plugins/storage/previewIsolation'
 
-const PROD_URL = `https://${PRODUCTION_ORIGIN_HOST}`
-const PREVIEW_URL = 'https://sahajcloud-pr-432.up.railway.app'
+const PREVIEW_ENV = 'pr-432'
 
-const ORIGINAL_SAHAJCLOUD_URL = process.env.SAHAJCLOUD_URL
+const ORIGINAL_ENV_NAME = process.env.RAILWAY_ENVIRONMENT_NAME
+const ORIGINAL_ENV = process.env.RAILWAY_ENVIRONMENT
 
-/** Point the deployment at a given public origin for the duration of one test. */
-const setOrigin = (url: string | undefined): void => {
-  if (url === undefined) delete process.env.SAHAJCLOUD_URL
-  else process.env.SAHAJCLOUD_URL = url
+const restore = (
+  key: 'RAILWAY_ENVIRONMENT_NAME' | 'RAILWAY_ENVIRONMENT',
+  value: string | undefined,
+): void => {
+  if (value === undefined) delete process.env[key]
+  else process.env[key] = value
+}
+
+/** Simulate running in a given Railway environment (or off-Railway) for one test. */
+const setRailwayEnv = (name: string | undefined): void => {
+  delete process.env.RAILWAY_ENVIRONMENT
+  if (name === undefined) delete process.env.RAILWAY_ENVIRONMENT_NAME
+  else process.env.RAILWAY_ENVIRONMENT_NAME = name
 }
 
 afterEach(() => {
-  setOrigin(ORIGINAL_SAHAJCLOUD_URL)
+  restore('RAILWAY_ENVIRONMENT_NAME', ORIGINAL_ENV_NAME)
+  restore('RAILWAY_ENVIRONMENT', ORIGINAL_ENV)
 })
 
-describe('isProductionOrigin', () => {
-  it('is true only for the canonical production host', () => {
-    expect(isProductionOrigin(PROD_URL)).toBe(true)
-    // Trailing path / slash do not change the host.
-    expect(isProductionOrigin(`${PROD_URL}/admin`)).toBe(true)
+describe('railwayEnvironmentName', () => {
+  it('prefers RAILWAY_ENVIRONMENT_NAME', () => {
+    process.env.RAILWAY_ENVIRONMENT_NAME = 'production'
+    process.env.RAILWAY_ENVIRONMENT = 'ignored'
+    expect(railwayEnvironmentName()).toBe('production')
   })
 
-  it('is false for previews, localhost, and other hosts', () => {
-    expect(isProductionOrigin(PREVIEW_URL)).toBe(false)
-    expect(isProductionOrigin('http://localhost:3000')).toBe(false)
-    expect(isProductionOrigin('https://staging.sydevelopers.com')).toBe(false)
-    // A look-alike subdomain must not match.
-    expect(isProductionOrigin('https://cloud.sydevelopers.com.evil.test')).toBe(false)
+  it('falls back to the legacy RAILWAY_ENVIRONMENT', () => {
+    delete process.env.RAILWAY_ENVIRONMENT_NAME
+    process.env.RAILWAY_ENVIRONMENT = 'pr-7'
+    expect(railwayEnvironmentName()).toBe('pr-7')
   })
 
-  it('is false (fail-safe) for missing or unparseable URLs', () => {
-    expect(isProductionOrigin(undefined)).toBe(false)
-    expect(isProductionOrigin(null)).toBe(false)
-    expect(isProductionOrigin('')).toBe(false)
-    expect(isProductionOrigin('not a url')).toBe(false)
+  it('is undefined off-Railway', () => {
+    setRailwayEnv(undefined)
+    expect(railwayEnvironmentName()).toBeUndefined()
   })
 })
 
 describe('isProductionDeployment / isStorageIsolationActive', () => {
-  it('treats the canonical prod origin as production (isolation off)', () => {
-    setOrigin(PROD_URL)
+  it('treats the production environment as production (isolation off)', () => {
+    setRailwayEnv(PRODUCTION_ENVIRONMENT_NAME)
     expect(isProductionDeployment()).toBe(true)
     expect(isStorageIsolationActive()).toBe(false)
   })
 
-  it('treats a Railway preview origin as non-production (isolation on)', () => {
-    setOrigin(PREVIEW_URL)
+  it('treats a pr-* preview environment as non-production (isolation on)', () => {
+    setRailwayEnv(PREVIEW_ENV)
     expect(isProductionDeployment()).toBe(false)
     expect(isStorageIsolationActive()).toBe(true)
   })
 
-  it('fails safe to non-production when the origin is unset', () => {
-    setOrigin(undefined)
+  it('fails safe to non-production off-Railway (no env name)', () => {
+    setRailwayEnv(undefined)
     expect(isProductionDeployment()).toBe(false)
     expect(isStorageIsolationActive()).toBe(true)
   })
@@ -72,18 +78,18 @@ describe('isProductionDeployment / isStorageIsolationActive', () => {
 
 describe('applyPreviewPrefix', () => {
   it('prefixes keys in non-production', () => {
-    setOrigin(PREVIEW_URL)
+    setRailwayEnv(PREVIEW_ENV)
     expect(applyPreviewPrefix('my-photo-xk2j9s')).toBe(`${PREVIEW_ASSET_PREFIX}my-photo-xk2j9s`)
   })
 
   it('is idempotent — never double-prefixes', () => {
-    setOrigin(PREVIEW_URL)
+    setRailwayEnv(PREVIEW_ENV)
     const once = applyPreviewPrefix('my-photo-xk2j9s')
     expect(applyPreviewPrefix(once)).toBe(once)
   })
 
   it('is a no-op in production', () => {
-    setOrigin(PROD_URL)
+    setRailwayEnv(PRODUCTION_ENVIRONMENT_NAME)
     expect(applyPreviewPrefix('my-photo-xk2j9s')).toBe('my-photo-xk2j9s')
   })
 })

--- a/tests/unit/previewIsolation.spec.ts
+++ b/tests/unit/previewIsolation.spec.ts
@@ -1,0 +1,135 @@
+import { afterEach, describe, expect, it } from 'vitest'
+
+import {
+  applyPreviewPrefix,
+  isPreviewOwnedKey,
+  isPreviewOwnedVideoMeta,
+  isProductionDeployment,
+  isProductionOrigin,
+  isReapablePreviewAsset,
+  isStorageIsolationActive,
+  PREVIEW_ASSET_PREFIX,
+  PRODUCTION_ORIGIN_HOST,
+} from '@/plugins/storage/previewIsolation'
+
+const PROD_URL = `https://${PRODUCTION_ORIGIN_HOST}`
+const PREVIEW_URL = 'https://sahajcloud-pr-432.up.railway.app'
+
+const ORIGINAL_SAHAJCLOUD_URL = process.env.SAHAJCLOUD_URL
+
+/** Point the deployment at a given public origin for the duration of one test. */
+const setOrigin = (url: string | undefined): void => {
+  if (url === undefined) delete process.env.SAHAJCLOUD_URL
+  else process.env.SAHAJCLOUD_URL = url
+}
+
+afterEach(() => {
+  setOrigin(ORIGINAL_SAHAJCLOUD_URL)
+})
+
+describe('isProductionOrigin', () => {
+  it('is true only for the canonical production host', () => {
+    expect(isProductionOrigin(PROD_URL)).toBe(true)
+    // Trailing path / slash do not change the host.
+    expect(isProductionOrigin(`${PROD_URL}/admin`)).toBe(true)
+  })
+
+  it('is false for previews, localhost, and other hosts', () => {
+    expect(isProductionOrigin(PREVIEW_URL)).toBe(false)
+    expect(isProductionOrigin('http://localhost:3000')).toBe(false)
+    expect(isProductionOrigin('https://staging.sydevelopers.com')).toBe(false)
+    // A look-alike subdomain must not match.
+    expect(isProductionOrigin('https://cloud.sydevelopers.com.evil.test')).toBe(false)
+  })
+
+  it('is false (fail-safe) for missing or unparseable URLs', () => {
+    expect(isProductionOrigin(undefined)).toBe(false)
+    expect(isProductionOrigin(null)).toBe(false)
+    expect(isProductionOrigin('')).toBe(false)
+    expect(isProductionOrigin('not a url')).toBe(false)
+  })
+})
+
+describe('isProductionDeployment / isStorageIsolationActive', () => {
+  it('treats the canonical prod origin as production (isolation off)', () => {
+    setOrigin(PROD_URL)
+    expect(isProductionDeployment()).toBe(true)
+    expect(isStorageIsolationActive()).toBe(false)
+  })
+
+  it('treats a Railway preview origin as non-production (isolation on)', () => {
+    setOrigin(PREVIEW_URL)
+    expect(isProductionDeployment()).toBe(false)
+    expect(isStorageIsolationActive()).toBe(true)
+  })
+
+  it('fails safe to non-production when the origin is unset', () => {
+    setOrigin(undefined)
+    expect(isProductionDeployment()).toBe(false)
+    expect(isStorageIsolationActive()).toBe(true)
+  })
+})
+
+describe('applyPreviewPrefix', () => {
+  it('prefixes keys in non-production', () => {
+    setOrigin(PREVIEW_URL)
+    expect(applyPreviewPrefix('my-photo-xk2j9s')).toBe(`${PREVIEW_ASSET_PREFIX}my-photo-xk2j9s`)
+  })
+
+  it('is idempotent — never double-prefixes', () => {
+    setOrigin(PREVIEW_URL)
+    const once = applyPreviewPrefix('my-photo-xk2j9s')
+    expect(applyPreviewPrefix(once)).toBe(once)
+  })
+
+  it('is a no-op in production', () => {
+    setOrigin(PROD_URL)
+    expect(applyPreviewPrefix('my-photo-xk2j9s')).toBe('my-photo-xk2j9s')
+  })
+})
+
+describe('isPreviewOwnedKey', () => {
+  it('recognizes preview-marked keys only', () => {
+    expect(isPreviewOwnedKey('preview-my-photo-xk2j9s')).toBe(true)
+    expect(isPreviewOwnedKey('my-photo-xk2j9s')).toBe(false)
+    expect(isPreviewOwnedKey('my-audio-file-1-xk2j9s.mp3')).toBe(false)
+  })
+})
+
+describe('isPreviewOwnedVideoMeta', () => {
+  it('recognizes the preview meta tag only', () => {
+    expect(isPreviewOwnedVideoMeta({ env: 'preview' })).toBe(true)
+    expect(isPreviewOwnedVideoMeta({ env: 'production' })).toBe(false)
+    expect(isPreviewOwnedVideoMeta({ name: 'something' })).toBe(false)
+    expect(isPreviewOwnedVideoMeta({})).toBe(false)
+    expect(isPreviewOwnedVideoMeta(undefined)).toBe(false)
+    expect(isPreviewOwnedVideoMeta(null)).toBe(false)
+  })
+})
+
+describe('isReapablePreviewAsset', () => {
+  const now = new Date('2026-06-17T12:00:00Z')
+  const eightDaysAgo = new Date('2026-06-09T12:00:00Z')
+  const oneDayAgo = new Date('2026-06-16T12:00:00Z')
+
+  it('NEVER reaps a non-preview (production) asset, regardless of age', () => {
+    expect(isReapablePreviewAsset(false, eightDaysAgo, now, 7)).toBe(false)
+  })
+
+  it('NEVER reaps an asset of unknown age', () => {
+    expect(isReapablePreviewAsset(true, null, now, 7)).toBe(false)
+  })
+
+  it('reaps a preview asset older than the cutoff', () => {
+    expect(isReapablePreviewAsset(true, eightDaysAgo, now, 7)).toBe(true)
+  })
+
+  it('keeps a preview asset younger than the cutoff', () => {
+    expect(isReapablePreviewAsset(true, oneDayAgo, now, 7)).toBe(false)
+  })
+
+  it('reaps at exactly the cutoff age (inclusive)', () => {
+    const exactlySevenDaysAgo = new Date('2026-06-10T12:00:00Z')
+    expect(isReapablePreviewAsset(true, exactlySevenDaysAgo, now, 7)).toBe(true)
+  })
+})

--- a/tests/unit/storageIsolationGuard.spec.ts
+++ b/tests/unit/storageIsolationGuard.spec.ts
@@ -17,11 +17,13 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { cloudflareImagesAdapter } from '@/plugins/storage/cloudflareImagesAdapter'
 import { cloudflareStreamAdapter } from '@/plugins/storage/cloudflareStreamAdapter'
-import { PREVIEW_ASSET_PREFIX, PRODUCTION_ORIGIN_HOST } from '@/plugins/storage/previewIsolation'
+import {
+  PREVIEW_ASSET_PREFIX,
+  PRODUCTION_ENVIRONMENT_NAME,
+} from '@/plugins/storage/previewIsolation'
 import { r2NativeAdapter } from '@/plugins/storage/r2NativeAdapter'
 
-const PROD_URL = `https://${PRODUCTION_ORIGIN_HOST}`
-const PREVIEW_URL = 'https://sahajcloud-pr-432.up.railway.app'
+const PREVIEW_ENV = 'pr-432'
 
 // A cloned-from-prod id/key carries no preview marker; a preview-created one does.
 const PROD_ASSET_ID = 'real-prod-photo-ab12cd'
@@ -32,10 +34,14 @@ type DeleteArg = Parameters<GeneratedAdapter['handleDelete']>[0]
 const adapterArg = (prefix?: string): AdapterArg => ({ prefix }) as unknown as AdapterArg
 const deleteArg = (filename: string): DeleteArg => ({ filename }) as unknown as DeleteArg
 
-const ORIGINAL_SAHAJCLOUD_URL = process.env.SAHAJCLOUD_URL
-const setOrigin = (url: string | undefined): void => {
-  if (url === undefined) delete process.env.SAHAJCLOUD_URL
-  else process.env.SAHAJCLOUD_URL = url
+const ORIGINAL_ENV_NAME = process.env.RAILWAY_ENVIRONMENT_NAME
+const ORIGINAL_ENV = process.env.RAILWAY_ENVIRONMENT
+
+/** Simulate running in a given Railway environment (`undefined` = off-Railway). */
+const setRailwayEnv = (name: string | undefined): void => {
+  delete process.env.RAILWAY_ENVIRONMENT
+  if (name === undefined) delete process.env.RAILWAY_ENVIRONMENT_NAME
+  else process.env.RAILWAY_ENVIRONMENT_NAME = name
 }
 
 /** Minimal Response stub for the adapters' `await fetch(...).json()` calls. */
@@ -54,7 +60,10 @@ const streamConfig = {
 }
 
 afterEach(() => {
-  setOrigin(ORIGINAL_SAHAJCLOUD_URL)
+  if (ORIGINAL_ENV_NAME === undefined) delete process.env.RAILWAY_ENVIRONMENT_NAME
+  else process.env.RAILWAY_ENVIRONMENT_NAME = ORIGINAL_ENV_NAME
+  if (ORIGINAL_ENV === undefined) delete process.env.RAILWAY_ENVIRONMENT
+  else process.env.RAILWAY_ENVIRONMENT = ORIGINAL_ENV
   vi.restoreAllMocks()
 })
 
@@ -71,13 +80,13 @@ describe('Cloudflare Images delete guard', () => {
     cloudflareImagesAdapter(imagesConfig)(adapterArg()).handleDelete(deleteArg(filename))
 
   it('refuses to delete a cloned prod image from a preview deployment', async () => {
-    setOrigin(PREVIEW_URL)
+    setRailwayEnv(PREVIEW_ENV)
     await handleDelete(PROD_ASSET_ID)
     expect(fetchSpy).not.toHaveBeenCalled()
   })
 
   it('deletes a preview-owned image from a preview deployment', async () => {
-    setOrigin(PREVIEW_URL)
+    setRailwayEnv(PREVIEW_ENV)
     await handleDelete(PREVIEW_ASSET_ID)
     expect(fetchSpy).toHaveBeenCalledOnce()
     const [url, init] = fetchSpy.mock.calls[0]
@@ -86,7 +95,7 @@ describe('Cloudflare Images delete guard', () => {
   })
 
   it('deletes any image from production (guard disabled)', async () => {
-    setOrigin(PROD_URL)
+    setRailwayEnv(PRODUCTION_ENVIRONMENT_NAME)
     await handleDelete(PROD_ASSET_ID)
     expect(fetchSpy).toHaveBeenCalledOnce()
     expect(fetchSpy.mock.calls[0][1]?.method).toBe('DELETE')
@@ -104,21 +113,21 @@ describe('R2 delete guard', () => {
   }
 
   it('refuses to delete a cloned prod object from a preview deployment', async () => {
-    setOrigin(PREVIEW_URL)
+    setRailwayEnv(PREVIEW_ENV)
     const { send, handleDelete } = buildAdapter()
     await handleDelete(`${PROD_ASSET_ID}.mp3`)
     expect(send).not.toHaveBeenCalled()
   })
 
   it('deletes a preview-owned object from a preview deployment', async () => {
-    setOrigin(PREVIEW_URL)
+    setRailwayEnv(PREVIEW_ENV)
     const { send, handleDelete } = buildAdapter()
     await handleDelete(`${PREVIEW_ASSET_ID}.mp3`)
     expect(send).toHaveBeenCalledOnce()
   })
 
   it('deletes any object from production (guard disabled)', async () => {
-    setOrigin(PROD_URL)
+    setRailwayEnv(PRODUCTION_ENVIRONMENT_NAME)
     const { send, handleDelete } = buildAdapter()
     await handleDelete(`${PROD_ASSET_ID}.mp3`)
     expect(send).toHaveBeenCalledOnce()
@@ -147,21 +156,21 @@ describe('Cloudflare Stream delete guard', () => {
     cloudflareStreamAdapter(streamConfig)(adapterArg()).handleDelete(deleteArg(uid))
 
   it('refuses to delete a cloned prod video (no preview meta) from a preview deployment', async () => {
-    setOrigin(PREVIEW_URL)
+    setRailwayEnv(PREVIEW_ENV)
     const spy = mockFetchWithMeta({ name: 'prod video' })
     await handleDelete('prod-uid')
     expect(deleteCalls(spy)).toHaveLength(0)
   })
 
   it('deletes a preview-owned video (preview meta) from a preview deployment', async () => {
-    setOrigin(PREVIEW_URL)
+    setRailwayEnv(PREVIEW_ENV)
     const spy = mockFetchWithMeta({ env: 'preview' })
     await handleDelete('preview-uid')
     expect(deleteCalls(spy)).toHaveLength(1)
   })
 
   it('deletes any video from production without a guard GET', async () => {
-    setOrigin(PROD_URL)
+    setRailwayEnv(PRODUCTION_ENVIRONMENT_NAME)
     const spy = vi
       .spyOn(globalThis, 'fetch')
       .mockResolvedValue(jsonResponse({ success: true, errors: [] }))

--- a/tests/unit/storageIsolationGuard.spec.ts
+++ b/tests/unit/storageIsolationGuard.spec.ts
@@ -1,0 +1,172 @@
+/**
+ * Safety test for the preview/non-production storage delete guard (issue #432,
+ * acceptance criterion: "from preview, attempt to delete a cloned asset that
+ * exists in prod; confirm it is intact afterwards").
+ *
+ * We prove the guard deterministically rather than by deleting a real prod asset:
+ * a non-production deployment's `handleDelete` must NOT issue the underlying
+ * delete API/SDK call for an asset that lacks the preview marker (a cloned prod
+ * asset), while production deletes anything and preview deletes its own marked
+ * assets. The network/SDK layer is mocked, so "did we call delete?" is the
+ * assertion.
+ */
+import type { S3Client } from '@aws-sdk/client-s3'
+import type { Adapter, GeneratedAdapter } from '@payloadcms/plugin-cloud-storage/types'
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { cloudflareImagesAdapter } from '@/plugins/storage/cloudflareImagesAdapter'
+import { cloudflareStreamAdapter } from '@/plugins/storage/cloudflareStreamAdapter'
+import { PREVIEW_ASSET_PREFIX, PRODUCTION_ORIGIN_HOST } from '@/plugins/storage/previewIsolation'
+import { r2NativeAdapter } from '@/plugins/storage/r2NativeAdapter'
+
+const PROD_URL = `https://${PRODUCTION_ORIGIN_HOST}`
+const PREVIEW_URL = 'https://sahajcloud-pr-432.up.railway.app'
+
+// A cloned-from-prod id/key carries no preview marker; a preview-created one does.
+const PROD_ASSET_ID = 'real-prod-photo-ab12cd'
+const PREVIEW_ASSET_ID = `${PREVIEW_ASSET_PREFIX}smoke-photo-ef34gh`
+
+type AdapterArg = Parameters<Adapter>[0]
+type DeleteArg = Parameters<GeneratedAdapter['handleDelete']>[0]
+const adapterArg = (prefix?: string): AdapterArg => ({ prefix }) as unknown as AdapterArg
+const deleteArg = (filename: string): DeleteArg => ({ filename }) as unknown as DeleteArg
+
+const ORIGINAL_SAHAJCLOUD_URL = process.env.SAHAJCLOUD_URL
+const setOrigin = (url: string | undefined): void => {
+  if (url === undefined) delete process.env.SAHAJCLOUD_URL
+  else process.env.SAHAJCLOUD_URL = url
+}
+
+/** Minimal Response stub for the adapters' `await fetch(...).json()` calls. */
+const jsonResponse = (body: unknown, status = 200): Response =>
+  ({ ok: status >= 200 && status < 300, status, json: async () => body }) as unknown as Response
+
+const imagesConfig = {
+  accountId: 'acct',
+  apiKey: 'key',
+  deliveryUrl: 'https://imagedelivery.net/hash',
+}
+const streamConfig = {
+  accountId: 'acct',
+  apiKey: 'key',
+  deliveryUrl: 'https://customer-x.cloudflarestream.com',
+}
+
+afterEach(() => {
+  setOrigin(ORIGINAL_SAHAJCLOUD_URL)
+  vi.restoreAllMocks()
+})
+
+describe('Cloudflare Images delete guard', () => {
+  let fetchSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue(jsonResponse({ success: true, errors: [] }))
+  })
+
+  const handleDelete = (filename: string) =>
+    cloudflareImagesAdapter(imagesConfig)(adapterArg()).handleDelete(deleteArg(filename))
+
+  it('refuses to delete a cloned prod image from a preview deployment', async () => {
+    setOrigin(PREVIEW_URL)
+    await handleDelete(PROD_ASSET_ID)
+    expect(fetchSpy).not.toHaveBeenCalled()
+  })
+
+  it('deletes a preview-owned image from a preview deployment', async () => {
+    setOrigin(PREVIEW_URL)
+    await handleDelete(PREVIEW_ASSET_ID)
+    expect(fetchSpy).toHaveBeenCalledOnce()
+    const [url, init] = fetchSpy.mock.calls[0]
+    expect(String(url)).toContain(PREVIEW_ASSET_ID)
+    expect(init?.method).toBe('DELETE')
+  })
+
+  it('deletes any image from production (guard disabled)', async () => {
+    setOrigin(PROD_URL)
+    await handleDelete(PROD_ASSET_ID)
+    expect(fetchSpy).toHaveBeenCalledOnce()
+    expect(fetchSpy.mock.calls[0][1]?.method).toBe('DELETE')
+  })
+})
+
+describe('R2 delete guard', () => {
+  const buildAdapter = () => {
+    const send = vi.fn().mockResolvedValue({})
+    const client = { send } as unknown as S3Client
+    const generated = r2NativeAdapter({ client, bucket: 'bucket', publicUrl: '' })(
+      adapterArg('meditations'),
+    )
+    return { send, handleDelete: (filename: string) => generated.handleDelete(deleteArg(filename)) }
+  }
+
+  it('refuses to delete a cloned prod object from a preview deployment', async () => {
+    setOrigin(PREVIEW_URL)
+    const { send, handleDelete } = buildAdapter()
+    await handleDelete(`${PROD_ASSET_ID}.mp3`)
+    expect(send).not.toHaveBeenCalled()
+  })
+
+  it('deletes a preview-owned object from a preview deployment', async () => {
+    setOrigin(PREVIEW_URL)
+    const { send, handleDelete } = buildAdapter()
+    await handleDelete(`${PREVIEW_ASSET_ID}.mp3`)
+    expect(send).toHaveBeenCalledOnce()
+  })
+
+  it('deletes any object from production (guard disabled)', async () => {
+    setOrigin(PROD_URL)
+    const { send, handleDelete } = buildAdapter()
+    await handleDelete(`${PROD_ASSET_ID}.mp3`)
+    expect(send).toHaveBeenCalledOnce()
+  })
+})
+
+describe('Cloudflare Stream delete guard', () => {
+  /**
+   * Stream's guard reads the video's `meta` via GET, then deletes only if the
+   * marker is present. The mock answers GET with the given meta and DELETE with
+   * a generic success, so we can assert whether a DELETE was ever issued.
+   */
+  const mockFetchWithMeta = (meta: Record<string, string>) =>
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async (_url, init) => {
+      const method = (init?.method ?? 'GET').toUpperCase()
+      if (method === 'GET') {
+        return jsonResponse({ success: true, errors: [], result: { uid: 'uid', meta } })
+      }
+      return jsonResponse({ success: true, errors: [] })
+    })
+
+  const deleteCalls = (spy: ReturnType<typeof vi.spyOn>) =>
+    spy.mock.calls.filter(([, init]) => (init?.method ?? 'GET').toUpperCase() === 'DELETE')
+
+  const handleDelete = (uid: string) =>
+    cloudflareStreamAdapter(streamConfig)(adapterArg()).handleDelete(deleteArg(uid))
+
+  it('refuses to delete a cloned prod video (no preview meta) from a preview deployment', async () => {
+    setOrigin(PREVIEW_URL)
+    const spy = mockFetchWithMeta({ name: 'prod video' })
+    await handleDelete('prod-uid')
+    expect(deleteCalls(spy)).toHaveLength(0)
+  })
+
+  it('deletes a preview-owned video (preview meta) from a preview deployment', async () => {
+    setOrigin(PREVIEW_URL)
+    const spy = mockFetchWithMeta({ env: 'preview' })
+    await handleDelete('preview-uid')
+    expect(deleteCalls(spy)).toHaveLength(1)
+  })
+
+  it('deletes any video from production without a guard GET', async () => {
+    setOrigin(PROD_URL)
+    const spy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue(jsonResponse({ success: true, errors: [] }))
+    await handleDelete('prod-uid')
+    expect(spy).toHaveBeenCalledOnce()
+    expect(spy.mock.calls[0][1]?.method).toBe('DELETE')
+  })
+})


### PR DESCRIPTION
## Summary

Implements per-environment isolation so **non-production deployments (Railway PR previews, staging) cannot pollute or delete production Cloudflare Images / Stream / R2 assets** — Closes #432.

> **Context correction:** #432 was written for the old Cloudflare Workers + D1 setup (`wrangler.toml`, `[env.preview]`, binding isolation). The app has since migrated to **Railway + Postgres** (#468); previews are Railway per-PR deploys that share the single prod Cloudflare account (Images + Stream) **and** the single R2 bucket. So the gap is broader than the ticket framed — **R2 is included here** — and the code lives in `src/plugins/storage/`, not `src/lib/cf*`.

## Decision: Option B (namespacing within one account)

Per the ticket's options, the team chose **B** — namespace non-prod uploads and refuse non-prod deletes of unmarked assets, plus a scheduled cleanup. No second Cloudflare account.

| Backend | Non-prod upload marker | Delete guard (non-prod) |
| --- | --- | --- |
| Cloudflare Images | `preview-` prefix on the custom ID | refuse IDs without the prefix |
| R2 | `preview-` prefix on the object key (filename) | refuse keys without the prefix |
| Cloudflare Stream | `meta.env=preview` tag (UIDs aren't caller-chosen) | GET the video, refuse unless tagged |

**"Is this production?" keys off the Railway environment name** (`RAILWAY_ENVIRONMENT_NAME` == `production`), because Railway previews also run `NODE_ENV=production` **and inherit the shared `SAHAJCLOUD_URL`** service var (so the origin is identical on a preview and on prod — an earlier origin-based attempt was caught by CI). PR previews are `pr-<number>`. Fails safe: any other / unknown env name ⇒ non-prod ⇒ guard active. Production short-circuits the guard and is byte-for-byte unchanged (no prefix, no extra API calls) — honoring the ticket's "no new code paths in the production data plane" constraint.

## Safety mechanism + tests

The delete guard is the safety property. `shouldRefusePreviewDelete()` centralizes it; the ownership check is thunked so production never even runs Stream's guard GET.

- **`tests/unit/storageIsolationGuard.spec.ts`** — proves a non-prod deploy's `handleDelete` issues **no** delete call for a cloned-prod (unmarked) asset, across Images/R2/Stream; production deletes anything.
- **`tests/unit/previewIsolation.spec.ts`** — origin detection (incl. fail-safe + look-alike host), prefix idempotency, ownership predicates, and the cleanup reap predicate (never reaps unmarked or unknown-age assets).
- **`tests/e2e/images.e2e.spec.ts`** — exercises the Image upload path on the live preview and asserts the `preview-` namespace.

## Cleanup

`.github/workflows/cleanup-preview-assets.yml` (daily) → `scripts/cleanup-preview-assets.ts` reaps preview-marked assets older than 7 days across all three backends. Deletes only assets that are **both** marked **and** aged; dry-run by default (`--apply` to delete). **Requires GitHub secrets:** `CLOUDFLARE_ACCOUNT_ID`, `CLOUDFLARE_API_KEY`, `R2_BUCKET`, `R2_ACCESS_KEY_ID`, `R2_SECRET_ACCESS_KEY` (R2 step skips if unset).

## Acceptance criteria (#432)

- [x] Team picks A/B/C/D → **B**; ticket "Proposed changes" updated (separately).
- [x] Implementation lands per Option B (Images + Stream + **R2**).
- [x] Smoke extended to the Image upload path (`images.e2e.spec.ts`). Stream upload deferred — smoke uploads no video (transcoding latency); guard still covered by unit tests.
- [x] `.claude/rules/storage.md` documents the mechanism (new "Preview / non-production isolation" section) — ⚠️ see note.
- [x] Safety test — covered deterministically by `storageIsolationGuard.spec.ts`; a one-time **manual** live verification (delete a cloned prod image from a preview, confirm prod intact) is documented in storage.md for an operator to run against a real preview.

## Notes / follow-ups

- **storage.md module-table row** for `previewIsolation.ts` couldn't be added — the auto-mode classifier blocks `.claude/` edits as self-modification. The substantive isolation docs landed; the one-line inventory row is a trivial follow-up needing explicit approval.
- **Marker collision** (inherent to Option B): a prod asset whose ID/key legitimately starts with `preview-` would be classed preview-owned. Bounded by the marker-AND-age cleanup condition; documented near the prefix constant. Harden the marker if it ever surfaces.
- **Reviewed** by code + security subagents — core "preview cannot delete prod" property holds. Dismissed with reason: GH secrets-as-env (GitHub auto-masks `secrets.*`, script logs no secrets); startup origin validation (outside this diff; the fail-safe is loud — prod can't delete — not destructive).

## Verify

The one-time manual safety check and its steps live in `.claude/rules/storage.md` § "Preview / non-production isolation".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
