### PR TITLE
feat(events): accept mailing-list consent flag on event registration

### DIFF
--- a/src/collections/Events/endpoints/registerForEvent.ts
+++ b/src/collections/Events/endpoints/registerForEvent.ts
@@ -19,6 +19,10 @@ const bodySchema = z.object({
     .record(z.string(), z.unknown())
     .refine((q) => JSON.stringify(q).length <= 10_000, 'questions payload is too large')
     .optional(),
+  // Mailing-list consent (opt-in). When true, stamp `mailingListSubscribedAt` on
+  // the registration; absent/false leaves it unset. Sent by the Atlas widget's
+  // consent checkbox (sydevs/SahajAtlasWeb#25).
+  subscribe: z.boolean().optional(),
 })
 
 /**
@@ -37,8 +41,9 @@ const bodySchema = z.object({
  * Flow: parse the `:id` + body → confirm the event is one the client may see
  * (published + project-visible) → upsert the registrant `user` by normalized
  * email with elevated access (`users` is admin-only) → create the `registration`
- * (event + user + startingAt + questions + a fresh uuid). Returns
- * `EventRegistrationResponse`.
+ * (event + user + startingAt + questions + a fresh uuid, plus
+ * `mailingListSubscribedAt` when the registrant opted in via `subscribe`).
+ * Returns `EventRegistrationResponse`.
  */
 export const registerForEvent: Endpoint = {
   path: '/:id/register',
@@ -54,7 +59,7 @@ export const registerForEvent: Endpoint = {
 
     const parsed = await parseBody(req, bodySchema)
     if (!parsed.ok) return parsed.response
-    const { email, name, startingAt, questions } = parsed.data
+    const { email, name, startingAt, questions, subscribe } = parsed.data
 
     try {
       // Only register for an event this client may actually read (published +
@@ -114,7 +119,15 @@ export const registerForEvent: Endpoint = {
 
       const registration = await req.payload.create({
         collection: 'registrations',
-        data: { event: eventId, user: userId, startingAt, questions, uuid: randomUUID() },
+        data: {
+          event: eventId,
+          user: userId,
+          startingAt,
+          questions,
+          uuid: randomUUID(),
+          // Record consent at registration time; omit when not opted in.
+          mailingListSubscribedAt: subscribe ? new Date().toISOString() : undefined,
+        },
         overrideAccess: true,
         req,
       })

--- a/src/plugins/openapi/customEndpoints.ts
+++ b/src/plugins/openapi/customEndpoints.ts
@@ -886,6 +886,12 @@ export const CUSTOM_ENDPOINT_SCHEMAS: Record<string, OpenAPISchemaObject> = {
         additionalProperties: true,
         description: 'Raw registrant answers (questions / experience / aspirations / referral).',
       },
+      subscribe: {
+        type: 'boolean',
+        description:
+          'Mailing-list consent (opt-in). When true, the registration is stamped with ' +
+          '`mailingListSubscribedAt`; absent/false records no consent.',
+      },
     },
   },
   /** `POST /api/events/{id}/register` success body. */

--- a/tests/int/event-registration.int.spec.ts
+++ b/tests/int/event-registration.int.spec.ts
@@ -244,5 +244,24 @@ describe('registerForEvent endpoint', () => {
       expect(status).toBe(201)
       expect(await subscribedAtFor(body.registration!.id)).toBeFalsy()
     })
+
+    it('ignores a client-supplied mailingListSubscribedAt (stamped server-side)', async () => {
+      // Consent is stamped server-side; a body-supplied value must never be
+      // honored, or a caller could backdate/forge consent. The field isn't in
+      // the schema (Zod drops it) — this locks that guarantee in against a future
+      // refactor that trusts the body.
+      const before = Date.now()
+      const { status, body } = await callRegister(eventId, {
+        email: 'injector@example.com',
+        name: 'In Jector',
+        subscribe: true,
+        mailingListSubscribedAt: '2020-01-01T00:00:00.000Z',
+      })
+      expect(status).toBe(201)
+
+      const stamped = await subscribedAtFor(body.registration!.id)
+      // Server time (>= before), never the injected 2020 value.
+      expect(new Date(stamped as string).getTime()).toBeGreaterThanOrEqual(before)
+    })
   })
 })

--- a/tests/int/event-registration.int.spec.ts
+++ b/tests/int/event-registration.int.spec.ts
@@ -198,4 +198,51 @@ describe('registerForEvent endpoint', () => {
     expect(await userCountByEmail(payload, email)).toBe(1)
     expect(first.body.registration!.id).not.toBe(second.body.registration!.id)
   })
+
+  describe('mailing-list consent (subscribe)', () => {
+    async function subscribedAtFor(id: number): Promise<unknown> {
+      const registration = await payload.findByID({
+        collection: 'registrations',
+        id,
+        depth: 0,
+        overrideAccess: true,
+      })
+      return registration.mailingListSubscribedAt
+    }
+
+    it('stamps mailingListSubscribedAt at registration time when subscribe is true', async () => {
+      const before = Date.now()
+      const { status, body } = await callRegister(eventId, {
+        email: 'consenting@example.com',
+        name: 'Con Senting',
+        subscribe: true,
+      })
+      expect(status).toBe(201)
+
+      const stamped = await subscribedAtFor(body.registration!.id)
+      expect(stamped).toBeTruthy()
+      const stampedAt = new Date(stamped as string).getTime()
+      expect(stampedAt).toBeGreaterThanOrEqual(before)
+      expect(stampedAt).toBeLessThanOrEqual(Date.now() + 1000)
+    })
+
+    it('leaves mailingListSubscribedAt unset when subscribe is false', async () => {
+      const { status, body } = await callRegister(eventId, {
+        email: 'declining@example.com',
+        name: 'De Clining',
+        subscribe: false,
+      })
+      expect(status).toBe(201)
+      expect(await subscribedAtFor(body.registration!.id)).toBeFalsy()
+    })
+
+    it('leaves mailingListSubscribedAt unset when subscribe is absent', async () => {
+      const { status, body } = await callRegister(eventId, {
+        email: 'silent@example.com',
+        name: 'Si Lent',
+      })
+      expect(status).toBe(201)
+      expect(await subscribedAtFor(body.registration!.id)).toBeFalsy()
+    })
+  })
 })

--- a/tests/unit/openapi-custom-endpoints.spec.ts
+++ b/tests/unit/openapi-custom-endpoints.spec.ts
@@ -23,6 +23,16 @@ describe('Atlas events custom endpoints (OpenAPI)', () => {
     }
   })
 
+  it('documents the optional subscribe consent flag on the register request body', () => {
+    const schema = CUSTOM_ENDPOINT_SCHEMAS.EventRegistrationRequest as {
+      required?: string[]
+      properties?: Record<string, { type?: string }>
+    }
+    expect(schema.properties?.subscribe?.type).toBe('boolean')
+    // Opt-in → optional, never in `required`.
+    expect(schema.required ?? []).not.toContain('subscribe')
+  })
+
   describe('filterSpec POST visibility', () => {
     // Minimal spec: the auto-generated events CRUD plus the hand-authored custom
     // subpaths, filtered for the project that owns `events`.


### PR DESCRIPTION
## Summary

- `POST /api/events/:id/register` now accepts an optional `subscribe` boolean; when `true`, the new registration is stamped with `mailingListSubscribedAt` (registration time). Absent/`false` records no consent.
- The flag is documented in the OpenAPI `EventRegistrationRequest` schema so the Sahaj Atlas widget (sydevs/SahajAtlasWeb#25) can match the payload shape.
- No schema change / migration — `mailingListSubscribedAt` already exists on the Registrations collection.

## Changes

- `src/collections/Events/endpoints/registerForEvent.ts` — allow-list `subscribe` in the Zod body schema; stamp `mailingListSubscribedAt` server-side on the created registration when opted in.
- `src/plugins/openapi/customEndpoints.ts` — document `subscribe` (optional boolean) on the register request schema.

## Test Results

- Integration (`event-registration.int.spec.ts`): 13 passed — `subscribe:true` stamps a server-side timestamp; `false`/absent leaves it unset; a body-supplied `mailingListSubscribedAt` is ignored (consent can't be injected/backdated).
- Unit: 635 passed — includes a guard that the OpenAPI schema documents `subscribe` as an optional boolean.
- Lint: ✓ No errors
- Build: runs on the Railway preview deploy (not in CI).

## Notes for reviewer

- **Field name confirmed as `subscribe`** (AC #3) — matches what the widget plans to send, now documented in `/api/docs`. No release-ordering dependency: until this ships the backend simply ignored the field; now it records consent.
- Consent timestamp is set **server-side only** — it's not in the request schema and the create data is hand-built (no body spread), so a caller can't forge/backdate it. A regression test locks this in.
- Security review: no Critical/High findings; the one actionable item (the injection-guard test above) is included. Code review: no findings.

Closes #524

🤖 Generated with [Claude Code](https://claude.com/claude-code)
