### PR TITLE
fix(seeds): upload atlas data inline so remote seeding works

### DIFF
--- a/seeds/atlas/import.ts
+++ b/seeds/atlas/import.ts
@@ -34,7 +34,13 @@ import {
 import { makeManualMapboxId } from '@/lib/mapbox/manualLocation'
 import { slugifyValue } from '@/lib/utilities/slugify'
 
-import { BaseImporter, type BaseImportOptions, fetchAsset, MediaUploader } from '../lib'
+import {
+  BaseImporter,
+  type BaseImportOptions,
+  fetchAsset,
+  loadJsonData,
+  MediaUploader,
+} from '../lib'
 import { plainTextToLexical } from './helpers/lexical'
 import {
   mapContactDetails,
@@ -331,9 +337,14 @@ export class AtlasImporter extends BaseImporter<BaseImportOptions> {
 
   private async getData(): Promise<AtlasData> {
     if (this.cachedData) return this.cachedData
-    const dir = path.resolve(process.cwd(), 'seeds/atlas/data')
-    const load = async <T>(name: string): Promise<T> =>
-      JSON.parse(await this.loadDataFile(path.join(dir, `${name}.json`))) as T
+    // The data files are excluded from the deployed standalone build (next.config
+    // `outputFileTracingExcludes` drops `seeds/**`), so when seeding a remote env
+    // the CLI uploads them as `inlineData` keyed by local path (see
+    // SCRIPT_DATA_FILES in seeds/run.ts); locally they're read from disk.
+    const load = <T>(name: string): Promise<T> => {
+      const localPath = `seeds/atlas/data/${name}.json`
+      return loadJsonData<T>({ localPath, inlineContent: this.options.inlineData?.[localPath] })
+    }
 
     const [users, managers, regions, venues, events, registrations, clients, pictures] =
       await Promise.all([

--- a/seeds/run.ts
+++ b/seeds/run.ts
@@ -95,6 +95,18 @@ const VALID_OPTIONS = ['--dry-run', '--clear-cache', '--update']
 const SCRIPT_DATA_FILES: Partial<Record<ScriptName, string[]>> = {
   'wm-app-translations': ['seeds/wm-app-translations/data.en.json'],
   translations: ['seeds/wm-app-translations/data.en.json'],
+  // Atlas reads all 8 dumps via loadJsonData (keyed by these exact paths); the
+  // standalone build excludes seeds/, so the CLI uploads them for remote seeding.
+  atlas: [
+    'seeds/atlas/data/users.json',
+    'seeds/atlas/data/managers.json',
+    'seeds/atlas/data/regions.json',
+    'seeds/atlas/data/venues.json',
+    'seeds/atlas/data/events.json',
+    'seeds/atlas/data/registrations.json',
+    'seeds/atlas/data/clients.json',
+    'seeds/atlas/data/pictures.json',
+  ],
 }
 
 /**


### PR DESCRIPTION
## Problem

Seeding Atlas against a **deployed** environment (`SAHAJCLOUD_URL=https://cloud.sydevelopers.com pnpm seed atlas …`) fails immediately with:

```
❌ Error: ENOENT: no such file or directory, open '/app/.next/standalone/seeds/atlas/data/users.json'
```

The production standalone build **excludes `seeds/**`** (`next.config.mjs` `outputFileTracingExcludes` — "prod never runs seeds"), so the Atlas importer's `fs` read of `seeds/atlas/data/*.json` has no files to read on the server. Auth succeeds; the data load is what fails.

Found while validating a production dry-run after #510 merged.

## Fix

Use the **inline-upload** mechanism the seed route + CLI already support (and that `wm-app-translations` already uses):

- `seeds/atlas/import.ts` — `getData()` loads each file via `loadJsonData({ localPath, inlineContent: this.options.inlineData?.[localPath] })` instead of a plain `fs` read.
- `seeds/run.ts` — register the 8 Atlas data files in `SCRIPT_DATA_FILES` so the CLI reads them locally and uploads them in the request body.

Locally the files are still read from disk. The data is only 2.2 MB — well under the route's `request.json()` limit (app-router, no 1 MB cap) and Cloudflare's 100 MB.

## Validation

Proved the inline path works under the exact prod condition (a filesystem without `seeds/`): with `inlineContent` it loads all 8 files; without it the same `fs` read fails (`ENOENT`) — confirming `inlineContent` genuinely carries the data, not an fs fallback.

The production dry-run itself can only pass once this is deployed (prod currently runs the old `fs`-only importer).

Refs #508

🤖 Generated with [Claude Code](https://claude.com/claude-code)
