### PR TITLE
feat(blocks): emit typed interfaces + add Splash textColor field

### DIFF
--- a/.claude/hooks/payload-types-gen.mjs
+++ b/.claude/hooks/payload-types-gen.mjs
@@ -3,8 +3,13 @@
 /**
  * Payload Types Generation Hook (PostToolUse / Edit|Write)
  *
- * Regenerates TypeScript types when collection / block / field / global schemas
- * or payload.config.ts change. Runs silently on success; reports errors only.
+ * Regenerates TypeScript types when a Payload schema source changes. Watched paths:
+ *   - src/collections/
+ *   - src/lib/richEditor/blocks/  (Lexical page-block configs live here, NOT src/blocks/)
+ *   - src/fields/
+ *   - src/globals/
+ *   - src/payload.config.ts
+ * Runs silently on success; reports errors only.
  */
 
 import { execSync } from 'child_process'
@@ -18,7 +23,7 @@ const rel = filePath.startsWith(projectDir + '/') ? filePath.slice(projectDir.le
 
 const shouldRegenerate =
   /^src\/collections\//.test(rel) ||
-  /^src\/blocks\//.test(rel) ||
+  /^src\/lib\/richEditor\/blocks\//.test(rel) ||
   /^src\/fields\//.test(rel) ||
   /^src\/globals\//.test(rel) ||
   rel === 'src/payload.config.ts'

--- a/src/lib/richEditor/blocks/ButtonBlock.ts
+++ b/src/lib/richEditor/blocks/ButtonBlock.ts
@@ -2,6 +2,7 @@ import { Block } from 'payload'
 
 export const ButtonBlock: Block = {
   slug: 'button',
+  interfaceName: 'ButtonBlock',
   // Icon: Rounded button shape (20x20, gray stroked)
   imageURL:
     'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyMCAyMCIgd2lkdGg9IjIwIiBoZWlnaHQ9IjIwIiBmaWxsPSJub25lIiBzdHJva2U9IiM2QjcyODAiIHN0cm9rZS1saW5lY2FwPSJyb3VuZCIgc3Ryb2tlLWxpbmVqb2luPSJyb3VuZCI+PHJlY3QgeD0iMyIgeT0iNiIgd2lkdGg9IjE0IiBoZWlnaHQ9IjgiIHJ4PSIyIi8+PGxpbmUgeDE9IjciIHkxPSIxMCIgeDI9IjEzIiB5Mj0iMTAiLz48L3N2Zz4K',

--- a/src/lib/richEditor/blocks/ContentIndexBlock.ts
+++ b/src/lib/richEditor/blocks/ContentIndexBlock.ts
@@ -47,10 +47,7 @@ export const computeApiEndpoint: FieldHook = ({ siblingData }) => {
 
   const rawLimit = siblingData?.limit
   const limit =
-    typeof rawLimit === 'number' &&
-    Number.isInteger(rawLimit) &&
-    rawLimit >= 1 &&
-    rawLimit <= 100
+    typeof rawLimit === 'number' && Number.isInteger(rawLimit) && rawLimit >= 1 && rawLimit <= 100
       ? rawLimit
       : null
   if (limit === null) return null
@@ -91,6 +88,7 @@ function clearWhenTypeNot(activeType: string): {
 
 export const ContentIndexBlock: Block = {
   slug: 'content-index',
+  interfaceName: 'ContentIndexBlock',
   // Icon: Grid of document pages (20x20, gray stroked)
   imageURL:
     'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyMCAyMCIgd2lkdGg9IjIwIiBoZWlnaHQ9IjIwIiBmaWxsPSJub25lIiBzdHJva2U9IiM2QjcyODAiIHN0cm9rZS1saW5lY2FwPSJyb3VuZCIgc3Ryb2tlLWxpbmVqb2luPSJyb3VuZCI+PHJlY3QgeD0iMiIgeT0iMiIgd2lkdGg9IjYiIGhlaWdodD0iNyIgcng9IjAuNSIvPjxsaW5lIHgxPSIzLjUiIHkxPSI0IiB4Mj0iNi41IiB5Mj0iNCIvPjxsaW5lIHgxPSIzLjUiIHkxPSI2IiB4Mj0iNS41IiB5Mj0iNiIvPjxyZWN0IHg9IjEyIiB5PSIyIiB3aWR0aD0iNiIgaGVpZ2h0PSI3IiByeD0iMC41Ii8+PGxpbmUgeDE9IjEzLjUiIHkxPSI0IiB4Mj0iMTYuNSIgeTI9IjQiLz48bGluZSB4MT0iMTMuNSIgeTE9IjYiIHgyPSIxNS41IiB5Mj0iNiIvPjxyZWN0IHg9IjIiIHk9IjExIiB3aWR0aD0iNiIgaGVpZ2h0PSI3IiByeD0iMC41Ii8+PGxpbmUgeDE9IjMuNSIgeTE9IjEzIiB4Mj0iNi41IiB5Mj0iMTMiLz48bGluZSB4MT0iMy41IiB5MT0iMTUiIHgyPSI1LjUiIHkyPSIxNSIvPjxyZWN0IHg9IjEyIiB5PSIxMSIgd2lkdGg9IjYiIGhlaWdodD0iNyIgcng9IjAuNSIvPjxsaW5lIHgxPSIxMy41IiB5MT0iMTMiIHgyPSIxNi41IiB5Mj0iMTMiLz48bGluZSB4MT0iMTMuNSIgeTE9IjE1IiB4Mj0iMTUuNSIgeTI9IjE1Ii8+PC9zdmc+Cg==',

--- a/src/lib/richEditor/blocks/ImageGalleryBlock.ts
+++ b/src/lib/richEditor/blocks/ImageGalleryBlock.ts
@@ -2,6 +2,7 @@ import { Block } from 'payload'
 
 export const ImageGalleryBlock: Block = {
   slug: 'image-gallery',
+  interfaceName: 'ImageGalleryBlock',
   // Icon: Overlapping frames with filled front (20x20, gray stroked/filled)
   imageURL:
     'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyMCAyMCIgd2lkdGg9IjIwIiBoZWlnaHQ9IjIwIiBmaWxsPSJub25lIiBzdHJva2U9IiM2QjcyODAiIHN0cm9rZS1saW5lY2FwPSJyb3VuZCIgc3Ryb2tlLWxpbmVqb2luPSJyb3VuZCI+PHJlY3QgeD0iMiIgeT0iNSIgd2lkdGg9IjEwIiBoZWlnaHQ9IjEwIiByeD0iMSIvPjxyZWN0IHg9IjUiIHk9IjMiIHdpZHRoPSIxMCIgaGVpZ2h0PSIxMCIgcng9IjEiLz48cmVjdCB4PSI4IiB5PSI2IiB3aWR0aD0iMTAiIGhlaWdodD0iMTAiIHJ4PSIxIiBmaWxsPSIjNkI3MjgwIiBzdHJva2U9IiM2QjcyODAiLz48L3N2Zz4K',

--- a/src/lib/richEditor/blocks/LayoutBlock.ts
+++ b/src/lib/richEditor/blocks/LayoutBlock.ts
@@ -15,6 +15,7 @@ const computeTabTitleUrls: FieldHook = ({ value, siblingData }) => {
 
 export const LayoutBlock: Block = {
   slug: 'layout',
+  interfaceName: 'LayoutBlock',
   // Icon: 2x2 grid (20x20, gray stroked)
   imageURL:
     'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyMCAyMCIgd2lkdGg9IjIwIiBoZWlnaHQ9IjIwIiBmaWxsPSJub25lIiBzdHJva2U9IiM2QjcyODAiIHN0cm9rZS1saW5lY2FwPSJyb3VuZCIgc3Ryb2tlLWxpbmVqb2luPSJyb3VuZCI+PHJlY3QgeD0iMyIgeT0iMyIgd2lkdGg9IjYiIGhlaWdodD0iNiIgcng9IjEiLz48cmVjdCB4PSIxMSIgeT0iMyIgd2lkdGg9IjYiIGhlaWdodD0iNiIgcng9IjEiLz48cmVjdCB4PSIzIiB5PSIxMSIgd2lkdGg9IjYiIGhlaWdodD0iNiIgcng9IjEiLz48cmVjdCB4PSIxMSIgeT0iMTEiIHdpZHRoPSI2IiBoZWlnaHQ9IjYiIHJ4PSIxIi8+PC9zdmc+Cg==',

--- a/src/lib/richEditor/blocks/QuoteBlock.ts
+++ b/src/lib/richEditor/blocks/QuoteBlock.ts
@@ -2,6 +2,7 @@ import { Block } from 'payload'
 
 export const QuoteBlock: Block = {
   slug: 'quote',
+  interfaceName: 'QuoteBlock',
   labels: {
     singular: 'Quote Box',
     plural: 'Quote Boxes',

--- a/src/lib/richEditor/blocks/ShowcaseBlock.ts
+++ b/src/lib/richEditor/blocks/ShowcaseBlock.ts
@@ -2,6 +2,7 @@ import { Block } from 'payload'
 
 export const ShowcaseBlock: Block = {
   slug: 'showcase',
+  interfaceName: 'ShowcaseBlock',
   // Icon: Star with content lines (20x20, gray filled/stroked)
   imageURL:
     'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyMCAyMCIgd2lkdGg9IjIwIiBoZWlnaHQ9IjIwIiBmaWxsPSJub25lIiBzdHJva2U9IiM2QjcyODAiIHN0cm9rZS1saW5lY2FwPSJyb3VuZCIgc3Ryb2tlLWxpbmVqb2luPSJyb3VuZCI+PHBhdGggZD0iTTEwIDJsMiA0aDRsLTMgMyAxIDQtNC0yLTQgMiAxLTQtMy0zaDR6IiBmaWxsPSIjNkI3MjgwIi8+PGxpbmUgeDE9IjQiIHkxPSIxNiIgeDI9IjE2IiB5Mj0iMTYiLz48bGluZSB4MT0iNiIgeTE9IjE4IiB4Mj0iMTQiIHkyPSIxOCIvPjwvc3ZnPgo=',

--- a/src/lib/richEditor/blocks/SplashBlock.ts
+++ b/src/lib/richEditor/blocks/SplashBlock.ts
@@ -2,6 +2,7 @@ import { Block } from 'payload'
 
 export const SplashBlock: Block = {
   slug: 'splash',
+  interfaceName: 'SplashBlock',
   // Icon: Full-width banner (20x20, gray stroked)
   imageURL:
     'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyMCAyMCIgd2lkdGg9IjIwIiBoZWlnaHQ9IjIwIiBmaWxsPSJub25lIiBzdHJva2U9IiM2QjcyODAiIHN0cm9rZS1saW5lY2FwPSJyb3VuZCIgc3Ryb2tlLWxpbmVqb2luPSJyb3VuZCI+PHJlY3QgeD0iMiIgeT0iNCIgd2lkdGg9IjE2IiBoZWlnaHQ9IjEyIiByeD0iMSIvPjxjaXJjbGUgY3g9IjYiIGN5PSI4IiByPSIxLjUiLz48bGluZSB4MT0iNiIgeTE9IjEyIiB4Mj0iMTQiIHkyPSIxMiIvPjxsaW5lIHgxPSI4IiB5MT0iMTQiIHgyPSIxMiIgeTI9IjE0Ii8+PC9zdmc+Cg==',

--- a/src/lib/richEditor/blocks/SplashBlock.ts
+++ b/src/lib/richEditor/blocks/SplashBlock.ts
@@ -30,6 +30,20 @@ export const SplashBlock: Block = {
       },
     },
     {
+      name: 'textColor',
+      type: 'select',
+      label: 'Text Colour',
+      defaultValue: 'dark',
+      options: [
+        { label: 'Dark Text', value: 'dark' },
+        { label: 'Light Text', value: 'light' },
+      ],
+      admin: {
+        description:
+          'Text colour for the splash. Light text suits a dark hero; dark text suits a light hero. The overlaid site-header theme follows this setting.',
+      },
+    },
+    {
       name: 'images',
       type: 'upload',
       relationTo: 'images',

--- a/src/lib/richEditor/blocks/SubtleSystemBlock.ts
+++ b/src/lib/richEditor/blocks/SubtleSystemBlock.ts
@@ -2,6 +2,7 @@ import { Block } from 'payload'
 
 export const SubtleSystemBlock: Block = {
   slug: 'subtle-system',
+  interfaceName: 'SubtleSystemBlock',
   // Icon: Lotus flower with three petals (20x20, gray filled)
   imageURL:
     'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyMCAyMCIgd2lkdGg9IjIwIiBoZWlnaHQ9IjIwIiBmaWxsPSIjNkI3MjgwIj48cGF0aCBkPSJNMTAgM2MtMSAzLTIgNi0yIDhoNGMwLTItMS01LTItOHoiLz48cGF0aCBkPSJNOCAxMWMtNC0xLTYgMS02IDFzMyAyIDYgMnYtM3oiLz48cGF0aCBkPSJNMTIgMTFjNC0xIDYgMSA2IDFzLTMgMi02IDJ2LTN6Ii8+PHBhdGggZD0iTTkgMTVoMnYzSDl6Ii8+PC9zdmc+Cg==',

--- a/src/lib/richEditor/blocks/TableOfContentsBlock.ts
+++ b/src/lib/richEditor/blocks/TableOfContentsBlock.ts
@@ -2,6 +2,7 @@ import type { Block } from 'payload'
 
 export const TableOfContentsBlock: Block = {
   slug: 'table-of-contents',
+  interfaceName: 'TableOfContentsBlock',
   // Icon: Hierarchical list (20x20, gray stroked) — 4 lines at varying indentation
   imageURL:
     'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyMCAyMCIgd2lkdGg9IjIwIiBoZWlnaHQ9IjIwIiBmaWxsPSJub25lIiBzdHJva2U9IiM2QjcyODAiIHN0cm9rZS1saW5lY2FwPSJyb3VuZCIgc3Ryb2tlLWxpbmVqb2luPSJyb3VuZCI+PGxpbmUgeDE9IjMiIHkxPSI0IiB4Mj0iMTMiIHkyPSI0Ii8+PGxpbmUgeDE9IjYiIHkxPSI4IiB4Mj0iMTYiIHkyPSI4Ii8+PGxpbmUgeDE9IjYiIHkxPSIxMiIgeDI9IjE1IiB5Mj0iMTIiLz48bGluZSB4MT0iOSIgeTE9IjE2IiB4Mj0iMTciIHkyPSIxNiIvPjwvc3ZnPg==',

--- a/src/lib/richEditor/blocks/TextBoxBlock.ts
+++ b/src/lib/richEditor/blocks/TextBoxBlock.ts
@@ -4,6 +4,7 @@ import { mediaField } from '@/fields'
 
 export const TextBoxBlock: Block = {
   slug: 'textbox',
+  interfaceName: 'TextBoxBlock',
   // Icon: Rectangle with text lines and image placeholder (20x20, gray stroked)
   imageURL:
     'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyMCAyMCIgd2lkdGg9IjIwIiBoZWlnaHQ9IjIwIiBmaWxsPSJub25lIiBzdHJva2U9IiM2QjcyODAiIHN0cm9rZS1saW5lY2FwPSJyb3VuZCIgc3Ryb2tlLWxpbmVqb2luPSJyb3VuZCI+PHJlY3QgeD0iMiIgeT0iMyIgd2lkdGg9IjE2IiBoZWlnaHQ9IjE0IiByeD0iMSIvPjxsaW5lIHgxPSI1IiB5MT0iNyIgeDI9IjEwIiB5Mj0iNyIvPjxsaW5lIHgxPSI1IiB5MT0iMTAiIHgyPSI5IiB5Mj0iMTAiLz48bGluZSB4MT0iNSIgeTE9IjEzIiB4Mj0iOCIgeTI9IjEzIi8+PHJlY3QgeD0iMTIiIHk9IjYiIHdpZHRoPSI0IiBoZWlnaHQ9IjUiIHJ4PSIwLjUiLz48L3N2Zz4K',

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -6956,6 +6956,237 @@ export interface TaskSchedulePublish {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "TextBoxBlock".
+ */
+export interface TextBoxBlock {
+  image: number | Image;
+  imagePosition: 'left' | 'right' | 'overlay';
+  textPosition?: ('left' | 'right' | 'center') | null;
+  textColor?: ('dark' | 'light') | null;
+  wisdomStyle?: boolean | null;
+  title?: string | null;
+  subtitle?: string | null;
+  text?: string | null;
+  buttonText?: string | null;
+  buttonUrl?: string | null;
+  /**
+   * Original import data (background, color, position, spacing, decorations)
+   */
+  importData?:
+    | {
+        [k: string]: unknown;
+      }
+    | unknown[]
+    | string
+    | number
+    | boolean
+    | null;
+  id?: string | null;
+  blockName?: string | null;
+  blockType: 'textbox';
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "LayoutBlock".
+ */
+export interface LayoutBlock {
+  style: 'grid' | 'tabs' | 'accordion' | 'list' | 'textList';
+  /**
+   * If you use this title instead of a regular heading block, this title will be used as a sticky header that remains visible as you scroll through the blocks.
+   */
+  title?: string | null;
+  /**
+   * Enter the title of the tab that should be open by default. Will be converted to match the tab anchor (e.g. "My Tab" → "#my-tab").
+   */
+  defaultTab?: string | null;
+  /**
+   * Display tabs as side-by-side columns on desktop screens.
+   */
+  useColumnsOnDesktop?: boolean | null;
+  items?:
+    | {
+        image?: (number | null) | Image;
+        title?: string | null;
+        titleUrl?: string | null;
+        text?: string | null;
+        id?: string | null;
+      }[]
+    | null;
+  id?: string | null;
+  blockName?: string | null;
+  blockType: 'layout';
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "ImageGalleryBlock".
+ */
+export interface ImageGalleryBlock {
+  items?: (number | Image)[] | null;
+  id?: string | null;
+  blockName?: string | null;
+  blockType: 'image-gallery';
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "ShowcaseBlock".
+ */
+export interface ShowcaseBlock {
+  items?:
+    | (
+        | {
+            relationTo: 'meditations';
+            value: number | Meditation;
+          }
+        | {
+            relationTo: 'pages';
+            value: number | Page;
+          }
+        | {
+            relationTo: 'lectures';
+            value: number | Lecture;
+          }
+        | {
+            relationTo: 'app-cards';
+            value: number | AppCard;
+          }
+      )[]
+    | null;
+  id?: string | null;
+  blockName?: string | null;
+  blockType: 'showcase';
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "ButtonBlock".
+ */
+export interface ButtonBlock {
+  text: string;
+  url: string;
+  id?: string | null;
+  blockName?: string | null;
+  blockType: 'button';
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "QuoteBlock".
+ */
+export interface QuoteBlock {
+  title?: string | null;
+  text: string;
+  /**
+   * This is the author or other source for the quote.
+   */
+  credit?: string | null;
+  /**
+   * This will appear below the credit.
+   */
+  caption?: string | null;
+  id?: string | null;
+  blockName?: string | null;
+  blockType: 'quote';
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "TableOfContentsBlock".
+ */
+export interface TableOfContentsBlock {
+  /**
+   * Optional heading displayed above the list (e.g. "In this article")
+   */
+  title?: string | null;
+  /**
+   * Select headings above to include in the table of contents
+   */
+  headings?:
+    | {
+        [k: string]: unknown;
+      }
+    | unknown[]
+    | string
+    | number
+    | boolean
+    | null;
+  id?: string | null;
+  blockName?: string | null;
+  blockType: 'table-of-contents';
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "ContentIndexBlock".
+ */
+export interface ContentIndexBlock {
+  type: 'meditations' | 'pages' | 'songs' | 'lectures';
+  /**
+   * Maximum number of items to return (1–100)
+   */
+  limit: number;
+  /**
+   * Select page tags to use as filters for this index grid
+   */
+  pageFilters?: ('wisdom' | 'lifestyle' | 'creativity' | 'event' | 'technique')[] | null;
+  /**
+   * Select user choices to use as filters for this index grid
+   */
+  userChoiceFilters?: (number | UserChoice)[] | null;
+  /**
+   * Select music tags to use as filters for this index grid
+   */
+  songFilters?: (number | SongTag)[] | null;
+  apiEndpoint?: string | null;
+  id?: string | null;
+  blockName?: string | null;
+  blockType: 'content-index';
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "SubtleSystemBlock".
+ */
+export interface SubtleSystemBlock {
+  left: number | Page;
+  right: number | Page;
+  center: number | Page;
+  mooladhara: number | Page;
+  kundalini: number | Page;
+  swadhistan: number | Page;
+  nabhi: number | Page;
+  void: number | Page;
+  anahat: number | Page;
+  vishuddhi: number | Page;
+  agnya: number | Page;
+  sahasrara: number | Page;
+  id?: string | null;
+  blockName?: string | null;
+  blockType: 'subtle-system';
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "SplashBlock".
+ */
+export interface SplashBlock {
+  /**
+   * Select the layout style for this splash section
+   */
+  layout: 'default' | 'countdown' | 'app' | 'map-search';
+  /**
+   * Select one or more images for the splash section
+   */
+  images?: (number | Image)[] | null;
+  title?: string | null;
+  subtitle?: string | null;
+  /**
+   * Button or call-to-action text
+   */
+  actionText?: string | null;
+  /**
+   * URL for the action button
+   */
+  actionURL?: string | null;
+  id?: string | null;
+  blockName?: string | null;
+  blockType: 'splash';
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "auth".
  */
 export interface Auth {

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -7168,6 +7168,10 @@ export interface SplashBlock {
    */
   layout: 'default' | 'countdown' | 'app' | 'map-search';
   /**
+   * Text colour for the splash. Light text suits a dark hero; dark text suits a light hero. The overlaid site-header theme follows this setting.
+   */
+  textColor?: ('dark' | 'light') | null;
+  /**
    * Select one or more images for the splash section
    */
   images?: (number | Image)[] | null;

--- a/tests/unit/splash-block.spec.ts
+++ b/tests/unit/splash-block.spec.ts
@@ -1,0 +1,36 @@
+import type { SelectField } from 'payload'
+
+import { describe, expect, it } from 'vitest'
+
+import { SplashBlock } from '@/lib/richEditor/blocks/SplashBlock'
+
+/**
+ * The WeMeditate web app overlays the site header on a page's lead Splash block
+ * and themes it from `splash.textColor` (light text ⇒ dark hero ⇒ dark header,
+ * and vice-versa). The field name and its `'dark' | 'light'` values are a
+ * cross-repo contract, so this guards them against accidental rename/removal.
+ * See issue #516.
+ */
+describe('SplashBlock textColor field', () => {
+  const textColor = SplashBlock.fields.find(
+    (field): field is SelectField => field.type === 'select' && field.name === 'textColor',
+  )
+
+  it('is a select field defaulting to dark', () => {
+    expect(textColor).toBeDefined()
+    expect(textColor?.defaultValue).toBe('dark')
+  })
+
+  it('offers exactly the dark and light options the web app expects', () => {
+    const values = textColor?.options?.map((option) =>
+      typeof option === 'string' ? option : option.value,
+    )
+    // Order-independent: the web-app contract is the set of values, not their
+    // dropdown order. Set equality still fails if a value is missing or added.
+    expect(new Set(values)).toEqual(new Set(['dark', 'light']))
+  })
+
+  it('stays optional so existing splash blocks remain valid (web app defaults to dark when absent)', () => {
+    expect(textColor?.required).toBeFalsy()
+  })
+})


### PR DESCRIPTION
## Summary

- Adds an optional `textColor` select (`'dark' | 'light'`, default `'dark'`) to the **Splash** block so editors can author light- or dark-themed splash heroes; the We Meditate web app reads it to theme the overlaid site header.
- Sets `interfaceName` on **all 10 page blocks** so Payload emits a named, importable interface per block in `payload-types.ts` — previously every Lexical block's fields collapsed into the generic `[k: string]: unknown` on the Pages `content` field, forcing the web app to hand-roll its own block types.

## Changes

- `src/lib/richEditor/blocks/*.ts` — `interfaceName` added to every page block (Button, ContentIndex, ImageGallery, Layout, Quote, Showcase, Splash, SubtleSystem, TableOfContents, TextBox).
- `src/lib/richEditor/blocks/SplashBlock.ts` — new optional `textColor` select, kept **optional** so existing splash blocks stay valid and the web app keeps its default-to-`dark`-when-absent fallback.
- `src/payload-types.ts` — regenerated; now exports a typed interface per block, including `SplashBlock.textColor?: ('dark' | 'light') | null`.
- `tests/unit/splash-block.spec.ts` — contract test guarding the field name, the `dark`/`light` value set, default, and optionality.

## Test Results

- Unit: 602 passed
- Integration (targeted): `pages` 18 passed, `content-index-block` 32 passed — verifies that adding `interfaceName` to a Lexical block doesn't change runtime block round-tripping
- Lint: ✓ No errors · Typecheck: ✓ · `payload-types.ts`: no drift
- Build: runs on the Railway preview deploy (not in GitHub Actions)

## Notes for reviewer

- **No DB migration**: these are Lexical inline blocks — their data lives in the Pages `content` JSON, not relational tables (verified: no Lexical block field appears as a DB column or in any migration). `interfaceName` is a type-generation-only change.
- The Pages `content` rich-text field type stays generic by design; the value of `interfaceName` is the standalone exported interfaces the web app imports.
- **Scope note**: #516 asked only for the Splash field. Emitting typed interfaces for *all* blocks (rather than a one-off `interfaceName` on Splash) was chosen for consistency — there is no Payload config-level switch to type Lexical blocks in bulk, so it's per-block by design.

Closes #516

🤖 Generated with [Claude Code](https://claude.com/claude-code)
