### PR TITLE
feat(globals): add featuredArticles to WeMeditate Web config

### DIFF
--- a/.claude/rules/globals.md
+++ b/.claude/rules/globals.md
@@ -45,8 +45,9 @@ src/globals/
 ## Config globals (per project)
 
 **WeMeditate Web** (admin group: System) — `homePage` (relationship to
-pages, required), `featuredPages` (hasMany 2–3), `classPages` /
-`knowledgePages` / `infoPages` (hasMany, max 5).
+pages, required), `featuredPages` (hasMany 2–3), `featuredArticles`
+(hasMany, required, min 2 — article pages for the header dropdown),
+`classPages` / `knowledgePages` / `infoPages` (hasMany, max 5).
 
 **WeMeditate App** (admin group: WeMeditate App, tabs: First Meditation) —
 `selfRealizationMeditation` (localized relationship to meditations),

--- a/src/globals/WeMeditateWebConfig/WeMeditateWebConfig.ts
+++ b/src/globals/WeMeditateWebConfig/WeMeditateWebConfig.ts
@@ -34,6 +34,17 @@ export const WeMeditateWebConfig: GlobalConfig = {
       },
     },
     {
+      name: 'featuredArticles',
+      type: 'relationship',
+      relationTo: 'pages',
+      hasMany: true,
+      minRows: 2,
+      required: true,
+      admin: {
+        description: 'Select 2 or more article pages to feature in the website header dropdown.',
+      },
+    },
+    {
       name: 'classPages',
       type: 'relationship',
       relationTo: 'pages',

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -5495,6 +5495,10 @@ export interface WmWebConfig {
    */
   featuredPages: (number | Page)[];
   /**
+   * Select 2 or more article pages to feature in the website header dropdown.
+   */
+  featuredArticles: (number | Page)[];
+  /**
    * Select up to 5 pages for seekers to start meditating. The first one will be featured in the header. (eg. Classes Near Me, Online Meditations, Recorded Meditations, WeMeditate App
    */
   classPages?: (number | Page)[] | null;
@@ -6637,6 +6641,7 @@ export interface PayloadJobsStat {
 export interface WmWebConfigSelect<T extends boolean = true> {
   homePage?: T;
   featuredPages?: T;
+  featuredArticles?: T;
   classPages?: T;
   knowledgePages?: T;
   infoPages?: T;


### PR DESCRIPTION
## Summary

- Add a required `featuredArticles` hasMany relationship (`relationTo: 'pages'`, `minRows: 2`) to the WeMeditate Web config global (`wm-web-config`).
- Editors select 2+ article pages to surface in the website **header dropdown**, mirroring the existing `featuredPages` field.
- "Articles" are `pages` in this app (no separate Articles collection) — hence the relation targets `pages`.

## Changes

- `src/globals/WeMeditateWebConfig/WeMeditateWebConfig.ts` — new `featuredArticles` relationship field.
- `src/payload-types.ts` — regenerated (`featuredArticles: (number | Page)[]`).
- `.claude/rules/globals.md` — updated WeMeditate Web config field summary.

## No migration required

`featuredArticles` is `hasMany`, so Payload stores it as path-discriminated rows in the existing `wm_web_config_rels` join table (columns `id, order, parent_id, path, pages_id` — already present for `featuredPages`/`classPages`/etc.). No DDL change → `db:migrations:create` correctly reports "No schema changes detected."

## Test plan / Test Results

- Lint: ✓ No errors (`pnpm lint`)
- Types: ✓ Regenerated clean (`pnpm generate:types`)
- Unit tests: ✓ 572 passed (`pnpm test:unit`)
- Integration/E2E: deferred to CI

## Notes

- The field currently allows selecting **any** page (matching `featuredPages`). If it should be restricted to article-tagged pages, a follow-up can add `filterOptions` on `tags`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
