### PR TITLE
feat(usage): enforce CORS + Origin/Referer against client allowedDomains

### DIFF
--- a/.claude/rules/api-clients.md
+++ b/.claude/rules/api-clients.md
@@ -147,6 +147,68 @@ the access layer uses to unlock drafts in `createAccessConfig`). Rate limiting
 and usage tracking still apply. Without this, PR #294's gate breaks the
 meditations, pages, and wemeditate-web live previews.
 
+## Origin / Referer Enforcement
+
+`validateClientOriginHook` (`src/plugins/usage/hooks.ts`) is the second
+beforeOperation client gate. The usage plugin runs it **first** on every
+non-excluded collection — ahead of the query-param gate and rate accounting — so
+a disallowed origin is rejected before any other work. Centralizing it in the
+plugin means it covers standard client reads **and** the custom Atlas endpoints
+(`GET /api/events/geojson`, `POST /api/events/:id/register`), whose internal
+`payload.find` / `payload.create` calls forward the client `req`.
+
+### Rule
+
+- Runs only when `req.user?.collection === 'clients'` — managers, admin UI, and
+  server tasks are untouched.
+- **Empty / unset `allowedDomains` → allow any origin** (backward-compatible
+  default; the field is the Atlas-config textarea on `Clients`).
+- **Non-empty `allowedDomains`** → the request `Origin` (or the `Referer` host as
+  fallback) must match an entry, else **403**.
+- **No `Origin`/`Referer`** (server-to-server, cron) → **allow**; the API key
+  remains the gate.
+
+### Matching (`src/plugins/usage/originEnforcement.ts`)
+
+Pure, unit-tested helpers normalize both sides to a bare host — scheme, userinfo,
+port, path, and trailing dot stripped, lowercased — then match:
+
+- **Exact host**: `example.org` matches only `example.org`.
+- **`*.` wildcard**: `*.example.org` matches any subdomain (`a.example.org`,
+  `a.b.example.org`) but **not** the apex `example.org`. The leading-dot suffix
+  blocks injection (`evil-example.org` does not match).
+
+### Bypasses
+
+- **Valid live-preview secret** (`hasValidPreviewSecret`) — same trust signal that
+  unlocks drafts and skips the query-param gate.
+- **Internal relationship-population reads** (numeric `currentDepth`) — they reuse
+  the already-validated top-level request's origin.
+- `asTrustedReq()` does **not** bypass origin enforcement. Its
+  `skipClientQueryValidation` flag is a query-shape opt-out, not a security one —
+  forwarded client reads stay enforced against the caller's real origin.
+
+On rejection the hook logs `clientId` + origin + referer at WARN. The geojson and
+register handlers surface the thrown `APIError(403)` verbatim (instead of masking
+it as a 500).
+
+### CORS
+
+`payload.config.ts` sets `cors: '*'`. Per-client CORS is impossible — CORS
+preflight (`OPTIONS`) is anonymous (the browser omits `Authorization`), so the
+server cannot return a per-client allowlist at preflight time. `'*'` lets embedded
+widgets' preflight succeed on any host page; the real per-domain gate is this
+server-side hook plus the API key. Payload omits `Access-Control-Allow-Credentials`
+for `'*'`, so cookie-based admin sessions stay protected — the `csrf` allowlist is
+unchanged.
+
+### Tests
+
+- `tests/unit/origin-enforcement.spec.ts` — normalization + matching (exact,
+  wildcard, suffix-injection, empty, missing-header).
+- `tests/int/client-origin-enforcement.int.spec.ts` — wiring through
+  `payload.find` and the geojson/register endpoints (403 / allow).
+
 ## Usage monitoring
 
 - **Async tracking** via Payload job queue (no in-request DB write).

--- a/src/collections/Events/endpoints/geojson.ts
+++ b/src/collections/Events/endpoints/geojson.ts
@@ -91,7 +91,8 @@ export const eventsGeoJson: Endpoint = {
       )
     } catch (error) {
       // validateClientQueryParamsHook throws APIError(400) for a missing
-      // select / populate-at-depth>1 — surface its status + message verbatim.
+      // select / populate-at-depth>1, and validateClientOriginHook throws
+      // APIError(403) for a disallowed origin — surface status + message verbatim.
       if (error instanceof APIError) {
         return Response.json({ errors: [{ message: error.message }] }, { status: error.status })
       }

--- a/src/collections/Events/endpoints/registerForEvent.ts
+++ b/src/collections/Events/endpoints/registerForEvent.ts
@@ -3,6 +3,7 @@ import type { Endpoint } from 'payload'
 
 import { randomUUID } from 'node:crypto'
 
+import { APIError } from 'payload'
 import { z } from 'zod'
 
 import { parseBody, requireActiveClient } from '@/lib/endpoints'
@@ -29,7 +30,9 @@ const bodySchema = z.object({
  * published client key (`requireActiveClient`); the event-existence read below is
  * an ordinary client read, so Cloudflare edge rate limiting + the usage plugin's
  * tracking cover abuse exactly as they do for every other client request.
- * (Per-origin `allowedDomains` enforcement is deferred to #509.)
+ * Per-origin `allowedDomains` enforcement also applies: the events lookup runs the
+ * usage plugin's `validateClientOriginHook`, which 403s a disallowed Origin/Referer
+ * (surfaced verbatim by the catch below).
  *
  * Flow: parse the `:id` + body → confirm the event is one the client may see
  * (published + project-visible) → upsert the registrant `user` by normalized
@@ -122,6 +125,12 @@ export const registerForEvent: Endpoint = {
       }
       return Response.json(body, { status: 201 })
     } catch (error) {
+      // validateClientOriginHook throws APIError(403) for a disallowed origin (and
+      // query validation could throw 400) from the reads above — surface its
+      // status + message verbatim rather than masking it as a 500.
+      if (error instanceof APIError) {
+        return Response.json({ errors: [{ message: error.message }] }, { status: error.status })
+      }
       req.payload.logger.error({
         msg: 'registerForEvent: registration failed',
         clientId: req.user?.id,

--- a/src/payload.config.ts
+++ b/src/payload.config.ts
@@ -51,7 +51,15 @@ const payloadConfig = (overrides?: Partial<Config>) => {
       defaultLocale: DEFAULT_LOCALE,
       filterAvailableLocales,
     },
-    cors: [serverUrl, serverEnv.WEMEDITATE_WEB_URL, serverEnv.SAHAJATLAS_URL],
+    // CORS is intentionally open. Per-client origin enforcement is server-side:
+    // `validateClientOriginHook` (usagePlugin) checks each request's Origin/Referer
+    // against the client's `allowedDomains`, and the API key gates access. CORS
+    // preflight is anonymous — the browser omits Authorization, so the server
+    // cannot return a per-client allowlist at preflight time. `'*'` lets embedded
+    // Atlas widgets' preflight succeed on any host page; Payload omits
+    // Access-Control-Allow-Credentials for `'*'`, so cookie-based admin sessions
+    // stay protected (the static `csrf` list below is unchanged). See #509.
+    cors: '*',
     csrf: [serverUrl, serverEnv.WEMEDITATE_WEB_URL, serverEnv.SAHAJATLAS_URL],
     admin: {
       user: Managers.slug,

--- a/src/plugins/usage/hooks.ts
+++ b/src/plugins/usage/hooks.ts
@@ -14,6 +14,7 @@ import { APIError } from 'payload'
 import { hasValidPreviewSecret } from '@/lib/utilities/previewSecret'
 
 import { getDbSchema, getPgPool } from './db'
+import { extractRequestHost, isHostAllowed, parseAllowedDomains } from './originEnforcement'
 
 const SKIP_VALIDATION = 'skipClientQueryValidation'
 
@@ -185,6 +186,78 @@ function describeStringPreview(value: unknown): string | null {
     return value.slice(0, 100)
   }
   return null
+}
+
+// ============================================================================
+// ORIGIN / REFERER ENFORCEMENT HOOK
+// ============================================================================
+
+/**
+ * beforeOperation hook enforcing per-client `Origin`/`Referer` allow-listing.
+ *
+ * Runs for every API-client operation on a usage-wrapped collection (the same
+ * seam as `validateClientQueryParamsHook`), so it covers standard client reads
+ * and the custom Atlas endpoints (geojson / register) whose internal
+ * `payload.find` / `payload.create` calls forward the client `req`. Rules:
+ *
+ * - Non-client requests (managers, admin UI, server tasks): untouched.
+ * - Empty / unset `allowedDomains`: ALLOW any origin (backward-compatible default).
+ * - Non-empty `allowedDomains`: the request `Origin` (or `Referer` host) must
+ *   match an entry, else 403. Exact host or `*.`-wildcard; see `originEnforcement.ts`.
+ * - No `Origin`/`Referer` (server-to-server, cron): ALLOW — the API key is the gate.
+ * - Valid live-preview secret: bypass — the same trust signal that unlocks drafts
+ *   and skips the select/populate gate.
+ * - Internal relationship-population reads (numeric `currentDepth`): skipped; the
+ *   already-validated top-level read carries the same origin.
+ *
+ * Unlike `asTrustedReq`'s `skipClientQueryValidation` flag (a query-shape opt-out),
+ * there is deliberately no trusted-req bypass here: origin is a security gate, so
+ * forwarded client reads (e.g. register's events lookup) stay enforced against the
+ * caller's real origin.
+ *
+ * On rejection, logs `clientId` + origin + referer at WARN so production denials
+ * are debuggable from the application logs.
+ */
+export const validateClientOriginHook: CollectionBeforeOperationHook = ({ args, req }) => {
+  if (req.user?.collection !== 'clients') {
+    return
+  }
+
+  // Trusted live-preview reads render the whole document from a known frontend —
+  // same bypass the select/populate gate uses.
+  if (hasValidPreviewSecret(req)) {
+    return
+  }
+
+  // Internal relationship-population reads reuse the top-level request's origin,
+  // which has already passed this check; don't re-evaluate (or double-log) them.
+  if (typeof (args as { currentDepth?: unknown }).currentDepth === 'number') {
+    return
+  }
+
+  const allowedDomains = (req.user as { allowedDomains?: string | null }).allowedDomains
+  const patterns = parseAllowedDomains(allowedDomains)
+  if (patterns.length === 0) {
+    return // No allowlist configured → allow all (backward-compatible default).
+  }
+
+  const host = extractRequestHost(req)
+  if (host === null) {
+    return // No Origin/Referer (server-to-server) → allow; API key remains the gate.
+  }
+
+  if (isHostAllowed(host, patterns)) {
+    return
+  }
+
+  req.payload.logger.warn({
+    msg: 'Client origin validation rejected: request host not in allowedDomains',
+    clientId: req.user.id,
+    host,
+    origin: req.headers?.get?.('origin') ?? null,
+    referer: req.headers?.get?.('referer') ?? null,
+  })
+  throw new APIError('This origin is not allowed for this API client.', 403)
 }
 
 // ============================================================================

--- a/src/plugins/usage/hooks.ts
+++ b/src/plugins/usage/hooks.ts
@@ -12,6 +12,8 @@ import type {
 import { APIError } from 'payload'
 
 import { hasValidPreviewSecret } from '@/lib/utilities/previewSecret'
+import type { Client } from '@/payload-types'
+
 
 import { getDbSchema, getPgPool } from './db'
 import { extractRequestHost, isHostAllowed, parseAllowedDomains } from './originEnforcement'
@@ -235,8 +237,7 @@ export const validateClientOriginHook: CollectionBeforeOperationHook = ({ args, 
     return
   }
 
-  const allowedDomains = (req.user as { allowedDomains?: string | null }).allowedDomains
-  const patterns = parseAllowedDomains(allowedDomains)
+  const patterns = parseAllowedDomains((req.user as Client).allowedDomains)
   if (patterns.length === 0) {
     return // No allowlist configured → allow all (backward-compatible default).
   }

--- a/src/plugins/usage/index.ts
+++ b/src/plugins/usage/index.ts
@@ -25,7 +25,15 @@ export {
 } from './constants'
 
 // Hook exports (for testing)
-export { rateLimitHook, usageTrackingHook } from './hooks'
+export { rateLimitHook, usageTrackingHook, validateClientOriginHook } from './hooks'
+
+// Origin/Referer enforcement helpers (for testing)
+export {
+  extractRequestHost,
+  isHostAllowed,
+  normalizeHost,
+  parseAllowedDomains,
+} from './originEnforcement'
 
 // Rate limiting utilities (for testing)
 export { buildRateLimitKey } from './hooks'

--- a/src/plugins/usage/originEnforcement.ts
+++ b/src/plugins/usage/originEnforcement.ts
@@ -66,7 +66,7 @@ export function parseAllowedDomains(raw: string | null | undefined): string[] {
  */
 export function extractRequestHost(req: PayloadRequest): string | null {
   const origin = req.headers?.get?.('origin')
-  if (origin && origin !== 'null') {
+  if (origin && origin.toLowerCase() !== 'null') {
     const fromOrigin = normalizeHost(origin)
     if (fromOrigin) return fromOrigin
   }

--- a/src/plugins/usage/originEnforcement.ts
+++ b/src/plugins/usage/originEnforcement.ts
@@ -1,0 +1,91 @@
+/**
+ * Origin / Referer enforcement helpers for API-client requests.
+ *
+ * Pure functions (no Payload bootstrap) backing `validateClientOriginHook` in
+ * `./hooks.ts`. They reduce a request's browser origin and a client's
+ * `allowedDomains` allowlist to comparable bare hosts and decide whether the
+ * request is allowed. Matching is exact-host or `*.`-wildcard; see
+ * `.claude/rules/api-clients.md` for the contract.
+ */
+import type { PayloadRequest } from 'payload'
+
+/**
+ * Reduce a raw origin/host string to a bare, comparable host: lowercased, with
+ * scheme + userinfo + port + path + trailing dot stripped. Accepts a full URL
+ * (`https://www.example.org:8080/widget`), a bare host (`www.example.org`), or a
+ * `*.`-prefixed wildcard pattern (`*.example.org`, whose label is preserved).
+ * Returns `null` when nothing host-like can be extracted.
+ */
+export function normalizeHost(raw: string | null | undefined): string | null {
+  if (!raw) return null
+  let value = raw.trim().toLowerCase()
+  if (!value) return null
+
+  // Strip any scheme first so a wildcard written with or without one
+  // (`*.example.org` or `https://*.example.org`) is detected the same way.
+  value = value.replace(/^[a-z][a-z0-9+.-]*:\/\//, '')
+
+  // Preserve a leading wildcard label — the URL parser would reject a bare `*`.
+  const wildcard = value.startsWith('*.')
+  if (wildcard) value = value.slice(2)
+
+  let host: string
+  try {
+    // Re-attach a scheme so the parser accepts bare hosts; it drops any
+    // userinfo / port / path and lowercases the hostname.
+    host = new URL(`https://${value}`).hostname
+  } catch {
+    return null
+  }
+  host = host.replace(/\.$/, '') // trailing-dot FQDN form
+  // The only valid wildcard is a leading `*.` label (handled above); any `*` left
+  // in the host itself is malformed (a bare `*`, `a.*.org`, `*.*.org`, …).
+  if (!host || host.includes('*')) return null
+
+  return wildcard ? `*.${host}` : host
+}
+
+/**
+ * Parse a client's newline-separated `allowedDomains` textarea into a list of
+ * normalized host patterns. Also tolerates comma separators and blank lines.
+ * Empty / unset input yields `[]` — the caller treats that as "allow all".
+ */
+export function parseAllowedDomains(raw: string | null | undefined): string[] {
+  if (!raw) return []
+  return raw
+    .split(/[\r\n,]+/)
+    .map((line) => normalizeHost(line))
+    .filter((host): host is string => host !== null)
+}
+
+/**
+ * Resolve the request's browser host: the `Origin` header, falling back to the
+ * `Referer` host. An opaque `Origin: null` (sandboxed iframe, privacy redirect)
+ * is treated as absent so the Referer can answer. Returns `null` when neither
+ * yields a host — the caller treats that as a server-to-server call and allows it.
+ */
+export function extractRequestHost(req: PayloadRequest): string | null {
+  const origin = req.headers?.get?.('origin')
+  if (origin && origin !== 'null') {
+    const fromOrigin = normalizeHost(origin)
+    if (fromOrigin) return fromOrigin
+  }
+  return normalizeHost(req.headers?.get?.('referer'))
+}
+
+/**
+ * True when `host` matches an entry in `patterns`. An entry is either an exact
+ * host (`example.org`) or a `*.`-wildcard (`*.example.org`) that matches any
+ * subdomain but NOT the apex. The leading dot in the wildcard suffix prevents
+ * suffix-injection (`evil-example.org` does not match `*.example.org`).
+ */
+export function isHostAllowed(host: string | null, patterns: string[]): boolean {
+  if (!host) return false
+  return patterns.some((pattern) => {
+    if (pattern.startsWith('*.')) {
+      const suffix = pattern.slice(1) // ".example.org"
+      return host.length > suffix.length && host.endsWith(suffix)
+    }
+    return host === pattern
+  })
+}

--- a/src/plugins/usage/usagePlugin.ts
+++ b/src/plugins/usage/usagePlugin.ts
@@ -10,7 +10,12 @@
 import type { CollectionSlug, Config } from 'payload'
 
 import { SYSTEM_EXCLUSIONS } from './constants'
-import { rateLimitHook, usageTrackingHook, validateClientQueryParamsHook } from './hooks'
+import {
+  rateLimitHook,
+  usageTrackingHook,
+  validateClientOriginHook,
+  validateClientQueryParamsHook,
+} from './hooks'
 import { resetUsageTask } from './tasks'
 
 /**
@@ -49,6 +54,9 @@ export function usagePlugin(
           ...collection.hooks,
           beforeOperation: [
             ...(collection.hooks?.beforeOperation || []),
+            // Origin enforcement runs first — a disallowed origin is rejected
+            // before query-shape validation or any rate accounting.
+            validateClientOriginHook,
             validateClientQueryParamsHook,
             rateLimitHook,
           ],

--- a/tests/int/client-origin-enforcement.int.spec.ts
+++ b/tests/int/client-origin-enforcement.int.spec.ts
@@ -1,0 +1,208 @@
+import type { Payload, PayloadRequest } from 'payload'
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+
+import { eventsGeoJson } from '@/collections/Events/endpoints/geojson'
+import { registerForEvent } from '@/collections/Events/endpoints/registerForEvent'
+
+import { testData } from '../utils/testData'
+import { createTestEnvironment } from '../utils/testHelpers'
+
+/**
+ * End-to-end wiring for `validateClientOriginHook` (added by the usage plugin to
+ * every non-excluded collection). The pure matching/normalization logic is
+ * covered in `tests/unit/origin-enforcement.spec.ts`; here we prove the hook
+ * fires through `payload.find` and the custom Atlas endpoints, and that a
+ * disallowed origin yields a 403.
+ *
+ * `req.user.allowedDomains` is set on the mock user exactly as production
+ * provides it — the API-key auth loads the full client doc as `req.user`, and the
+ * hook only reads that field (it never re-queries).
+ */
+const SCHEDULE = {
+  firstDate: '2025-01-06T10:00:00.000Z',
+  firstDate_tz: 'Europe/London',
+  recurrenceType: 'DAILY' as const,
+  interval: 1,
+}
+
+describe('client Origin/Referer enforcement', () => {
+  let payload: Payload
+  let cleanup: () => Promise<void>
+  let clientId: number
+  let managerId: number
+  let narratorId: number
+  let eventId: number
+
+  // Build a client request carrying the given allowlist + origin/referer headers.
+  function clientReq(opts: {
+    allowedDomains?: string | null
+    origin?: string
+    referer?: string
+  }): PayloadRequest {
+    const headers = new Headers()
+    if (opts.origin) headers.set('origin', opts.origin)
+    if (opts.referer) headers.set('referer', opts.referer)
+    return {
+      payload,
+      headers,
+      routeParams: {},
+      user: {
+        id: clientId,
+        collection: 'clients',
+        _status: 'published',
+        roles: ['sahaj-atlas-client'],
+        allowedDomains: opts.allowedDomains ?? null,
+      },
+    } as unknown as PayloadRequest
+  }
+
+  // A valid client read (origin allowed → query validation runs next, so select
+  // is required). Narrators is a plain usage-wrapped collection.
+  const findNarrators = (req: PayloadRequest) =>
+    payload.find({
+      collection: 'narrators',
+      select: { name: true },
+      depth: 1,
+      req,
+      overrideAccess: true,
+    })
+
+  beforeAll(async () => {
+    const env = await createTestEnvironment()
+    payload = env.payload
+    cleanup = env.cleanup
+
+    const manager = await testData.createManager(payload, {
+      name: 'Origin Manager',
+      email: 'origin-manager@example.com',
+    })
+    managerId = manager.id
+    const clientDoc = await testData.createClient(payload, managerId, {
+      name: 'Atlas Origin Client',
+      roles: ['sahaj-atlas-client'],
+    })
+    clientId = clientDoc.id
+
+    const narrator = await testData.createNarrator(payload)
+    narratorId = narrator.id
+
+    const region = await payload.create({
+      collection: 'regions',
+      overrideAccess: true,
+      data: { name: 'Origin City', level: 'city', mapboxId: 'origin-city', slug: 'origin-city' },
+    })
+    const event = await payload.create({
+      collection: 'events',
+      overrideAccess: true,
+      data: {
+        title: 'Origin Event',
+        languages: ['en'],
+        eventType: 'online',
+        onlineUrl: 'https://example.com/meet',
+        registrationMode: 'sahaj-atlas',
+        manager: managerId,
+        region: region.id,
+        schedule: SCHEDULE,
+        _status: 'published',
+      },
+    })
+    eventId = event.id
+  })
+
+  afterAll(async () => {
+    await cleanup()
+  })
+
+  describe('non-empty allowedDomains', () => {
+    const allowedDomains = 'allowed.org\n*.wild.org'
+
+    it('rejects with 403 when the Origin host is not in the list', async () => {
+      await expect(
+        findNarrators(clientReq({ allowedDomains, origin: 'https://evil.org' })),
+      ).rejects.toMatchObject({ status: 403 })
+    })
+
+    it('allows when the Origin host matches exactly', async () => {
+      const result = await findNarrators(
+        clientReq({ allowedDomains, origin: 'https://allowed.org' }),
+      )
+      expect(result.docs.map((d) => d.id)).toContain(narratorId)
+    })
+
+    it('allows when only the Referer matches (no Origin header)', async () => {
+      const result = await findNarrators(
+        clientReq({ allowedDomains, referer: 'https://allowed.org/widget?x=1' }),
+      )
+      expect(result.docs.map((d) => d.id)).toContain(narratorId)
+    })
+
+    it('allows a subdomain via a *. wildcard entry', async () => {
+      const result = await findNarrators(
+        clientReq({ allowedDomains, origin: 'https://sub.wild.org' }),
+      )
+      expect(result.docs.map((d) => d.id)).toContain(narratorId)
+    })
+
+    it('rejects the apex of a *. wildcard entry with 403', async () => {
+      await expect(
+        findNarrators(clientReq({ allowedDomains, origin: 'https://wild.org' })),
+      ).rejects.toMatchObject({ status: 403 })
+    })
+
+    it('allows when no Origin/Referer is present (server-to-server)', async () => {
+      const result = await findNarrators(clientReq({ allowedDomains }))
+      expect(result.docs.map((d) => d.id)).toContain(narratorId)
+    })
+  })
+
+  describe('empty allowedDomains', () => {
+    it('allows any origin when the list is null', async () => {
+      const result = await findNarrators(
+        clientReq({ allowedDomains: null, origin: 'https://anything.example' }),
+      )
+      expect(result.docs.map((d) => d.id)).toContain(narratorId)
+    })
+
+    it('allows any origin when the list is blank/whitespace', async () => {
+      const result = await findNarrators(
+        clientReq({ allowedDomains: '   \n  ', origin: 'https://anything.example' }),
+      )
+      expect(result.docs.map((d) => d.id)).toContain(narratorId)
+    })
+  })
+
+  describe('custom Atlas endpoints', () => {
+    const allowedDomains = 'allowed.org'
+
+    it('geojson: 403 for a disallowed origin', async () => {
+      const req = clientReq({ allowedDomains, origin: 'https://evil.org' })
+      req.query = { select: { title: true }, depth: 1 }
+      const res = (await eventsGeoJson.handler(req)) as Response
+      expect(res.status).toBe(403)
+    })
+
+    it('geojson: 200 for an allowed origin', async () => {
+      const req = clientReq({ allowedDomains, origin: 'https://allowed.org' })
+      req.query = { select: { title: true }, depth: 1 }
+      const res = (await eventsGeoJson.handler(req)) as Response
+      expect(res.status).toBe(200)
+    })
+
+    it('register: 403 for a disallowed origin', async () => {
+      const req = clientReq({ allowedDomains, origin: 'https://evil.org' })
+      req.routeParams = { id: String(eventId) }
+      req.json = async () => ({ email: 'reg@evil.org', name: 'Reg' })
+      const res = (await registerForEvent.handler(req)) as Response
+      expect(res.status).toBe(403)
+    })
+
+    it('register: 201 for an allowed origin', async () => {
+      const req = clientReq({ allowedDomains, origin: 'https://allowed.org' })
+      req.routeParams = { id: String(eventId) }
+      req.json = async () => ({ email: 'reg@allowed.org', name: 'Reg' })
+      const res = (await registerForEvent.handler(req)) as Response
+      expect(res.status).toBe(201)
+    })
+  })
+})

--- a/tests/unit/origin-enforcement.spec.ts
+++ b/tests/unit/origin-enforcement.spec.ts
@@ -1,0 +1,115 @@
+import type { PayloadRequest } from 'payload'
+
+import { describe, expect, it } from 'vitest'
+
+// Deep import (not the plugin barrel) keeps this in the unit lane — the barrel
+// pulls in hooks → db → pg pool, which the unit lane must not bootstrap.
+import {
+  extractRequestHost,
+  isHostAllowed,
+  normalizeHost,
+  parseAllowedDomains,
+} from '@/plugins/usage/originEnforcement'
+
+describe('normalizeHost', () => {
+  it('strips scheme, userinfo, port, path and lowercases', () => {
+    expect(normalizeHost('https://user@WWW.Example.org:8080/widget?x=1')).toBe('www.example.org')
+  })
+
+  it('accepts a bare host', () => {
+    expect(normalizeHost('Example.ORG')).toBe('example.org')
+  })
+
+  it('preserves a leading wildcard label', () => {
+    expect(normalizeHost('*.example.org')).toBe('*.example.org')
+    expect(normalizeHost('HTTPS://*.Example.org/')).toBe('*.example.org')
+    expect(normalizeHost('*.example.org:443')).toBe('*.example.org')
+  })
+
+  it('drops a trailing dot (FQDN form)', () => {
+    expect(normalizeHost('example.org.')).toBe('example.org')
+  })
+
+  it('returns null for empty / whitespace / junk', () => {
+    expect(normalizeHost('')).toBeNull()
+    expect(normalizeHost('   ')).toBeNull()
+    expect(normalizeHost(null)).toBeNull()
+    expect(normalizeHost(undefined)).toBeNull()
+    expect(normalizeHost('*')).toBeNull()
+  })
+})
+
+describe('parseAllowedDomains', () => {
+  it('splits on newlines and normalizes each entry', () => {
+    expect(parseAllowedDomains('https://a.org\nb.org\n  *.c.org  ')).toEqual([
+      'a.org',
+      'b.org',
+      '*.c.org',
+    ])
+  })
+
+  it('tolerates comma separators, CRLF, and blank lines', () => {
+    expect(parseAllowedDomains('a.org,,\r\n , b.org\n')).toEqual(['a.org', 'b.org'])
+  })
+
+  it('returns [] for empty / null / undefined', () => {
+    expect(parseAllowedDomains('')).toEqual([])
+    expect(parseAllowedDomains(null)).toEqual([])
+    expect(parseAllowedDomains(undefined)).toEqual([])
+  })
+})
+
+describe('isHostAllowed', () => {
+  it('matches an exact host only', () => {
+    expect(isHostAllowed('example.org', ['example.org'])).toBe(true)
+    expect(isHostAllowed('www.example.org', ['example.org'])).toBe(false)
+  })
+
+  it('wildcard matches subdomains but not the apex', () => {
+    expect(isHostAllowed('a.example.org', ['*.example.org'])).toBe(true)
+    expect(isHostAllowed('a.b.example.org', ['*.example.org'])).toBe(true)
+    expect(isHostAllowed('example.org', ['*.example.org'])).toBe(false)
+  })
+
+  it('wildcard does not allow suffix injection', () => {
+    expect(isHostAllowed('evil-example.org', ['*.example.org'])).toBe(false)
+    expect(isHostAllowed('notexample.org', ['*.example.org'])).toBe(false)
+    expect(isHostAllowed('example.org.evil.com', ['*.example.org'])).toBe(false)
+  })
+
+  it('matches against any entry in the list', () => {
+    expect(isHostAllowed('b.org', ['a.org', 'b.org', '*.c.org'])).toBe(true)
+    expect(isHostAllowed('sub.c.org', ['a.org', 'b.org', '*.c.org'])).toBe(true)
+    expect(isHostAllowed('d.org', ['a.org', 'b.org', '*.c.org'])).toBe(false)
+  })
+
+  it('is false for a null host or an empty pattern list', () => {
+    expect(isHostAllowed(null, ['example.org'])).toBe(false)
+    expect(isHostAllowed('example.org', [])).toBe(false)
+  })
+})
+
+describe('extractRequestHost', () => {
+  const reqWith = (headers: Record<string, string>): PayloadRequest =>
+    ({ headers: new Headers(headers) }) as unknown as PayloadRequest
+
+  it('prefers the Origin header', () => {
+    expect(
+      extractRequestHost(reqWith({ origin: 'https://a.org', referer: 'https://b.org/x' })),
+    ).toBe('a.org')
+  })
+
+  it('falls back to the Referer host when Origin is absent', () => {
+    expect(extractRequestHost(reqWith({ referer: 'https://b.org/page?q=1' }))).toBe('b.org')
+  })
+
+  it('treats an opaque "null" Origin as absent and falls back to Referer', () => {
+    expect(extractRequestHost(reqWith({ origin: 'null', referer: 'https://b.org/x' }))).toBe(
+      'b.org',
+    )
+  })
+
+  it('returns null when neither Origin nor Referer is present', () => {
+    expect(extractRequestHost(reqWith({}))).toBeNull()
+  })
+})

--- a/tests/unit/origin-enforcement.spec.ts
+++ b/tests/unit/origin-enforcement.spec.ts
@@ -37,6 +37,23 @@ describe('normalizeHost', () => {
     expect(normalizeHost(undefined)).toBeNull()
     expect(normalizeHost('*')).toBeNull()
   })
+
+  it('converts IDN to punycode identically for the URL and bare-host forms', () => {
+    // The request side (browser Origin) arrives already punycoded; normalizing the
+    // config side the same way means they compare equal — and a lookalike ASCII
+    // host does NOT (no homograph bypass).
+    expect(normalizeHost('https://MÜNCHEN.de')).toBe(normalizeHost('münchen.de'))
+    expect(normalizeHost('münchen.de')).not.toBe(normalizeHost('munchen.de'))
+  })
+
+  it('normalizes IPv6 hosts in brackets, dropping the port', () => {
+    expect(normalizeHost('[::1]')).toBe('[::1]')
+    expect(normalizeHost('http://[::1]:8080/path')).toBe('[::1]')
+  })
+
+  it('returns null for a malformed URL the parser rejects', () => {
+    expect(normalizeHost('https://[incomplete')).toBeNull()
+  })
 })
 
 describe('parseAllowedDomains', () => {
@@ -87,6 +104,13 @@ describe('isHostAllowed', () => {
     expect(isHostAllowed(null, ['example.org'])).toBe(false)
     expect(isHostAllowed('example.org', [])).toBe(false)
   })
+
+  it('does not let an IDN lookalike match its ASCII allowlist entry', () => {
+    const requestHost = normalizeHost('münchen.de') // xn--… punycode
+    expect(requestHost).not.toBeNull()
+    expect(isHostAllowed(requestHost, ['munchen.de'])).toBe(false)
+    expect(isHostAllowed(requestHost, [normalizeHost('münchen.de')!])).toBe(true)
+  })
 })
 
 describe('extractRequestHost', () => {
@@ -103,10 +127,19 @@ describe('extractRequestHost', () => {
     expect(extractRequestHost(reqWith({ referer: 'https://b.org/page?q=1' }))).toBe('b.org')
   })
 
-  it('treats an opaque "null" Origin as absent and falls back to Referer', () => {
+  it('treats an opaque "null" Origin (any case) as absent and falls back to Referer', () => {
     expect(extractRequestHost(reqWith({ origin: 'null', referer: 'https://b.org/x' }))).toBe(
       'b.org',
     )
+    expect(extractRequestHost(reqWith({ origin: 'NULL', referer: 'https://b.org/x' }))).toBe(
+      'b.org',
+    )
+  })
+
+  it('falls back to Referer when the Origin is malformed', () => {
+    expect(
+      extractRequestHost(reqWith({ origin: 'https://[incomplete', referer: 'https://b.org/x' })),
+    ).toBe('b.org')
   })
 
   it('returns null when neither Origin nor Referer is present', () => {


### PR DESCRIPTION
## Summary

- Enforce per-client `Origin`/`Referer` against `Clients.allowedDomains` server-side, centralized in the `usagePlugin` so it covers standard client reads **and** the Atlas endpoints (`/api/events/geojson`, `/api/events/:id/register`).
- Empty `allowedDomains` allows any origin (backward-compatible); a non-empty list requires the request host to match an exact entry or a `*.` wildcard, else **403**. No `Origin`/`Referer` (server-to-server) is allowed — the API key remains the gate.
- Open Payload `cors` to `'*'` so embedded widgets' (anonymous) CORS preflight succeeds; the real per-domain gate is the server-side hook + API key.

## Changes

- `src/plugins/usage/originEnforcement.ts` — pure, unit-tested matching helpers (`normalizeHost`, `parseAllowedDomains`, `extractRequestHost`, `isHostAllowed`).
- `src/plugins/usage/hooks.ts` — `validateClientOriginHook` (beforeOperation), wired **first** by `usagePlugin.ts` on every non-excluded collection.
- `src/payload.config.ts` — `cors: '*'` (`csrf` unchanged).
- `src/collections/Events/endpoints/registerForEvent.ts` — surface `APIError` status verbatim (origin → 403, not a masked 500), matching `geojson.ts`.
- `.claude/rules/api-clients.md` — documents the gate, matching rules, bypasses, and the CORS rationale.

## Design notes

- **The ticket's CORS mechanism (#3) was infeasible as written.** Payload 3.85 types `cors` as `'*' | { origins, headers } | string[]` — no function. More fundamentally, CORS preflight (`OPTIONS`) is anonymous (the browser omits `Authorization`), so the server cannot return a per-client allowlist at preflight time. CORS is therefore not the security boundary here; the per-request hook + API key is. `cors: '*'` makes preflight succeed for embedded widgets, and Payload omits `Access-Control-Allow-Credentials` for `'*'`, so cookie/admin sessions stay protected (the static `csrf` allowlist is unchanged).
- **Resolved open questions:** server-to-server / missing-header → **allow**; valid preview-secret → **bypass** (same trust signal that unlocks drafts); `asTrustedReq()` does **not** bypass origin (it's a query-shape opt-out, not a security one); matching is **exact host + `*.` wildcard** (apex excluded); rejections **WARN-log** `clientId` + origin + referer.

## Test Results

- Unit: full lane **621 passed** (incl. 22 new in `origin-enforcement.spec.ts` — normalization, exact/wildcard matching, suffix-injection, IDN→punycode/no-homograph, IPv6 brackets, malformed/opaque origin).
- Integration: **12 new** in `client-origin-enforcement.int.spec.ts` (hook wiring via `payload.find` + geojson/register 403/allow); **55 related** specs (geojson, register, query-validation, client-hooks) pass — no regressions.
- Lint: ✓  Typecheck: ✓
- Build: runs on the Railway PR preview (not GitHub Actions).

## Notes for reviewer

- Reviewed via `/simplify` + `/code-review` (high) + `/security-review`. Security review found **no critical/high/medium** issues; applied its one low finding (lowercase the opaque-origin guard).
- **Dismissed code-review findings:** two import-order claims (false positives — `pnpm lint` is clean, and one targets pre-existing lines outside this diff); the "missing-header allows" finding (intentional, user-confirmed — and not exploitable: a cross-origin `fetch` with `Authorization` is CORS-triggering, so the browser always attaches `Origin`; an attacker can't suppress it).

## Manual verification

1. On a `sahaj-atlas-client` with `allowedDomains` set, load the widget on an allowed host page → `GET /api/events/geojson` + `POST /api/events/:id/register` succeed (preflight OK).
2. From a non-allowed origin (with the same key) → 403.
3. Confirm a client with empty `allowedDomains` still works from any origin.

Closes #509

🤖 Generated with [Claude Code](https://claude.com/claude-code)
