### PR TITLE
feat(translations): WeMeditate Web schema + BCP-47 compound locales

### DIFF
--- a/.claude/rules/collections.md
+++ b/.claude/rules/collections.md
@@ -175,16 +175,17 @@ slugField({
 })
 ```
 
-## Localization (16 locales)
+## Localization (17 locales)
 
 Configured in `src/payload.config.ts` via `buildPayloadLocales()` from
 `src/lib/locales/index.ts`. Default locale: `en`. Fallback enabled — non-English
-locales fall back to English. Farsi (`fa`) has `rtl: true`. Locale labels
-come from the `iso-639-1` package with overrides for `pt-br` (Brazilian
-Portuguese) and `fa` (Farsi/Persian).
+locales fall back to English. Farsi (`fa`) has `rtl: true`. Compound codes use
+BCP-47 form (lowercase language, uppercase region). Locale labels come from the
+`iso-639-1` package with overrides for `pt-BR` (Brazilian Portuguese), `en-AU`
+(Australian English), and `fa` (Farsi/Persian).
 
 Supported: `en`, `es`, `de`, `it`, `fr`, `ru`, `ro`, `cs`, `uk`, `el`,
-`hy`, `pl`, `pt-br`, `fa`, `bg`, `tr`.
+`hy`, `pl`, `pt-BR`, `fa`, `bg`, `tr`, `en-AU`.
 
 ### Admin locale filtering (`filterAvailableLocales`)
 
@@ -194,7 +195,7 @@ in the admin locale selector:
 | User | Locales shown |
 |---|---|
 | Unauthenticated | English only (login page) |
-| Admin managers | All 16 |
+| Admin managers | All 17 |
 | API clients | All (filter only applies to admin UI) |
 | Regular managers | English (always) + locales where they have ≥ 1 role |
 | Inactive managers | English only |
@@ -215,7 +216,7 @@ Mark fields `localized: true`. Currently localized fields include:
 Meditations don't use field-level localization — each meditation **is**
 a single-locale document:
 
-- `locale` select field with all 16 options, default `en`.
+- `locale` select field with all 17 options, default `en`.
 - `filterMeditationsByLocale` (beforeOperation hook in
   `src/collections/Meditations/hooks/`) adds `{ locale: { equals: req.locale } }`
   to `find`/`count` operations.

--- a/seeds/wemeditate/AGENTS.md
+++ b/seeds/wemeditate/AGENTS.md
@@ -65,7 +65,7 @@ pnpm seed wemeditate --clear-cache # Fresh start
 
 ## Multi-Locale Support
 
-16 locales: `en`, `es`, `de`, `it`, `fr`, `ru`, `ro`, `cs`, `uk`, `el`, `hy`, `pl`, `pt-br`, `fa`, `bg`, `tr`
+17 locales: `en`, `es`, `de`, `it`, `fr`, `ru`, `ro`, `cs`, `uk`, `el`, `hy`, `pl`, `pt-BR`, `fa`, `bg`, `tr`, `en-AU`
 
 Translation tables (`*_translations`) contain locale-specific content.
 

--- a/src/globals/WeMeditateWebTranslations/translationsSchema.json
+++ b/src/globals/WeMeditateWebTranslations/translationsSchema.json
@@ -7,15 +7,15 @@
       "properties": {
         "loading": {
           "type": "string",
-          "description": "Loading indicator text shown while content is being fetched"
+          "description": "Loading indicator text shown while content is being fetched."
         },
         "error": {
           "type": "string",
-          "description": "Generic error message shown when something goes wrong"
+          "description": "Generic error message shown when something goes wrong."
         },
         "retry": {
           "type": "string",
-          "description": "Button text to retry a failed action"
+          "description": "Button text to retry a failed action."
         }
       },
       "additionalProperties": false
@@ -26,19 +26,76 @@
       "properties": {
         "about_meditation": {
           "type": "string",
-          "description": "Navigation link to the About Meditation section"
+          "description": "Primary navigation link opening the \"About Meditation\" knowledge section."
         },
         "learn_more": {
           "type": "string",
-          "description": "Navigation link to educational content and resources"
+          "description": "Navigation link to educational content and resources."
         },
         "come_meditate": {
           "type": "string",
-          "description": "Call-to-action navigation link inviting users to meditate"
+          "description": "Call-to-action navigation link inviting users to start meditating."
         },
         "languages": {
           "type": "string",
-          "description": "Language selector label in the navigation"
+          "description": "Label for the language selector in the header/navigation."
+        },
+        "classes_near_me": {
+          "type": "string",
+          "description": "Action link inviting users to find in-person meditation classes near their location (frontend: \"Classes near me\")."
+        }
+      },
+      "additionalProperties": false
+    },
+    "footer": {
+      "type": "object",
+      "description": "Footer section headings and labels",
+      "properties": {
+        "info": {
+          "type": "string",
+          "description": "Heading for the footer's \"Info\" column, which lists informational pages (about, contact, privacy, etc.) (frontend: \"Info\")."
+        }
+      },
+      "additionalProperties": false
+    },
+    "page_tags": {
+      "type": "object",
+      "description": "Category labels for page tags, shown as pills/facets on article and content-index listings; mirrors the frontend `PAGE_TAG_LABELS`",
+      "properties": {
+        "wisdom": {
+          "type": "string",
+          "description": "Category label for pages tagged \"Wisdom\" (frontend: \"Wisdom\")."
+        },
+        "lifestyle": {
+          "type": "string",
+          "description": "Category label for pages tagged \"Lifestyle\" (frontend: \"Lifestyle\")."
+        },
+        "creativity": {
+          "type": "string",
+          "description": "Category label for pages tagged \"Creativity\" (frontend: \"Creativity\")."
+        },
+        "event": {
+          "type": "string",
+          "description": "Category label for pages tagged \"Event\" (frontend: \"Event\")."
+        },
+        "technique": {
+          "type": "string",
+          "description": "Category label for pages tagged \"Technique\" (frontend: \"Technique\")."
+        }
+      },
+      "additionalProperties": false
+    },
+    "errors": {
+      "type": "object",
+      "description": "User-facing error messages shown when content cannot be played",
+      "properties": {
+        "meditation_missing_audio": {
+          "type": "string",
+          "description": "Error shown on a meditation page when the meditation has no playable audio source (frontend: \"This meditation is missing a required audio URL.\")."
+        },
+        "lecture_missing_video": {
+          "type": "string",
+          "description": "Error shown on a lecture page when the lecture has no playable video source (frontend: \"This lecture is missing a playable video source.\")."
         }
       },
       "additionalProperties": false

--- a/src/lib/lectures/nirmalaVidya.ts
+++ b/src/lib/lectures/nirmalaVidya.ts
@@ -12,11 +12,16 @@ import { isValidLocale } from '@/lib/locales'
  */
 export function apiLanguageToLocale(apiCode: string): LocaleCode | null {
   if (isValidLocale(apiCode)) return apiCode
-  // Normalize: lowercase and replace underscores with hyphens
-  const normalized = apiCode.toLowerCase().replace('_', '-')
+  // Normalize to BCP-47 shape: lowercase language subtag, uppercase region
+  // subtag (e.g. 'pt_BR' / 'pt-br' -> 'pt-BR'), so a lowercased region no
+  // longer collides with the old invalid 'pt-br' spelling.
+  const [language, region] = apiCode.replace('_', '-').split('-')
+  const normalized = region
+    ? `${language.toLowerCase()}-${region.toUpperCase()}`
+    : language.toLowerCase()
   if (isValidLocale(normalized)) return normalized
   // Special case: API may use 'pt' for Brazilian Portuguese
-  if (normalized === 'pt') return 'pt-br'
+  if (normalized === 'pt') return 'pt-BR'
   return null
 }
 

--- a/src/lib/locales/index.ts
+++ b/src/lib/locales/index.ts
@@ -23,10 +23,11 @@ export const LOCALES = [
   { code: 'el', label: 'Greek' },
   { code: 'hy', label: 'Armenian' },
   { code: 'pl', label: 'Polish' },
-  { code: 'pt-br', label: 'Brazilian Portuguese' },
+  { code: 'pt-BR', label: 'Brazilian Portuguese' },
   { code: 'fa', label: 'Farsi/Persian' },
   { code: 'bg', label: 'Bulgarian' },
   { code: 'tr', label: 'Turkish' },
+  { code: 'en-AU', label: 'Australian English' },
 ] as const
 
 /**
@@ -58,7 +59,8 @@ export function isValidLocale(code: string): code is LocaleCode {
  * Special case labels for locales not in ISO 639-1 or needing override
  */
 const LOCALE_LABEL_OVERRIDES: Record<string, string> = {
-  'pt-br': 'Brazilian Portuguese',
+  'pt-BR': 'Brazilian Portuguese',
+  'en-AU': 'Australian English',
   fa: 'Farsi/Persian',
 }
 
@@ -73,7 +75,7 @@ const LOCALE_LABEL_OVERRIDES: Record<string, string> = {
 export function buildPayloadLocales(): Locale[] {
   return LOCALES.map(({ code }) => {
     // Get label from override or ISO 639-1
-    // For compound codes like 'pt-br', try the full code first, then the base
+    // For compound codes like 'pt-BR', try the full code first, then the base
     const baseCode = code.split('-')[0]
     const isoLabel = ISO6391.getName(baseCode)
     const label = LOCALE_LABEL_OVERRIDES[code] || isoLabel || code

--- a/src/lib/locales/languageOptions.ts
+++ b/src/lib/locales/languageOptions.ts
@@ -12,7 +12,7 @@ export interface LanguageOption {
  *
  * Shared by the Atlas Events `languages` field and the Clients / Managers
  * language selects. This is the broad language set — distinct
- * from the 16 app `LOCALES` in this folder, which are the locales the CMS
+ * from the 17 app `LOCALES` in this folder, which are the locales the CMS
  * itself is translated into.
  */
 export function getLanguageOptions(): LanguageOption[] {

--- a/src/migrations/20260705_161112_bcp47_locales_web_translations.json
+++ b/src/migrations/20260705_161112_bcp47_locales_web_translations.json
@@ -1,0 +1,26902 @@
+{
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.pages_tags": {
+      "name": "pages_tags",
+      "schema": "",
+      "columns": {
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "enum_pages_tags",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "pages_tags_order_idx": {
+          "name": "pages_tags_order_idx",
+          "columns": [
+            {
+              "expression": "order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pages_tags_parent_idx": {
+          "name": "pages_tags_parent_idx",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pages_tags_parent_fk": {
+          "name": "pages_tags_parent_fk",
+          "tableFrom": "pages_tags",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pages": {
+      "name": "pages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "generate_slug": {
+          "name": "generate_slug",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "featured_video_id": {
+          "name": "featured_video_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "_status": {
+          "name": "_status",
+          "type": "enum_pages_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'draft'"
+        }
+      },
+      "indexes": {
+        "pages_slug_idx": {
+          "name": "pages_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pages_author_idx": {
+          "name": "pages_author_idx",
+          "columns": [
+            {
+              "expression": "author_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pages_featured_video_idx": {
+          "name": "pages_featured_video_idx",
+          "columns": [
+            {
+              "expression": "featured_video_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pages_updated_at_idx": {
+          "name": "pages_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pages_created_at_idx": {
+          "name": "pages_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pages_deleted_at_idx": {
+          "name": "pages_deleted_at_idx",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pages__status_idx": {
+          "name": "pages__status_idx",
+          "columns": [
+            {
+              "expression": "_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pages_author_id_authors_id_fk": {
+          "name": "pages_author_id_authors_id_fk",
+          "tableFrom": "pages",
+          "tableTo": "authors",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "pages_featured_video_id_videos_id_fk": {
+          "name": "pages_featured_video_id_videos_id_fk",
+          "tableFrom": "pages",
+          "tableTo": "videos",
+          "columnsFrom": [
+            "featured_video_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pages_locales": {
+      "name": "pages_locales",
+      "schema": "",
+      "columns": {
+        "title": {
+          "name": "title",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta_title": {
+          "name": "meta_title",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta_description": {
+          "name": "meta_description",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta_image_id": {
+          "name": "meta_image_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "_locale": {
+          "name": "_locale",
+          "type": "_locales",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "pages_meta_meta_image_idx": {
+          "name": "pages_meta_meta_image_idx",
+          "columns": [
+            {
+              "expression": "meta_image_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "_locale",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pages_locales_locale_parent_id_unique": {
+          "name": "pages_locales_locale_parent_id_unique",
+          "columns": [
+            {
+              "expression": "_locale",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pages_locales_meta_image_id_images_id_fk": {
+          "name": "pages_locales_meta_image_id_images_id_fk",
+          "tableFrom": "pages_locales",
+          "tableTo": "images",
+          "columnsFrom": [
+            "meta_image_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "pages_locales_parent_id_fk": {
+          "name": "pages_locales_parent_id_fk",
+          "tableFrom": "pages_locales",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pages_rels": {
+      "name": "pages_rels",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "managers_id": {
+          "name": "managers_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "pages_rels_order_idx": {
+          "name": "pages_rels_order_idx",
+          "columns": [
+            {
+              "expression": "order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pages_rels_parent_idx": {
+          "name": "pages_rels_parent_idx",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pages_rels_path_idx": {
+          "name": "pages_rels_path_idx",
+          "columns": [
+            {
+              "expression": "path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pages_rels_managers_id_idx": {
+          "name": "pages_rels_managers_id_idx",
+          "columns": [
+            {
+              "expression": "managers_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pages_rels_parent_fk": {
+          "name": "pages_rels_parent_fk",
+          "tableFrom": "pages_rels",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pages_rels_managers_fk": {
+          "name": "pages_rels_managers_fk",
+          "tableFrom": "pages_rels",
+          "tableTo": "managers",
+          "columnsFrom": [
+            "managers_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public._pages_v_version_tags": {
+      "name": "_pages_v_version_tags",
+      "schema": "",
+      "columns": {
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "enum__pages_v_version_tags",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "_pages_v_version_tags_order_idx": {
+          "name": "_pages_v_version_tags_order_idx",
+          "columns": [
+            {
+              "expression": "order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_pages_v_version_tags_parent_idx": {
+          "name": "_pages_v_version_tags_parent_idx",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "_pages_v_version_tags_parent_fk": {
+          "name": "_pages_v_version_tags_parent_fk",
+          "tableFrom": "_pages_v_version_tags",
+          "tableTo": "_pages_v",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public._pages_v": {
+      "name": "_pages_v",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_generate_slug": {
+          "name": "version_generate_slug",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "version_slug": {
+          "name": "version_slug",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_author_id": {
+          "name": "version_author_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_featured_video_id": {
+          "name": "version_featured_video_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_updated_at": {
+          "name": "version_updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_created_at": {
+          "name": "version_created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_deleted_at": {
+          "name": "version_deleted_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version__status": {
+          "name": "version__status",
+          "type": "enum__pages_v_version_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'draft'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "snapshot": {
+          "name": "snapshot",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_locale": {
+          "name": "published_locale",
+          "type": "enum__pages_v_published_locale",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latest": {
+          "name": "latest",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "autosave": {
+          "name": "autosave",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "_pages_v_parent_idx": {
+          "name": "_pages_v_parent_idx",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_pages_v_version_version_slug_idx": {
+          "name": "_pages_v_version_version_slug_idx",
+          "columns": [
+            {
+              "expression": "version_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_pages_v_version_version_author_idx": {
+          "name": "_pages_v_version_version_author_idx",
+          "columns": [
+            {
+              "expression": "version_author_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_pages_v_version_version_featured_video_idx": {
+          "name": "_pages_v_version_version_featured_video_idx",
+          "columns": [
+            {
+              "expression": "version_featured_video_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_pages_v_version_version_updated_at_idx": {
+          "name": "_pages_v_version_version_updated_at_idx",
+          "columns": [
+            {
+              "expression": "version_updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_pages_v_version_version_created_at_idx": {
+          "name": "_pages_v_version_version_created_at_idx",
+          "columns": [
+            {
+              "expression": "version_created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_pages_v_version_version_deleted_at_idx": {
+          "name": "_pages_v_version_version_deleted_at_idx",
+          "columns": [
+            {
+              "expression": "version_deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_pages_v_version_version__status_idx": {
+          "name": "_pages_v_version_version__status_idx",
+          "columns": [
+            {
+              "expression": "version__status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_pages_v_created_at_idx": {
+          "name": "_pages_v_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_pages_v_updated_at_idx": {
+          "name": "_pages_v_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_pages_v_snapshot_idx": {
+          "name": "_pages_v_snapshot_idx",
+          "columns": [
+            {
+              "expression": "snapshot",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_pages_v_published_locale_idx": {
+          "name": "_pages_v_published_locale_idx",
+          "columns": [
+            {
+              "expression": "published_locale",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_pages_v_latest_idx": {
+          "name": "_pages_v_latest_idx",
+          "columns": [
+            {
+              "expression": "latest",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_pages_v_autosave_idx": {
+          "name": "_pages_v_autosave_idx",
+          "columns": [
+            {
+              "expression": "autosave",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "_pages_v_parent_id_pages_id_fk": {
+          "name": "_pages_v_parent_id_pages_id_fk",
+          "tableFrom": "_pages_v",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "_pages_v_version_author_id_authors_id_fk": {
+          "name": "_pages_v_version_author_id_authors_id_fk",
+          "tableFrom": "_pages_v",
+          "tableTo": "authors",
+          "columnsFrom": [
+            "version_author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "_pages_v_version_featured_video_id_videos_id_fk": {
+          "name": "_pages_v_version_featured_video_id_videos_id_fk",
+          "tableFrom": "_pages_v",
+          "tableTo": "videos",
+          "columnsFrom": [
+            "version_featured_video_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public._pages_v_locales": {
+      "name": "_pages_v_locales",
+      "schema": "",
+      "columns": {
+        "version_title": {
+          "name": "version_title",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_content": {
+          "name": "version_content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_meta_title": {
+          "name": "version_meta_title",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_meta_description": {
+          "name": "version_meta_description",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_meta_image_id": {
+          "name": "version_meta_image_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "_locale": {
+          "name": "_locale",
+          "type": "_locales",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "_pages_v_version_meta_version_meta_image_idx": {
+          "name": "_pages_v_version_meta_version_meta_image_idx",
+          "columns": [
+            {
+              "expression": "version_meta_image_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "_locale",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_pages_v_locales_locale_parent_id_unique": {
+          "name": "_pages_v_locales_locale_parent_id_unique",
+          "columns": [
+            {
+              "expression": "_locale",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "_pages_v_locales_version_meta_image_id_images_id_fk": {
+          "name": "_pages_v_locales_version_meta_image_id_images_id_fk",
+          "tableFrom": "_pages_v_locales",
+          "tableTo": "images",
+          "columnsFrom": [
+            "version_meta_image_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "_pages_v_locales_parent_id_fk": {
+          "name": "_pages_v_locales_parent_id_fk",
+          "tableFrom": "_pages_v_locales",
+          "tableTo": "_pages_v",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public._pages_v_rels": {
+      "name": "_pages_v_rels",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "managers_id": {
+          "name": "managers_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "_pages_v_rels_order_idx": {
+          "name": "_pages_v_rels_order_idx",
+          "columns": [
+            {
+              "expression": "order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_pages_v_rels_parent_idx": {
+          "name": "_pages_v_rels_parent_idx",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_pages_v_rels_path_idx": {
+          "name": "_pages_v_rels_path_idx",
+          "columns": [
+            {
+              "expression": "path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_pages_v_rels_managers_id_idx": {
+          "name": "_pages_v_rels_managers_id_idx",
+          "columns": [
+            {
+              "expression": "managers_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "_pages_v_rels_parent_fk": {
+          "name": "_pages_v_rels_parent_fk",
+          "tableFrom": "_pages_v_rels",
+          "tableTo": "_pages_v",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "_pages_v_rels_managers_fk": {
+          "name": "_pages_v_rels_managers_fk",
+          "tableFrom": "_pages_v_rels",
+          "tableTo": "managers",
+          "columnsFrom": [
+            "managers_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.meditations": {
+      "name": "meditations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "locale": {
+          "name": "locale",
+          "type": "enum_meditations_locale",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "narrator_id": {
+          "name": "narrator_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "song_tag_id": {
+          "name": "song_tag_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration": {
+          "name": "duration",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subtle_system_node_weights": {
+          "name": "subtle_system_node_weights",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thumbnail_id": {
+          "name": "thumbnail_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "enum_meditations_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'daily'"
+        },
+        "frames": {
+          "name": "frames",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "_status": {
+          "name": "_status",
+          "type": "enum_meditations_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'draft'"
+        },
+        "thumbnail_u_r_l": {
+          "name": "thumbnail_u_r_l",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "filename": {
+          "name": "filename",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "filesize": {
+          "name": "filesize",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "width": {
+          "name": "width",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "height": {
+          "name": "height",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "focal_x": {
+          "name": "focal_x",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "focal_y": {
+          "name": "focal_y",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "meditations_locale_idx": {
+          "name": "meditations_locale_idx",
+          "columns": [
+            {
+              "expression": "locale",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "meditations_narrator_idx": {
+          "name": "meditations_narrator_idx",
+          "columns": [
+            {
+              "expression": "narrator_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "meditations_song_tag_idx": {
+          "name": "meditations_song_tag_idx",
+          "columns": [
+            {
+              "expression": "song_tag_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "meditations_thumbnail_idx": {
+          "name": "meditations_thumbnail_idx",
+          "columns": [
+            {
+              "expression": "thumbnail_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "meditations_updated_at_idx": {
+          "name": "meditations_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "meditations_created_at_idx": {
+          "name": "meditations_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "meditations_deleted_at_idx": {
+          "name": "meditations_deleted_at_idx",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "meditations__status_idx": {
+          "name": "meditations__status_idx",
+          "columns": [
+            {
+              "expression": "_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "meditations_filename_idx": {
+          "name": "meditations_filename_idx",
+          "columns": [
+            {
+              "expression": "filename",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "meditations_narrator_id_narrators_id_fk": {
+          "name": "meditations_narrator_id_narrators_id_fk",
+          "tableFrom": "meditations",
+          "tableTo": "narrators",
+          "columnsFrom": [
+            "narrator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "meditations_song_tag_id_song_tags_id_fk": {
+          "name": "meditations_song_tag_id_song_tags_id_fk",
+          "tableFrom": "meditations",
+          "tableTo": "song_tags",
+          "columnsFrom": [
+            "song_tag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "meditations_thumbnail_id_images_id_fk": {
+          "name": "meditations_thumbnail_id_images_id_fk",
+          "tableFrom": "meditations",
+          "tableTo": "images",
+          "columnsFrom": [
+            "thumbnail_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public._meditations_v": {
+      "name": "_meditations_v",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_label": {
+          "name": "version_label",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_locale": {
+          "name": "version_locale",
+          "type": "enum__meditations_v_version_locale",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_narrator_id": {
+          "name": "version_narrator_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_song_tag_id": {
+          "name": "version_song_tag_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_duration": {
+          "name": "version_duration",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_subtle_system_node_weights": {
+          "name": "version_subtle_system_node_weights",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_thumbnail_id": {
+          "name": "version_thumbnail_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_type": {
+          "name": "version_type",
+          "type": "enum__meditations_v_version_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'daily'"
+        },
+        "version_frames": {
+          "name": "version_frames",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_updated_at": {
+          "name": "version_updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_created_at": {
+          "name": "version_created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_deleted_at": {
+          "name": "version_deleted_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version__status": {
+          "name": "version__status",
+          "type": "enum__meditations_v_version_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'draft'"
+        },
+        "version_thumbnail_u_r_l": {
+          "name": "version_thumbnail_u_r_l",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_filename": {
+          "name": "version_filename",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_mime_type": {
+          "name": "version_mime_type",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_filesize": {
+          "name": "version_filesize",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_width": {
+          "name": "version_width",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_height": {
+          "name": "version_height",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_focal_x": {
+          "name": "version_focal_x",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_focal_y": {
+          "name": "version_focal_y",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "snapshot": {
+          "name": "snapshot",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_locale": {
+          "name": "published_locale",
+          "type": "enum__meditations_v_published_locale",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latest": {
+          "name": "latest",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "_meditations_v_parent_idx": {
+          "name": "_meditations_v_parent_idx",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_meditations_v_version_version_locale_idx": {
+          "name": "_meditations_v_version_version_locale_idx",
+          "columns": [
+            {
+              "expression": "version_locale",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_meditations_v_version_version_narrator_idx": {
+          "name": "_meditations_v_version_version_narrator_idx",
+          "columns": [
+            {
+              "expression": "version_narrator_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_meditations_v_version_version_song_tag_idx": {
+          "name": "_meditations_v_version_version_song_tag_idx",
+          "columns": [
+            {
+              "expression": "version_song_tag_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_meditations_v_version_version_thumbnail_idx": {
+          "name": "_meditations_v_version_version_thumbnail_idx",
+          "columns": [
+            {
+              "expression": "version_thumbnail_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_meditations_v_version_version_updated_at_idx": {
+          "name": "_meditations_v_version_version_updated_at_idx",
+          "columns": [
+            {
+              "expression": "version_updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_meditations_v_version_version_created_at_idx": {
+          "name": "_meditations_v_version_version_created_at_idx",
+          "columns": [
+            {
+              "expression": "version_created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_meditations_v_version_version_deleted_at_idx": {
+          "name": "_meditations_v_version_version_deleted_at_idx",
+          "columns": [
+            {
+              "expression": "version_deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_meditations_v_version_version__status_idx": {
+          "name": "_meditations_v_version_version__status_idx",
+          "columns": [
+            {
+              "expression": "version__status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_meditations_v_version_version_filename_idx": {
+          "name": "_meditations_v_version_version_filename_idx",
+          "columns": [
+            {
+              "expression": "version_filename",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_meditations_v_created_at_idx": {
+          "name": "_meditations_v_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_meditations_v_updated_at_idx": {
+          "name": "_meditations_v_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_meditations_v_snapshot_idx": {
+          "name": "_meditations_v_snapshot_idx",
+          "columns": [
+            {
+              "expression": "snapshot",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_meditations_v_published_locale_idx": {
+          "name": "_meditations_v_published_locale_idx",
+          "columns": [
+            {
+              "expression": "published_locale",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_meditations_v_latest_idx": {
+          "name": "_meditations_v_latest_idx",
+          "columns": [
+            {
+              "expression": "latest",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "_meditations_v_parent_id_meditations_id_fk": {
+          "name": "_meditations_v_parent_id_meditations_id_fk",
+          "tableFrom": "_meditations_v",
+          "tableTo": "meditations",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "_meditations_v_version_narrator_id_narrators_id_fk": {
+          "name": "_meditations_v_version_narrator_id_narrators_id_fk",
+          "tableFrom": "_meditations_v",
+          "tableTo": "narrators",
+          "columnsFrom": [
+            "version_narrator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "_meditations_v_version_song_tag_id_song_tags_id_fk": {
+          "name": "_meditations_v_version_song_tag_id_song_tags_id_fk",
+          "tableFrom": "_meditations_v",
+          "tableTo": "song_tags",
+          "columnsFrom": [
+            "version_song_tag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "_meditations_v_version_thumbnail_id_images_id_fk": {
+          "name": "_meditations_v_version_thumbnail_id_images_id_fk",
+          "tableFrom": "_meditations_v",
+          "tableTo": "images",
+          "columnsFrom": [
+            "version_thumbnail_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.songs": {
+      "name": "songs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "album_id": {
+          "name": "album_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "include_for_meditations": {
+          "name": "include_for_meditations",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "file_metadata": {
+          "name": "file_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thumbnail_u_r_l": {
+          "name": "thumbnail_u_r_l",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "filename": {
+          "name": "filename",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "filesize": {
+          "name": "filesize",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "width": {
+          "name": "width",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "height": {
+          "name": "height",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "focal_x": {
+          "name": "focal_x",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "focal_y": {
+          "name": "focal_y",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "songs_album_idx": {
+          "name": "songs_album_idx",
+          "columns": [
+            {
+              "expression": "album_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "songs_updated_at_idx": {
+          "name": "songs_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "songs_created_at_idx": {
+          "name": "songs_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "songs_deleted_at_idx": {
+          "name": "songs_deleted_at_idx",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "songs_filename_idx": {
+          "name": "songs_filename_idx",
+          "columns": [
+            {
+              "expression": "filename",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "songs_album_id_albums_id_fk": {
+          "name": "songs_album_id_albums_id_fk",
+          "tableFrom": "songs",
+          "tableTo": "albums",
+          "columnsFrom": [
+            "album_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.songs_locales": {
+      "name": "songs_locales",
+      "schema": "",
+      "columns": {
+        "title": {
+          "name": "title",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "_locale": {
+          "name": "_locale",
+          "type": "_locales",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "songs_locales_locale_parent_id_unique": {
+          "name": "songs_locales_locale_parent_id_unique",
+          "columns": [
+            {
+              "expression": "_locale",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "songs_locales_parent_id_fk": {
+          "name": "songs_locales_parent_id_fk",
+          "tableFrom": "songs_locales",
+          "tableTo": "songs",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.songs_rels": {
+      "name": "songs_rels",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "song_tags_id": {
+          "name": "song_tags_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "songs_rels_order_idx": {
+          "name": "songs_rels_order_idx",
+          "columns": [
+            {
+              "expression": "order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "songs_rels_parent_idx": {
+          "name": "songs_rels_parent_idx",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "songs_rels_path_idx": {
+          "name": "songs_rels_path_idx",
+          "columns": [
+            {
+              "expression": "path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "songs_rels_song_tags_id_idx": {
+          "name": "songs_rels_song_tags_id_idx",
+          "columns": [
+            {
+              "expression": "song_tags_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "songs_rels_parent_fk": {
+          "name": "songs_rels_parent_fk",
+          "tableFrom": "songs_rels",
+          "tableTo": "songs",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "songs_rels_song_tags_fk": {
+          "name": "songs_rels_song_tags_fk",
+          "tableFrom": "songs_rels",
+          "tableTo": "song_tags",
+          "columnsFrom": [
+            "song_tags_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.albums": {
+      "name": "albums",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "artwork_id": {
+          "name": "artwork_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artist_url": {
+          "name": "artist_url",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "albums_artwork_idx": {
+          "name": "albums_artwork_idx",
+          "columns": [
+            {
+              "expression": "artwork_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "albums_updated_at_idx": {
+          "name": "albums_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "albums_created_at_idx": {
+          "name": "albums_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "albums_deleted_at_idx": {
+          "name": "albums_deleted_at_idx",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "albums_artwork_id_images_id_fk": {
+          "name": "albums_artwork_id_images_id_fk",
+          "tableFrom": "albums",
+          "tableTo": "images",
+          "columnsFrom": [
+            "artwork_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.albums_locales": {
+      "name": "albums_locales",
+      "schema": "",
+      "columns": {
+        "title": {
+          "name": "title",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artist": {
+          "name": "artist",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "_locale": {
+          "name": "_locale",
+          "type": "_locales",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "albums_locales_locale_parent_id_unique": {
+          "name": "albums_locales_locale_parent_id_unique",
+          "columns": [
+            {
+              "expression": "_locale",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "albums_locales_parent_id_fk": {
+          "name": "albums_locales_parent_id_fk",
+          "tableFrom": "albums_locales",
+          "tableTo": "albums",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.videos": {
+      "name": "videos",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "thumbnail_id": {
+          "name": "thumbnail_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subtitles": {
+          "name": "subtitles",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "enum_videos_tags",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_metadata": {
+          "name": "file_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "thumbnail_u_r_l": {
+          "name": "thumbnail_u_r_l",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "filename": {
+          "name": "filename",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "filesize": {
+          "name": "filesize",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "width": {
+          "name": "width",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "height": {
+          "name": "height",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "focal_x": {
+          "name": "focal_x",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "focal_y": {
+          "name": "focal_y",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "videos_thumbnail_idx": {
+          "name": "videos_thumbnail_idx",
+          "columns": [
+            {
+              "expression": "thumbnail_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "videos_updated_at_idx": {
+          "name": "videos_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "videos_created_at_idx": {
+          "name": "videos_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "videos_filename_idx": {
+          "name": "videos_filename_idx",
+          "columns": [
+            {
+              "expression": "filename",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "videos_thumbnail_id_images_id_fk": {
+          "name": "videos_thumbnail_id_images_id_fk",
+          "tableFrom": "videos",
+          "tableTo": "images",
+          "columnsFrom": [
+            "thumbnail_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.videos_locales": {
+      "name": "videos_locales",
+      "schema": "",
+      "columns": {
+        "title": {
+          "name": "title",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "_locale": {
+          "name": "_locale",
+          "type": "_locales",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "videos_locales_locale_parent_id_unique": {
+          "name": "videos_locales_locale_parent_id_unique",
+          "columns": [
+            {
+              "expression": "_locale",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "videos_locales_parent_id_fk": {
+          "name": "videos_locales_parent_id_fk",
+          "tableFrom": "videos_locales",
+          "tableTo": "videos",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.lessons_panels": {
+      "name": "lessons_panels",
+      "schema": "",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text": {
+          "name": "text",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "media_id": {
+          "name": "media_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subtitles": {
+          "name": "subtitles",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "lessons_panels_order_idx": {
+          "name": "lessons_panels_order_idx",
+          "columns": [
+            {
+              "expression": "_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lessons_panels_parent_id_idx": {
+          "name": "lessons_panels_parent_id_idx",
+          "columns": [
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lessons_panels_media_idx": {
+          "name": "lessons_panels_media_idx",
+          "columns": [
+            {
+              "expression": "media_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "lessons_panels_media_id_files_id_fk": {
+          "name": "lessons_panels_media_id_files_id_fk",
+          "tableFrom": "lessons_panels",
+          "tableTo": "files",
+          "columnsFrom": [
+            "media_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "lessons_panels_parent_id_fk": {
+          "name": "lessons_panels_parent_id_fk",
+          "tableFrom": "lessons_panels",
+          "tableTo": "lessons",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.lessons": {
+      "name": "lessons",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "intro_audio_id": {
+          "name": "intro_audio_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "intro_subtitles": {
+          "name": "intro_subtitles",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unit": {
+          "name": "unit",
+          "type": "enum_lessons_unit",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "step": {
+          "name": "step",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon_id": {
+          "name": "icon_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "lessons_intro_audio_idx": {
+          "name": "lessons_intro_audio_idx",
+          "columns": [
+            {
+              "expression": "intro_audio_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lessons_icon_idx": {
+          "name": "lessons_icon_idx",
+          "columns": [
+            {
+              "expression": "icon_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lessons_updated_at_idx": {
+          "name": "lessons_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lessons_created_at_idx": {
+          "name": "lessons_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lessons_deleted_at_idx": {
+          "name": "lessons_deleted_at_idx",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "lessons_intro_audio_id_files_id_fk": {
+          "name": "lessons_intro_audio_id_files_id_fk",
+          "tableFrom": "lessons",
+          "tableTo": "files",
+          "columnsFrom": [
+            "intro_audio_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "lessons_icon_id_images_id_fk": {
+          "name": "lessons_icon_id_images_id_fk",
+          "tableFrom": "lessons",
+          "tableTo": "images",
+          "columnsFrom": [
+            "icon_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.lessons_locales": {
+      "name": "lessons_locales",
+      "schema": "",
+      "columns": {
+        "pre_meditation_lines": {
+          "name": "pre_meditation_lines",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "article": {
+          "name": "article",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "_locale": {
+          "name": "_locale",
+          "type": "_locales",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "lessons_locales_locale_parent_id_unique": {
+          "name": "lessons_locales_locale_parent_id_unique",
+          "columns": [
+            {
+              "expression": "_locale",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "lessons_locales_parent_id_fk": {
+          "name": "lessons_locales_parent_id_fk",
+          "tableFrom": "lessons_locales",
+          "tableTo": "lessons",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.lessons_rels": {
+      "name": "lessons_rels",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "locale": {
+          "name": "locale",
+          "type": "_locales",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meditations_id": {
+          "name": "meditations_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "videos_id": {
+          "name": "videos_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lectures_id": {
+          "name": "lectures_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "lessons_rels_order_idx": {
+          "name": "lessons_rels_order_idx",
+          "columns": [
+            {
+              "expression": "order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lessons_rels_parent_idx": {
+          "name": "lessons_rels_parent_idx",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lessons_rels_path_idx": {
+          "name": "lessons_rels_path_idx",
+          "columns": [
+            {
+              "expression": "path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lessons_rels_locale_idx": {
+          "name": "lessons_rels_locale_idx",
+          "columns": [
+            {
+              "expression": "locale",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lessons_rels_meditations_id_idx": {
+          "name": "lessons_rels_meditations_id_idx",
+          "columns": [
+            {
+              "expression": "meditations_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "locale",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lessons_rels_videos_id_idx": {
+          "name": "lessons_rels_videos_id_idx",
+          "columns": [
+            {
+              "expression": "videos_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "locale",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lessons_rels_lectures_id_idx": {
+          "name": "lessons_rels_lectures_id_idx",
+          "columns": [
+            {
+              "expression": "lectures_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "locale",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "lessons_rels_parent_fk": {
+          "name": "lessons_rels_parent_fk",
+          "tableFrom": "lessons_rels",
+          "tableTo": "lessons",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "lessons_rels_meditations_fk": {
+          "name": "lessons_rels_meditations_fk",
+          "tableFrom": "lessons_rels",
+          "tableTo": "meditations",
+          "columnsFrom": [
+            "meditations_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "lessons_rels_videos_fk": {
+          "name": "lessons_rels_videos_fk",
+          "tableFrom": "lessons_rels",
+          "tableTo": "videos",
+          "columnsFrom": [
+            "videos_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "lessons_rels_lectures_fk": {
+          "name": "lessons_rels_lectures_fk",
+          "tableFrom": "lessons_rels",
+          "tableTo": "lectures",
+          "columnsFrom": [
+            "lectures_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.lectures_subtitles": {
+      "name": "lectures_subtitles",
+      "schema": "",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "locale": {
+          "name": "locale",
+          "type": "enum_lectures_subtitles_locale",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url": {
+          "name": "url",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "lectures_subtitles_order_idx": {
+          "name": "lectures_subtitles_order_idx",
+          "columns": [
+            {
+              "expression": "_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lectures_subtitles_parent_id_idx": {
+          "name": "lectures_subtitles_parent_id_idx",
+          "columns": [
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "lectures_subtitles_parent_id_fk": {
+          "name": "lectures_subtitles_parent_id_fk",
+          "tableFrom": "lectures_subtitles",
+          "tableTo": "lectures",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.lectures": {
+      "name": "lectures",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "enum_lectures_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'full'"
+        },
+        "nirmal_vidya_vimeo_url": {
+          "name": "nirmal_vidya_vimeo_url",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thumbnail_id": {
+          "name": "thumbnail_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stop_time": {
+          "name": "stop_time",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "full_lecture_id": {
+          "name": "full_lecture_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "lectures_nirmal_vidya_vimeo_url_idx": {
+          "name": "lectures_nirmal_vidya_vimeo_url_idx",
+          "columns": [
+            {
+              "expression": "nirmal_vidya_vimeo_url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lectures_thumbnail_idx": {
+          "name": "lectures_thumbnail_idx",
+          "columns": [
+            {
+              "expression": "thumbnail_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lectures_full_lecture_idx": {
+          "name": "lectures_full_lecture_idx",
+          "columns": [
+            {
+              "expression": "full_lecture_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lectures_updated_at_idx": {
+          "name": "lectures_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lectures_created_at_idx": {
+          "name": "lectures_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "lectures_thumbnail_id_images_id_fk": {
+          "name": "lectures_thumbnail_id_images_id_fk",
+          "tableFrom": "lectures",
+          "tableTo": "images",
+          "columnsFrom": [
+            "thumbnail_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "lectures_full_lecture_id_lectures_id_fk": {
+          "name": "lectures_full_lecture_id_lectures_id_fk",
+          "tableFrom": "lectures",
+          "tableTo": "lectures",
+          "columnsFrom": [
+            "full_lecture_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.lectures_locales": {
+      "name": "lectures_locales",
+      "schema": "",
+      "columns": {
+        "title": {
+          "name": "title",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "_locale": {
+          "name": "_locale",
+          "type": "_locales",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "lectures_locales_locale_parent_id_unique": {
+          "name": "lectures_locales_locale_parent_id_unique",
+          "columns": [
+            {
+              "expression": "_locale",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "lectures_locales_parent_id_fk": {
+          "name": "lectures_locales_parent_id_fk",
+          "tableFrom": "lectures_locales",
+          "tableTo": "lectures",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.lectures_rels": {
+      "name": "lectures_rels",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "audiences_id": {
+          "name": "audiences_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_choices_id": {
+          "name": "user_choices_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subtle_system_nodes_id": {
+          "name": "subtle_system_nodes_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "lectures_rels_order_idx": {
+          "name": "lectures_rels_order_idx",
+          "columns": [
+            {
+              "expression": "order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lectures_rels_parent_idx": {
+          "name": "lectures_rels_parent_idx",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lectures_rels_path_idx": {
+          "name": "lectures_rels_path_idx",
+          "columns": [
+            {
+              "expression": "path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lectures_rels_audiences_id_idx": {
+          "name": "lectures_rels_audiences_id_idx",
+          "columns": [
+            {
+              "expression": "audiences_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lectures_rels_user_choices_id_idx": {
+          "name": "lectures_rels_user_choices_id_idx",
+          "columns": [
+            {
+              "expression": "user_choices_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "lectures_rels_subtle_system_nodes_id_idx": {
+          "name": "lectures_rels_subtle_system_nodes_id_idx",
+          "columns": [
+            {
+              "expression": "subtle_system_nodes_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "lectures_rels_parent_fk": {
+          "name": "lectures_rels_parent_fk",
+          "tableFrom": "lectures_rels",
+          "tableTo": "lectures",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "lectures_rels_audiences_fk": {
+          "name": "lectures_rels_audiences_fk",
+          "tableFrom": "lectures_rels",
+          "tableTo": "audiences",
+          "columnsFrom": [
+            "audiences_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "lectures_rels_user_choices_fk": {
+          "name": "lectures_rels_user_choices_fk",
+          "tableFrom": "lectures_rels",
+          "tableTo": "user_choices",
+          "columnsFrom": [
+            "user_choices_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "lectures_rels_subtle_system_nodes_fk": {
+          "name": "lectures_rels_subtle_system_nodes_fk",
+          "tableFrom": "lectures_rels",
+          "tableTo": "subtle_system_nodes",
+          "columnsFrom": [
+            "subtle_system_nodes_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.frames_tags": {
+      "name": "frames_tags",
+      "schema": "",
+      "columns": {
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "enum_frames_tags",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "frames_tags_order_idx": {
+          "name": "frames_tags_order_idx",
+          "columns": [
+            {
+              "expression": "order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "frames_tags_parent_idx": {
+          "name": "frames_tags_parent_idx",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "frames_tags_parent_fk": {
+          "name": "frames_tags_parent_fk",
+          "tableFrom": "frames_tags",
+          "tableTo": "frames",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.frames": {
+      "name": "frames",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "image_set": {
+          "name": "image_set",
+          "type": "enum_frames_image_set",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subtle_system_node_id": {
+          "name": "subtle_system_node_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration": {
+          "name": "duration",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_metadata": {
+          "name": "file_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "thumbnail_u_r_l": {
+          "name": "thumbnail_u_r_l",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "filename": {
+          "name": "filename",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "filesize": {
+          "name": "filesize",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "width": {
+          "name": "width",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "height": {
+          "name": "height",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "focal_x": {
+          "name": "focal_x",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "focal_y": {
+          "name": "focal_y",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "frames_subtle_system_node_idx": {
+          "name": "frames_subtle_system_node_idx",
+          "columns": [
+            {
+              "expression": "subtle_system_node_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "frames_updated_at_idx": {
+          "name": "frames_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "frames_created_at_idx": {
+          "name": "frames_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "frames_filename_idx": {
+          "name": "frames_filename_idx",
+          "columns": [
+            {
+              "expression": "filename",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "imageSet_idx": {
+          "name": "imageSet_idx",
+          "columns": [
+            {
+              "expression": "image_set",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "frames_subtle_system_node_id_subtle_system_nodes_id_fk": {
+          "name": "frames_subtle_system_node_id_subtle_system_nodes_id_fk",
+          "tableFrom": "frames",
+          "tableTo": "subtle_system_nodes",
+          "columnsFrom": [
+            "subtle_system_node_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.narrators": {
+      "name": "narrators",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gender": {
+          "name": "gender",
+          "type": "enum_narrators_gender",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "narrators_updated_at_idx": {
+          "name": "narrators_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "narrators_created_at_idx": {
+          "name": "narrators_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.authors": {
+      "name": "authors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "generate_slug": {
+          "name": "generate_slug",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "country_code": {
+          "name": "country_code",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "years_meditating": {
+          "name": "years_meditating",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "photo_id": {
+          "name": "photo_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "authors_slug_idx": {
+          "name": "authors_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "authors_photo_idx": {
+          "name": "authors_photo_idx",
+          "columns": [
+            {
+              "expression": "photo_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "authors_updated_at_idx": {
+          "name": "authors_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "authors_created_at_idx": {
+          "name": "authors_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "authors_photo_id_images_id_fk": {
+          "name": "authors_photo_id_images_id_fk",
+          "tableFrom": "authors",
+          "tableTo": "images",
+          "columnsFrom": [
+            "photo_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.authors_locales": {
+      "name": "authors_locales",
+      "schema": "",
+      "columns": {
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "_locale": {
+          "name": "_locale",
+          "type": "_locales",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "authors_locales_locale_parent_id_unique": {
+          "name": "authors_locales_locale_parent_id_unique",
+          "columns": [
+            {
+              "expression": "_locale",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "authors_locales_parent_id_fk": {
+          "name": "authors_locales_parent_id_fk",
+          "tableFrom": "authors_locales",
+          "tableTo": "authors",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.images_tags": {
+      "name": "images_tags",
+      "schema": "",
+      "columns": {
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "enum_images_tags",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "images_tags_order_idx": {
+          "name": "images_tags_order_idx",
+          "columns": [
+            {
+              "expression": "order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "images_tags_parent_idx": {
+          "name": "images_tags_parent_idx",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "images_tags_parent_fk": {
+          "name": "images_tags_parent_fk",
+          "tableFrom": "images_tags",
+          "tableTo": "images",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.images": {
+      "name": "images",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "file_metadata": {
+          "name": "file_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thumbnail_u_r_l": {
+          "name": "thumbnail_u_r_l",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "filename": {
+          "name": "filename",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "filesize": {
+          "name": "filesize",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "width": {
+          "name": "width",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "height": {
+          "name": "height",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "focal_x": {
+          "name": "focal_x",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "focal_y": {
+          "name": "focal_y",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "images_updated_at_idx": {
+          "name": "images_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "images_created_at_idx": {
+          "name": "images_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "images_deleted_at_idx": {
+          "name": "images_deleted_at_idx",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "images_filename_idx": {
+          "name": "images_filename_idx",
+          "columns": [
+            {
+              "expression": "filename",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.images_locales": {
+      "name": "images_locales",
+      "schema": "",
+      "columns": {
+        "alt": {
+          "name": "alt",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credit": {
+          "name": "credit",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "_locale": {
+          "name": "_locale",
+          "type": "_locales",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "images_locales_locale_parent_id_unique": {
+          "name": "images_locales_locale_parent_id_unique",
+          "columns": [
+            {
+              "expression": "_locale",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "images_locales_parent_id_fk": {
+          "name": "images_locales_parent_id_fk",
+          "tableFrom": "images_locales",
+          "tableTo": "images",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.files": {
+      "name": "files",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thumbnail_u_r_l": {
+          "name": "thumbnail_u_r_l",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "filename": {
+          "name": "filename",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "filesize": {
+          "name": "filesize",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "width": {
+          "name": "width",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "height": {
+          "name": "height",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "focal_x": {
+          "name": "focal_x",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "focal_y": {
+          "name": "focal_y",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "files_updated_at_idx": {
+          "name": "files_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "files_deleted_at_idx": {
+          "name": "files_deleted_at_idx",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "files_filename_idx": {
+          "name": "files_filename_idx",
+          "columns": [
+            {
+              "expression": "filename",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.audiences_location_countries": {
+      "name": "audiences_location_countries",
+      "schema": "",
+      "columns": {
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "enum_audiences_location_countries",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "audiences_location_countries_order_idx": {
+          "name": "audiences_location_countries_order_idx",
+          "columns": [
+            {
+              "expression": "order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audiences_location_countries_parent_idx": {
+          "name": "audiences_location_countries_parent_idx",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audiences_location_countries_parent_fk": {
+          "name": "audiences_location_countries_parent_fk",
+          "tableFrom": "audiences_location_countries",
+          "tableTo": "audiences",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.audiences": {
+      "name": "audiences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path_progress_min": {
+          "name": "path_progress_min",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "path_progress_max": {
+          "name": "path_progress_max",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meditations_per_week_min": {
+          "name": "meditations_per_week_min",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meditations_per_week_max": {
+          "name": "meditations_per_week_max",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_meditations_viewed_min": {
+          "name": "total_meditations_viewed_min",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_meditations_viewed_max": {
+          "name": "total_meditations_viewed_max",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_lectures_viewed_min": {
+          "name": "total_lectures_viewed_min",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_lectures_viewed_max": {
+          "name": "total_lectures_viewed_max",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "audiences_updated_at_idx": {
+          "name": "audiences_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audiences_created_at_idx": {
+          "name": "audiences_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_choices_timings": {
+      "name": "user_choices_timings",
+      "schema": "",
+      "columns": {
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "enum_user_choices_timings",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "user_choices_timings_order_idx": {
+          "name": "user_choices_timings_order_idx",
+          "columns": [
+            {
+              "expression": "order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_choices_timings_parent_idx": {
+          "name": "user_choices_timings_parent_idx",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_choices_timings_parent_fk": {
+          "name": "user_choices_timings_parent_fk",
+          "tableFrom": "user_choices_timings",
+          "tableTo": "user_choices",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_choices": {
+      "name": "user_choices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "generate_slug": {
+          "name": "generate_slug",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "enum_user_choices_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'mood'"
+        },
+        "color": {
+          "name": "color",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'#000000'"
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_featured": {
+          "name": "is_featured",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "order": {
+          "name": "order",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 1
+        },
+        "is_parent": {
+          "name": "is_parent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "thumbnail_u_r_l": {
+          "name": "thumbnail_u_r_l",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "filename": {
+          "name": "filename",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "filesize": {
+          "name": "filesize",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "width": {
+          "name": "width",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "height": {
+          "name": "height",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "focal_x": {
+          "name": "focal_x",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "focal_y": {
+          "name": "focal_y",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "user_choices_slug_idx": {
+          "name": "user_choices_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_choices_parent_idx": {
+          "name": "user_choices_parent_idx",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_choices_is_parent_idx": {
+          "name": "user_choices_is_parent_idx",
+          "columns": [
+            {
+              "expression": "is_parent",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_choices_updated_at_idx": {
+          "name": "user_choices_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_choices_created_at_idx": {
+          "name": "user_choices_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_choices_filename_idx": {
+          "name": "user_choices_filename_idx",
+          "columns": [
+            {
+              "expression": "filename",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_choices_parent_id_user_choices_id_fk": {
+          "name": "user_choices_parent_id_user_choices_id_fk",
+          "tableFrom": "user_choices",
+          "tableTo": "user_choices",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_choices_locales": {
+      "name": "user_choices_locales",
+      "schema": "",
+      "columns": {
+        "title": {
+          "name": "title",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "morning_meditation_id": {
+          "name": "morning_meditation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "afternoon_meditation_id": {
+          "name": "afternoon_meditation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "evening_meditation_id": {
+          "name": "evening_meditation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "night_meditation_id": {
+          "name": "night_meditation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "_locale": {
+          "name": "_locale",
+          "type": "_locales",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "user_choices_morning_meditation_idx": {
+          "name": "user_choices_morning_meditation_idx",
+          "columns": [
+            {
+              "expression": "morning_meditation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "_locale",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_choices_afternoon_meditation_idx": {
+          "name": "user_choices_afternoon_meditation_idx",
+          "columns": [
+            {
+              "expression": "afternoon_meditation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "_locale",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_choices_evening_meditation_idx": {
+          "name": "user_choices_evening_meditation_idx",
+          "columns": [
+            {
+              "expression": "evening_meditation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "_locale",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_choices_night_meditation_idx": {
+          "name": "user_choices_night_meditation_idx",
+          "columns": [
+            {
+              "expression": "night_meditation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "_locale",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_choices_locales_locale_parent_id_unique": {
+          "name": "user_choices_locales_locale_parent_id_unique",
+          "columns": [
+            {
+              "expression": "_locale",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_choices_locales_morning_meditation_id_meditations_id_fk": {
+          "name": "user_choices_locales_morning_meditation_id_meditations_id_fk",
+          "tableFrom": "user_choices_locales",
+          "tableTo": "meditations",
+          "columnsFrom": [
+            "morning_meditation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "user_choices_locales_afternoon_meditation_id_meditations_id_fk": {
+          "name": "user_choices_locales_afternoon_meditation_id_meditations_id_fk",
+          "tableFrom": "user_choices_locales",
+          "tableTo": "meditations",
+          "columnsFrom": [
+            "afternoon_meditation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "user_choices_locales_evening_meditation_id_meditations_id_fk": {
+          "name": "user_choices_locales_evening_meditation_id_meditations_id_fk",
+          "tableFrom": "user_choices_locales",
+          "tableTo": "meditations",
+          "columnsFrom": [
+            "evening_meditation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "user_choices_locales_night_meditation_id_meditations_id_fk": {
+          "name": "user_choices_locales_night_meditation_id_meditations_id_fk",
+          "tableFrom": "user_choices_locales",
+          "tableTo": "meditations",
+          "columnsFrom": [
+            "night_meditation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "user_choices_locales_parent_id_fk": {
+          "name": "user_choices_locales_parent_id_fk",
+          "tableFrom": "user_choices_locales",
+          "tableTo": "user_choices",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.subtle_system_nodes": {
+      "name": "subtle_system_nodes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "enum_subtle_system_nodes_slug",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "page_id": {
+          "name": "page_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "subtle_system_nodes_slug_idx": {
+          "name": "subtle_system_nodes_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "subtle_system_nodes_page_idx": {
+          "name": "subtle_system_nodes_page_idx",
+          "columns": [
+            {
+              "expression": "page_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "subtle_system_nodes_updated_at_idx": {
+          "name": "subtle_system_nodes_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "subtle_system_nodes_created_at_idx": {
+          "name": "subtle_system_nodes_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "subtle_system_nodes_page_id_pages_id_fk": {
+          "name": "subtle_system_nodes_page_id_pages_id_fk",
+          "tableFrom": "subtle_system_nodes",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "page_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.song_tags": {
+      "name": "song_tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "generate_slug": {
+          "name": "generate_slug",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "thumbnail_u_r_l": {
+          "name": "thumbnail_u_r_l",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "filename": {
+          "name": "filename",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "filesize": {
+          "name": "filesize",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "width": {
+          "name": "width",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "height": {
+          "name": "height",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "focal_x": {
+          "name": "focal_x",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "focal_y": {
+          "name": "focal_y",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "song_tags_slug_idx": {
+          "name": "song_tags_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "song_tags_updated_at_idx": {
+          "name": "song_tags_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "song_tags_created_at_idx": {
+          "name": "song_tags_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "song_tags_filename_idx": {
+          "name": "song_tags_filename_idx",
+          "columns": [
+            {
+              "expression": "filename",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.song_tags_locales": {
+      "name": "song_tags_locales",
+      "schema": "",
+      "columns": {
+        "title": {
+          "name": "title",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "_locale": {
+          "name": "_locale",
+          "type": "_locales",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "song_tags_locales_locale_parent_id_unique": {
+          "name": "song_tags_locales_locale_parent_id_unique",
+          "columns": [
+            {
+              "expression": "_locale",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "song_tags_locales_parent_id_fk": {
+          "name": "song_tags_locales_parent_id_fk",
+          "tableFrom": "song_tags_locales",
+          "tableTo": "song_tags",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.managers_roles": {
+      "name": "managers_roles",
+      "schema": "",
+      "columns": {
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "enum_managers_roles",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "locale": {
+          "name": "locale",
+          "type": "_locales",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "managers_roles_order_idx": {
+          "name": "managers_roles_order_idx",
+          "columns": [
+            {
+              "expression": "order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "managers_roles_parent_idx": {
+          "name": "managers_roles_parent_idx",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "managers_roles_locale_idx": {
+          "name": "managers_roles_locale_idx",
+          "columns": [
+            {
+              "expression": "locale",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "managers_roles_parent_fk": {
+          "name": "managers_roles_parent_fk",
+          "tableFrom": "managers_roles",
+          "tableTo": "managers",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.managers_contact_details": {
+      "name": "managers_contact_details",
+      "schema": "",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "platform": {
+          "name": "platform",
+          "type": "enum_managers_contact_details_platform",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verified": {
+          "name": "verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "managers_contact_details_order_idx": {
+          "name": "managers_contact_details_order_idx",
+          "columns": [
+            {
+              "expression": "_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "managers_contact_details_parent_id_idx": {
+          "name": "managers_contact_details_parent_id_idx",
+          "columns": [
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "managers_contact_details_parent_id_fk": {
+          "name": "managers_contact_details_parent_id_fk",
+          "tableFrom": "managers_contact_details",
+          "tableTo": "managers",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.managers_sessions": {
+      "name": "managers_sessions",
+      "schema": "",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "managers_sessions_order_idx": {
+          "name": "managers_sessions_order_idx",
+          "columns": [
+            {
+              "expression": "_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "managers_sessions_parent_id_idx": {
+          "name": "managers_sessions_parent_id_idx",
+          "columns": [
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "managers_sessions_parent_id_fk": {
+          "name": "managers_sessions_parent_id_fk",
+          "tableFrom": "managers_sessions",
+          "tableTo": "managers",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.managers": {
+      "name": "managers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_project": {
+          "name": "current_project",
+          "type": "enum_managers_current_project",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "enum_managers_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manager'"
+        },
+        "language": {
+          "name": "language",
+          "type": "enum_managers_language",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notification_preferences": {
+          "name": "notification_preferences",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{\"new_responsibility\":{\"frequency\":\"Immediate\",\"method\":\"email\"},\"event_verification\":{\"frequency\":\"Monthly\",\"method\":\"email\"},\"event_registration\":{\"frequency\":\"Immediate\",\"method\":\"email\"},\"regional_summary\":{\"frequency\":\"Monthly\",\"method\":\"email\"}}'::jsonb"
+        },
+        "legacy_id": {
+          "name": "legacy_id",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "legacy_data": {
+          "name": "legacy_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reset_password_token": {
+          "name": "reset_password_token",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reset_password_expiration": {
+          "name": "reset_password_expiration",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "salt": {
+          "name": "salt",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hash": {
+          "name": "hash",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "_verified": {
+          "name": "_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "_verificationtoken": {
+          "name": "_verificationtoken",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "login_attempts": {
+          "name": "login_attempts",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "lock_until": {
+          "name": "lock_until",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "managers_legacy_id_idx": {
+          "name": "managers_legacy_id_idx",
+          "columns": [
+            {
+              "expression": "legacy_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "managers_updated_at_idx": {
+          "name": "managers_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "managers_created_at_idx": {
+          "name": "managers_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "managers_email_idx": {
+          "name": "managers_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.clients_roles": {
+      "name": "clients_roles",
+      "schema": "",
+      "columns": {
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "enum_clients_roles",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "clients_roles_order_idx": {
+          "name": "clients_roles_order_idx",
+          "columns": [
+            {
+              "expression": "order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clients_roles_parent_idx": {
+          "name": "clients_roles_parent_idx",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "clients_roles_parent_fk": {
+          "name": "clients_roles_parent_fk",
+          "tableFrom": "clients_roles",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.clients": {
+      "name": "clients",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "primary_contact_id": {
+          "name": "primary_contact_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allowed_domains": {
+          "name": "allowed_domains",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color1": {
+          "name": "color1",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'#000000'"
+        },
+        "color2": {
+          "name": "color2",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'#000000'"
+        },
+        "color3": {
+          "name": "color3",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'#000000'"
+        },
+        "locale": {
+          "name": "locale",
+          "type": "enum_clients_locale",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "region_id": {
+          "name": "region_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "legacy_config": {
+          "name": "legacy_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "key_generated_at": {
+          "name": "key_generated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "usage_daily_requests": {
+          "name": "usage_daily_requests",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "usage_peak_daily_requests": {
+          "name": "usage_peak_daily_requests",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "usage_last_request_at": {
+          "name": "usage_last_request_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "usage_total_requests": {
+          "name": "usage_total_requests",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "usage_high_usage_days": {
+          "name": "usage_high_usage_days",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "usage_last_high_usage_at": {
+          "name": "usage_last_high_usage_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "usage_first_request_at": {
+          "name": "usage_first_request_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "legacy_id": {
+          "name": "legacy_id",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "legacy_data": {
+          "name": "legacy_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "_status": {
+          "name": "_status",
+          "type": "enum_clients_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'draft'"
+        },
+        "enable_a_p_i_key": {
+          "name": "enable_a_p_i_key",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_key_index": {
+          "name": "api_key_index",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "clients_primary_contact_idx": {
+          "name": "clients_primary_contact_idx",
+          "columns": [
+            {
+              "expression": "primary_contact_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clients_region_idx": {
+          "name": "clients_region_idx",
+          "columns": [
+            {
+              "expression": "region_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clients_legacy_id_idx": {
+          "name": "clients_legacy_id_idx",
+          "columns": [
+            {
+              "expression": "legacy_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clients_updated_at_idx": {
+          "name": "clients_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clients_created_at_idx": {
+          "name": "clients_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clients__status_idx": {
+          "name": "clients__status_idx",
+          "columns": [
+            {
+              "expression": "_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "clients_primary_contact_id_managers_id_fk": {
+          "name": "clients_primary_contact_id_managers_id_fk",
+          "tableFrom": "clients",
+          "tableTo": "managers",
+          "columnsFrom": [
+            "primary_contact_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "clients_region_id_regions_id_fk": {
+          "name": "clients_region_id_regions_id_fk",
+          "tableFrom": "clients",
+          "tableTo": "regions",
+          "columnsFrom": [
+            "region_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.clients_rels": {
+      "name": "clients_rels",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "managers_id": {
+          "name": "managers_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "clients_rels_order_idx": {
+          "name": "clients_rels_order_idx",
+          "columns": [
+            {
+              "expression": "order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clients_rels_parent_idx": {
+          "name": "clients_rels_parent_idx",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clients_rels_path_idx": {
+          "name": "clients_rels_path_idx",
+          "columns": [
+            {
+              "expression": "path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clients_rels_managers_id_idx": {
+          "name": "clients_rels_managers_id_idx",
+          "columns": [
+            {
+              "expression": "managers_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "clients_rels_parent_fk": {
+          "name": "clients_rels_parent_fk",
+          "tableFrom": "clients_rels",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "clients_rels_managers_fk": {
+          "name": "clients_rels_managers_fk",
+          "tableFrom": "clients_rels",
+          "tableTo": "managers",
+          "columnsFrom": [
+            "managers_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public._clients_v_version_roles": {
+      "name": "_clients_v_version_roles",
+      "schema": "",
+      "columns": {
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "enum__clients_v_version_roles",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "_clients_v_version_roles_order_idx": {
+          "name": "_clients_v_version_roles_order_idx",
+          "columns": [
+            {
+              "expression": "order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_clients_v_version_roles_parent_idx": {
+          "name": "_clients_v_version_roles_parent_idx",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "_clients_v_version_roles_parent_fk": {
+          "name": "_clients_v_version_roles_parent_fk",
+          "tableFrom": "_clients_v_version_roles",
+          "tableTo": "_clients_v",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public._clients_v": {
+      "name": "_clients_v",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_name": {
+          "name": "version_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_notes": {
+          "name": "version_notes",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_primary_contact_id": {
+          "name": "version_primary_contact_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_allowed_domains": {
+          "name": "version_allowed_domains",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_color1": {
+          "name": "version_color1",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'#000000'"
+        },
+        "version_color2": {
+          "name": "version_color2",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'#000000'"
+        },
+        "version_color3": {
+          "name": "version_color3",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'#000000'"
+        },
+        "version_locale": {
+          "name": "version_locale",
+          "type": "enum__clients_v_version_locale",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_region_id": {
+          "name": "version_region_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_legacy_config": {
+          "name": "version_legacy_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_client_id": {
+          "name": "version_client_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_key_generated_at": {
+          "name": "version_key_generated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_usage_daily_requests": {
+          "name": "version_usage_daily_requests",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "version_usage_peak_daily_requests": {
+          "name": "version_usage_peak_daily_requests",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "version_usage_last_request_at": {
+          "name": "version_usage_last_request_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_usage_total_requests": {
+          "name": "version_usage_total_requests",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "version_usage_high_usage_days": {
+          "name": "version_usage_high_usage_days",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "version_usage_last_high_usage_at": {
+          "name": "version_usage_last_high_usage_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_usage_first_request_at": {
+          "name": "version_usage_first_request_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_legacy_id": {
+          "name": "version_legacy_id",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_legacy_data": {
+          "name": "version_legacy_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_updated_at": {
+          "name": "version_updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_created_at": {
+          "name": "version_created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version__status": {
+          "name": "version__status",
+          "type": "enum__clients_v_version_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'draft'"
+        },
+        "version_enable_a_p_i_key": {
+          "name": "version_enable_a_p_i_key",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_api_key": {
+          "name": "version_api_key",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_api_key_index": {
+          "name": "version_api_key_index",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "snapshot": {
+          "name": "snapshot",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_locale": {
+          "name": "published_locale",
+          "type": "enum__clients_v_published_locale",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latest": {
+          "name": "latest",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "_clients_v_parent_idx": {
+          "name": "_clients_v_parent_idx",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_clients_v_version_version_primary_contact_idx": {
+          "name": "_clients_v_version_version_primary_contact_idx",
+          "columns": [
+            {
+              "expression": "version_primary_contact_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_clients_v_version_version_region_idx": {
+          "name": "_clients_v_version_version_region_idx",
+          "columns": [
+            {
+              "expression": "version_region_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_clients_v_version_version_legacy_id_idx": {
+          "name": "_clients_v_version_version_legacy_id_idx",
+          "columns": [
+            {
+              "expression": "version_legacy_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_clients_v_version_version_updated_at_idx": {
+          "name": "_clients_v_version_version_updated_at_idx",
+          "columns": [
+            {
+              "expression": "version_updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_clients_v_version_version_created_at_idx": {
+          "name": "_clients_v_version_version_created_at_idx",
+          "columns": [
+            {
+              "expression": "version_created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_clients_v_version_version__status_idx": {
+          "name": "_clients_v_version_version__status_idx",
+          "columns": [
+            {
+              "expression": "version__status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_clients_v_created_at_idx": {
+          "name": "_clients_v_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_clients_v_updated_at_idx": {
+          "name": "_clients_v_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_clients_v_snapshot_idx": {
+          "name": "_clients_v_snapshot_idx",
+          "columns": [
+            {
+              "expression": "snapshot",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_clients_v_published_locale_idx": {
+          "name": "_clients_v_published_locale_idx",
+          "columns": [
+            {
+              "expression": "published_locale",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_clients_v_latest_idx": {
+          "name": "_clients_v_latest_idx",
+          "columns": [
+            {
+              "expression": "latest",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "_clients_v_parent_id_clients_id_fk": {
+          "name": "_clients_v_parent_id_clients_id_fk",
+          "tableFrom": "_clients_v",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "_clients_v_version_primary_contact_id_managers_id_fk": {
+          "name": "_clients_v_version_primary_contact_id_managers_id_fk",
+          "tableFrom": "_clients_v",
+          "tableTo": "managers",
+          "columnsFrom": [
+            "version_primary_contact_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "_clients_v_version_region_id_regions_id_fk": {
+          "name": "_clients_v_version_region_id_regions_id_fk",
+          "tableFrom": "_clients_v",
+          "tableTo": "regions",
+          "columnsFrom": [
+            "version_region_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public._clients_v_rels": {
+      "name": "_clients_v_rels",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "managers_id": {
+          "name": "managers_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "_clients_v_rels_order_idx": {
+          "name": "_clients_v_rels_order_idx",
+          "columns": [
+            {
+              "expression": "order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_clients_v_rels_parent_idx": {
+          "name": "_clients_v_rels_parent_idx",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_clients_v_rels_path_idx": {
+          "name": "_clients_v_rels_path_idx",
+          "columns": [
+            {
+              "expression": "path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_clients_v_rels_managers_id_idx": {
+          "name": "_clients_v_rels_managers_id_idx",
+          "columns": [
+            {
+              "expression": "managers_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "_clients_v_rels_parent_fk": {
+          "name": "_clients_v_rels_parent_fk",
+          "tableFrom": "_clients_v_rels",
+          "tableTo": "_clients_v",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "_clients_v_rels_managers_fk": {
+          "name": "_clients_v_rels_managers_fk",
+          "tableFrom": "_clients_v_rels",
+          "tableTo": "managers",
+          "columnsFrom": [
+            "managers_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_cards_schedule_weekdays": {
+      "name": "app_cards_schedule_weekdays",
+      "schema": "",
+      "columns": {
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "enum_app_cards_schedule_weekdays",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "app_cards_schedule_weekdays_order_idx": {
+          "name": "app_cards_schedule_weekdays_order_idx",
+          "columns": [
+            {
+              "expression": "order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "app_cards_schedule_weekdays_parent_idx": {
+          "name": "app_cards_schedule_weekdays_parent_idx",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "app_cards_schedule_weekdays_parent_fk": {
+          "name": "app_cards_schedule_weekdays_parent_fk",
+          "tableFrom": "app_cards_schedule_weekdays",
+          "tableTo": "app_cards",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_cards_schedule_exclusions": {
+      "name": "app_cards_schedule_exclusions",
+      "schema": "",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "app_cards_schedule_exclusions_order_idx": {
+          "name": "app_cards_schedule_exclusions_order_idx",
+          "columns": [
+            {
+              "expression": "_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "app_cards_schedule_exclusions_parent_id_idx": {
+          "name": "app_cards_schedule_exclusions_parent_id_idx",
+          "columns": [
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "app_cards_schedule_exclusions_parent_id_fk": {
+          "name": "app_cards_schedule_exclusions_parent_id_fk",
+          "tableFrom": "app_cards_schedule_exclusions",
+          "tableTo": "app_cards",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_cards_target_sections": {
+      "name": "app_cards_target_sections",
+      "schema": "",
+      "columns": {
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "enum_app_cards_target_sections",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "app_cards_target_sections_order_idx": {
+          "name": "app_cards_target_sections_order_idx",
+          "columns": [
+            {
+              "expression": "order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "app_cards_target_sections_parent_idx": {
+          "name": "app_cards_target_sections_parent_idx",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "app_cards_target_sections_parent_fk": {
+          "name": "app_cards_target_sections_parent_fk",
+          "tableFrom": "app_cards_target_sections",
+          "tableTo": "app_cards",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_cards_timings": {
+      "name": "app_cards_timings",
+      "schema": "",
+      "columns": {
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "enum_app_cards_timings",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "app_cards_timings_order_idx": {
+          "name": "app_cards_timings_order_idx",
+          "columns": [
+            {
+              "expression": "order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "app_cards_timings_parent_idx": {
+          "name": "app_cards_timings_parent_idx",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "app_cards_timings_parent_fk": {
+          "name": "app_cards_timings_parent_fk",
+          "tableFrom": "app_cards_timings",
+          "tableTo": "app_cards",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_cards": {
+      "name": "app_cards",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "enum_app_cards_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'standard'"
+        },
+        "default_button_icon_id": {
+          "name": "default_button_icon_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_destination": {
+          "name": "default_destination",
+          "type": "enum_app_cards_default_destination",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_page_id": {
+          "name": "default_page_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_lecture_id": {
+          "name": "default_lecture_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_album_id": {
+          "name": "default_album_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_meditation_id": {
+          "name": "default_meditation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_image_id": {
+          "name": "default_image_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_aspect_ratio": {
+          "name": "default_aspect_ratio",
+          "type": "enum_app_cards_default_aspect_ratio",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'square'"
+        },
+        "default_text_color": {
+          "name": "default_text_color",
+          "type": "enum_app_cards_default_text_color",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'black'"
+        },
+        "default_alignment": {
+          "name": "default_alignment",
+          "type": "enum_app_cards_default_alignment",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'center'"
+        },
+        "starting_soon_enabled": {
+          "name": "starting_soon_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "starting_soon_threshold": {
+          "name": "starting_soon_threshold",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'1:00'"
+        },
+        "starting_soon_button_icon_id": {
+          "name": "starting_soon_button_icon_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "starting_soon_destination": {
+          "name": "starting_soon_destination",
+          "type": "enum_app_cards_starting_soon_destination",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "starting_soon_page_id": {
+          "name": "starting_soon_page_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "starting_soon_lecture_id": {
+          "name": "starting_soon_lecture_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "starting_soon_album_id": {
+          "name": "starting_soon_album_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "starting_soon_meditation_id": {
+          "name": "starting_soon_meditation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "starting_soon_image_id": {
+          "name": "starting_soon_image_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "starting_soon_aspect_ratio": {
+          "name": "starting_soon_aspect_ratio",
+          "type": "enum_app_cards_starting_soon_aspect_ratio",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'square'"
+        },
+        "starting_soon_text_color": {
+          "name": "starting_soon_text_color",
+          "type": "enum_app_cards_starting_soon_text_color",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'black'"
+        },
+        "starting_soon_alignment": {
+          "name": "starting_soon_alignment",
+          "type": "enum_app_cards_starting_soon_alignment",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'center'"
+        },
+        "live_now_enabled": {
+          "name": "live_now_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "live_now_threshold": {
+          "name": "live_now_threshold",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0:00'"
+        },
+        "live_now_button_icon_id": {
+          "name": "live_now_button_icon_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "live_now_destination": {
+          "name": "live_now_destination",
+          "type": "enum_app_cards_live_now_destination",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "live_now_page_id": {
+          "name": "live_now_page_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "live_now_lecture_id": {
+          "name": "live_now_lecture_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "live_now_album_id": {
+          "name": "live_now_album_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "live_now_meditation_id": {
+          "name": "live_now_meditation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "live_now_image_id": {
+          "name": "live_now_image_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "live_now_aspect_ratio": {
+          "name": "live_now_aspect_ratio",
+          "type": "enum_app_cards_live_now_aspect_ratio",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'square'"
+        },
+        "live_now_text_color": {
+          "name": "live_now_text_color",
+          "type": "enum_app_cards_live_now_text_color",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'black'"
+        },
+        "live_now_alignment": {
+          "name": "live_now_alignment",
+          "type": "enum_app_cards_live_now_alignment",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'center'"
+        },
+        "schedule_first_date": {
+          "name": "schedule_first_date",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "schedule_firstdate_tz": {
+          "name": "schedule_firstdate_tz",
+          "type": "enum_app_cards_schedule_firstdate_tz",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "schedule_end_time": {
+          "name": "schedule_end_time",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "schedule_recurrence_type": {
+          "name": "schedule_recurrence_type",
+          "type": "enum_app_cards_schedule_recurrence_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "schedule_interval": {
+          "name": "schedule_interval",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 1
+        },
+        "weight": {
+          "name": "weight",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 3
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "_status": {
+          "name": "_status",
+          "type": "enum_app_cards_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'draft'"
+        }
+      },
+      "indexes": {
+        "app_cards_default_default_button_icon_idx": {
+          "name": "app_cards_default_default_button_icon_idx",
+          "columns": [
+            {
+              "expression": "default_button_icon_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "app_cards_default_default_page_idx": {
+          "name": "app_cards_default_default_page_idx",
+          "columns": [
+            {
+              "expression": "default_page_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "app_cards_default_default_lecture_idx": {
+          "name": "app_cards_default_default_lecture_idx",
+          "columns": [
+            {
+              "expression": "default_lecture_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "app_cards_default_default_album_idx": {
+          "name": "app_cards_default_default_album_idx",
+          "columns": [
+            {
+              "expression": "default_album_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "app_cards_default_default_meditation_idx": {
+          "name": "app_cards_default_default_meditation_idx",
+          "columns": [
+            {
+              "expression": "default_meditation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "app_cards_default_default_image_idx": {
+          "name": "app_cards_default_default_image_idx",
+          "columns": [
+            {
+              "expression": "default_image_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "app_cards_starting_soon_starting_soon_button_icon_idx": {
+          "name": "app_cards_starting_soon_starting_soon_button_icon_idx",
+          "columns": [
+            {
+              "expression": "starting_soon_button_icon_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "app_cards_starting_soon_starting_soon_page_idx": {
+          "name": "app_cards_starting_soon_starting_soon_page_idx",
+          "columns": [
+            {
+              "expression": "starting_soon_page_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "app_cards_starting_soon_starting_soon_lecture_idx": {
+          "name": "app_cards_starting_soon_starting_soon_lecture_idx",
+          "columns": [
+            {
+              "expression": "starting_soon_lecture_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "app_cards_starting_soon_starting_soon_album_idx": {
+          "name": "app_cards_starting_soon_starting_soon_album_idx",
+          "columns": [
+            {
+              "expression": "starting_soon_album_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "app_cards_starting_soon_starting_soon_meditation_idx": {
+          "name": "app_cards_starting_soon_starting_soon_meditation_idx",
+          "columns": [
+            {
+              "expression": "starting_soon_meditation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "app_cards_starting_soon_starting_soon_image_idx": {
+          "name": "app_cards_starting_soon_starting_soon_image_idx",
+          "columns": [
+            {
+              "expression": "starting_soon_image_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "app_cards_live_now_live_now_button_icon_idx": {
+          "name": "app_cards_live_now_live_now_button_icon_idx",
+          "columns": [
+            {
+              "expression": "live_now_button_icon_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "app_cards_live_now_live_now_page_idx": {
+          "name": "app_cards_live_now_live_now_page_idx",
+          "columns": [
+            {
+              "expression": "live_now_page_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "app_cards_live_now_live_now_lecture_idx": {
+          "name": "app_cards_live_now_live_now_lecture_idx",
+          "columns": [
+            {
+              "expression": "live_now_lecture_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "app_cards_live_now_live_now_album_idx": {
+          "name": "app_cards_live_now_live_now_album_idx",
+          "columns": [
+            {
+              "expression": "live_now_album_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "app_cards_live_now_live_now_meditation_idx": {
+          "name": "app_cards_live_now_live_now_meditation_idx",
+          "columns": [
+            {
+              "expression": "live_now_meditation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "app_cards_live_now_live_now_image_idx": {
+          "name": "app_cards_live_now_live_now_image_idx",
+          "columns": [
+            {
+              "expression": "live_now_image_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "app_cards_updated_at_idx": {
+          "name": "app_cards_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "app_cards_created_at_idx": {
+          "name": "app_cards_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "app_cards__status_idx": {
+          "name": "app_cards__status_idx",
+          "columns": [
+            {
+              "expression": "_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "app_cards_default_button_icon_id_images_id_fk": {
+          "name": "app_cards_default_button_icon_id_images_id_fk",
+          "tableFrom": "app_cards",
+          "tableTo": "images",
+          "columnsFrom": [
+            "default_button_icon_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "app_cards_default_page_id_pages_id_fk": {
+          "name": "app_cards_default_page_id_pages_id_fk",
+          "tableFrom": "app_cards",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "default_page_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "app_cards_default_lecture_id_lectures_id_fk": {
+          "name": "app_cards_default_lecture_id_lectures_id_fk",
+          "tableFrom": "app_cards",
+          "tableTo": "lectures",
+          "columnsFrom": [
+            "default_lecture_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "app_cards_default_album_id_albums_id_fk": {
+          "name": "app_cards_default_album_id_albums_id_fk",
+          "tableFrom": "app_cards",
+          "tableTo": "albums",
+          "columnsFrom": [
+            "default_album_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "app_cards_default_meditation_id_meditations_id_fk": {
+          "name": "app_cards_default_meditation_id_meditations_id_fk",
+          "tableFrom": "app_cards",
+          "tableTo": "meditations",
+          "columnsFrom": [
+            "default_meditation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "app_cards_default_image_id_images_id_fk": {
+          "name": "app_cards_default_image_id_images_id_fk",
+          "tableFrom": "app_cards",
+          "tableTo": "images",
+          "columnsFrom": [
+            "default_image_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "app_cards_starting_soon_button_icon_id_images_id_fk": {
+          "name": "app_cards_starting_soon_button_icon_id_images_id_fk",
+          "tableFrom": "app_cards",
+          "tableTo": "images",
+          "columnsFrom": [
+            "starting_soon_button_icon_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "app_cards_starting_soon_page_id_pages_id_fk": {
+          "name": "app_cards_starting_soon_page_id_pages_id_fk",
+          "tableFrom": "app_cards",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "starting_soon_page_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "app_cards_starting_soon_lecture_id_lectures_id_fk": {
+          "name": "app_cards_starting_soon_lecture_id_lectures_id_fk",
+          "tableFrom": "app_cards",
+          "tableTo": "lectures",
+          "columnsFrom": [
+            "starting_soon_lecture_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "app_cards_starting_soon_album_id_albums_id_fk": {
+          "name": "app_cards_starting_soon_album_id_albums_id_fk",
+          "tableFrom": "app_cards",
+          "tableTo": "albums",
+          "columnsFrom": [
+            "starting_soon_album_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "app_cards_starting_soon_meditation_id_meditations_id_fk": {
+          "name": "app_cards_starting_soon_meditation_id_meditations_id_fk",
+          "tableFrom": "app_cards",
+          "tableTo": "meditations",
+          "columnsFrom": [
+            "starting_soon_meditation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "app_cards_starting_soon_image_id_images_id_fk": {
+          "name": "app_cards_starting_soon_image_id_images_id_fk",
+          "tableFrom": "app_cards",
+          "tableTo": "images",
+          "columnsFrom": [
+            "starting_soon_image_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "app_cards_live_now_button_icon_id_images_id_fk": {
+          "name": "app_cards_live_now_button_icon_id_images_id_fk",
+          "tableFrom": "app_cards",
+          "tableTo": "images",
+          "columnsFrom": [
+            "live_now_button_icon_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "app_cards_live_now_page_id_pages_id_fk": {
+          "name": "app_cards_live_now_page_id_pages_id_fk",
+          "tableFrom": "app_cards",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "live_now_page_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "app_cards_live_now_lecture_id_lectures_id_fk": {
+          "name": "app_cards_live_now_lecture_id_lectures_id_fk",
+          "tableFrom": "app_cards",
+          "tableTo": "lectures",
+          "columnsFrom": [
+            "live_now_lecture_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "app_cards_live_now_album_id_albums_id_fk": {
+          "name": "app_cards_live_now_album_id_albums_id_fk",
+          "tableFrom": "app_cards",
+          "tableTo": "albums",
+          "columnsFrom": [
+            "live_now_album_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "app_cards_live_now_meditation_id_meditations_id_fk": {
+          "name": "app_cards_live_now_meditation_id_meditations_id_fk",
+          "tableFrom": "app_cards",
+          "tableTo": "meditations",
+          "columnsFrom": [
+            "live_now_meditation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "app_cards_live_now_image_id_images_id_fk": {
+          "name": "app_cards_live_now_image_id_images_id_fk",
+          "tableFrom": "app_cards",
+          "tableTo": "images",
+          "columnsFrom": [
+            "live_now_image_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_cards_locales": {
+      "name": "app_cards_locales",
+      "schema": "",
+      "columns": {
+        "default_header": {
+          "name": "default_header",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_title": {
+          "name": "default_title",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_subtitle": {
+          "name": "default_subtitle",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_button_text": {
+          "name": "default_button_text",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_url": {
+          "name": "default_url",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "starting_soon_header": {
+          "name": "starting_soon_header",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "starting_soon_title": {
+          "name": "starting_soon_title",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "starting_soon_subtitle": {
+          "name": "starting_soon_subtitle",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "starting_soon_button_text": {
+          "name": "starting_soon_button_text",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "starting_soon_url": {
+          "name": "starting_soon_url",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "live_now_header": {
+          "name": "live_now_header",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "live_now_title": {
+          "name": "live_now_title",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "live_now_subtitle": {
+          "name": "live_now_subtitle",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "live_now_button_text": {
+          "name": "live_now_button_text",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "live_now_url": {
+          "name": "live_now_url",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "_locale": {
+          "name": "_locale",
+          "type": "_locales",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "app_cards_locales_locale_parent_id_unique": {
+          "name": "app_cards_locales_locale_parent_id_unique",
+          "columns": [
+            {
+              "expression": "_locale",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "app_cards_locales_parent_id_fk": {
+          "name": "app_cards_locales_parent_id_fk",
+          "tableFrom": "app_cards_locales",
+          "tableTo": "app_cards",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_cards_rels": {
+      "name": "app_cards_rels",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "audiences_id": {
+          "name": "audiences_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "app_cards_rels_order_idx": {
+          "name": "app_cards_rels_order_idx",
+          "columns": [
+            {
+              "expression": "order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "app_cards_rels_parent_idx": {
+          "name": "app_cards_rels_parent_idx",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "app_cards_rels_path_idx": {
+          "name": "app_cards_rels_path_idx",
+          "columns": [
+            {
+              "expression": "path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "app_cards_rels_audiences_id_idx": {
+          "name": "app_cards_rels_audiences_id_idx",
+          "columns": [
+            {
+              "expression": "audiences_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "app_cards_rels_parent_fk": {
+          "name": "app_cards_rels_parent_fk",
+          "tableFrom": "app_cards_rels",
+          "tableTo": "app_cards",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "app_cards_rels_audiences_fk": {
+          "name": "app_cards_rels_audiences_fk",
+          "tableFrom": "app_cards_rels",
+          "tableTo": "audiences",
+          "columnsFrom": [
+            "audiences_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public._app_cards_v_version_schedule_weekdays": {
+      "name": "_app_cards_v_version_schedule_weekdays",
+      "schema": "",
+      "columns": {
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "enum__app_cards_v_version_schedule_weekdays",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "_app_cards_v_version_schedule_weekdays_order_idx": {
+          "name": "_app_cards_v_version_schedule_weekdays_order_idx",
+          "columns": [
+            {
+              "expression": "order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_app_cards_v_version_schedule_weekdays_parent_idx": {
+          "name": "_app_cards_v_version_schedule_weekdays_parent_idx",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "_app_cards_v_version_schedule_weekdays_parent_fk": {
+          "name": "_app_cards_v_version_schedule_weekdays_parent_fk",
+          "tableFrom": "_app_cards_v_version_schedule_weekdays",
+          "tableTo": "_app_cards_v",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public._app_cards_v_version_schedule_exclusions": {
+      "name": "_app_cards_v_version_schedule_exclusions",
+      "schema": "",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "_uuid": {
+          "name": "_uuid",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "_app_cards_v_version_schedule_exclusions_order_idx": {
+          "name": "_app_cards_v_version_schedule_exclusions_order_idx",
+          "columns": [
+            {
+              "expression": "_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_app_cards_v_version_schedule_exclusions_parent_id_idx": {
+          "name": "_app_cards_v_version_schedule_exclusions_parent_id_idx",
+          "columns": [
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "_app_cards_v_version_schedule_exclusions_parent_id_fk": {
+          "name": "_app_cards_v_version_schedule_exclusions_parent_id_fk",
+          "tableFrom": "_app_cards_v_version_schedule_exclusions",
+          "tableTo": "_app_cards_v",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public._app_cards_v_version_target_sections": {
+      "name": "_app_cards_v_version_target_sections",
+      "schema": "",
+      "columns": {
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "enum__app_cards_v_version_target_sections",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "_app_cards_v_version_target_sections_order_idx": {
+          "name": "_app_cards_v_version_target_sections_order_idx",
+          "columns": [
+            {
+              "expression": "order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_app_cards_v_version_target_sections_parent_idx": {
+          "name": "_app_cards_v_version_target_sections_parent_idx",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "_app_cards_v_version_target_sections_parent_fk": {
+          "name": "_app_cards_v_version_target_sections_parent_fk",
+          "tableFrom": "_app_cards_v_version_target_sections",
+          "tableTo": "_app_cards_v",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public._app_cards_v_version_timings": {
+      "name": "_app_cards_v_version_timings",
+      "schema": "",
+      "columns": {
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "enum__app_cards_v_version_timings",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "_app_cards_v_version_timings_order_idx": {
+          "name": "_app_cards_v_version_timings_order_idx",
+          "columns": [
+            {
+              "expression": "order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_app_cards_v_version_timings_parent_idx": {
+          "name": "_app_cards_v_version_timings_parent_idx",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "_app_cards_v_version_timings_parent_fk": {
+          "name": "_app_cards_v_version_timings_parent_fk",
+          "tableFrom": "_app_cards_v_version_timings",
+          "tableTo": "_app_cards_v",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public._app_cards_v": {
+      "name": "_app_cards_v",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_label": {
+          "name": "version_label",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_type": {
+          "name": "version_type",
+          "type": "enum__app_cards_v_version_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'standard'"
+        },
+        "version_default_button_icon_id": {
+          "name": "version_default_button_icon_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_default_destination": {
+          "name": "version_default_destination",
+          "type": "enum__app_cards_v_version_default_destination",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_default_page_id": {
+          "name": "version_default_page_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_default_lecture_id": {
+          "name": "version_default_lecture_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_default_album_id": {
+          "name": "version_default_album_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_default_meditation_id": {
+          "name": "version_default_meditation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_default_image_id": {
+          "name": "version_default_image_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_default_aspect_ratio": {
+          "name": "version_default_aspect_ratio",
+          "type": "enum__app_cards_v_version_default_aspect_ratio",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'square'"
+        },
+        "version_default_text_color": {
+          "name": "version_default_text_color",
+          "type": "enum__app_cards_v_version_default_text_color",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'black'"
+        },
+        "version_default_alignment": {
+          "name": "version_default_alignment",
+          "type": "enum__app_cards_v_version_default_alignment",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'center'"
+        },
+        "version_starting_soon_enabled": {
+          "name": "version_starting_soon_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "version_starting_soon_threshold": {
+          "name": "version_starting_soon_threshold",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'1:00'"
+        },
+        "version_starting_soon_button_icon_id": {
+          "name": "version_starting_soon_button_icon_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_starting_soon_destination": {
+          "name": "version_starting_soon_destination",
+          "type": "enum__app_cards_v_version_starting_soon_destination",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_starting_soon_page_id": {
+          "name": "version_starting_soon_page_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_starting_soon_lecture_id": {
+          "name": "version_starting_soon_lecture_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_starting_soon_album_id": {
+          "name": "version_starting_soon_album_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_starting_soon_meditation_id": {
+          "name": "version_starting_soon_meditation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_starting_soon_image_id": {
+          "name": "version_starting_soon_image_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_starting_soon_aspect_ratio": {
+          "name": "version_starting_soon_aspect_ratio",
+          "type": "enum__app_cards_v_version_starting_soon_aspect_ratio",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'square'"
+        },
+        "version_starting_soon_text_color": {
+          "name": "version_starting_soon_text_color",
+          "type": "enum__app_cards_v_version_starting_soon_text_color",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'black'"
+        },
+        "version_starting_soon_alignment": {
+          "name": "version_starting_soon_alignment",
+          "type": "enum__app_cards_v_version_starting_soon_alignment",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'center'"
+        },
+        "version_live_now_enabled": {
+          "name": "version_live_now_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "version_live_now_threshold": {
+          "name": "version_live_now_threshold",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0:00'"
+        },
+        "version_live_now_button_icon_id": {
+          "name": "version_live_now_button_icon_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_live_now_destination": {
+          "name": "version_live_now_destination",
+          "type": "enum__app_cards_v_version_live_now_destination",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_live_now_page_id": {
+          "name": "version_live_now_page_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_live_now_lecture_id": {
+          "name": "version_live_now_lecture_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_live_now_album_id": {
+          "name": "version_live_now_album_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_live_now_meditation_id": {
+          "name": "version_live_now_meditation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_live_now_image_id": {
+          "name": "version_live_now_image_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_live_now_aspect_ratio": {
+          "name": "version_live_now_aspect_ratio",
+          "type": "enum__app_cards_v_version_live_now_aspect_ratio",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'square'"
+        },
+        "version_live_now_text_color": {
+          "name": "version_live_now_text_color",
+          "type": "enum__app_cards_v_version_live_now_text_color",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'black'"
+        },
+        "version_live_now_alignment": {
+          "name": "version_live_now_alignment",
+          "type": "enum__app_cards_v_version_live_now_alignment",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'center'"
+        },
+        "version_schedule_first_date": {
+          "name": "version_schedule_first_date",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_schedule_firstdate_tz": {
+          "name": "version_schedule_firstdate_tz",
+          "type": "enum__app_cards_v_version_schedule_firstdate_tz",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_schedule_end_time": {
+          "name": "version_schedule_end_time",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_schedule_recurrence_type": {
+          "name": "version_schedule_recurrence_type",
+          "type": "enum__app_cards_v_version_schedule_recurrence_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_schedule_interval": {
+          "name": "version_schedule_interval",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 1
+        },
+        "version_weight": {
+          "name": "version_weight",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 3
+        },
+        "version_updated_at": {
+          "name": "version_updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_created_at": {
+          "name": "version_created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version__status": {
+          "name": "version__status",
+          "type": "enum__app_cards_v_version_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'draft'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "snapshot": {
+          "name": "snapshot",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_locale": {
+          "name": "published_locale",
+          "type": "enum__app_cards_v_published_locale",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latest": {
+          "name": "latest",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "_app_cards_v_parent_idx": {
+          "name": "_app_cards_v_parent_idx",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_app_cards_v_version_default_version_default_button_icon_idx": {
+          "name": "_app_cards_v_version_default_version_default_button_icon_idx",
+          "columns": [
+            {
+              "expression": "version_default_button_icon_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_app_cards_v_version_default_version_default_page_idx": {
+          "name": "_app_cards_v_version_default_version_default_page_idx",
+          "columns": [
+            {
+              "expression": "version_default_page_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_app_cards_v_version_default_version_default_lecture_idx": {
+          "name": "_app_cards_v_version_default_version_default_lecture_idx",
+          "columns": [
+            {
+              "expression": "version_default_lecture_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_app_cards_v_version_default_version_default_album_idx": {
+          "name": "_app_cards_v_version_default_version_default_album_idx",
+          "columns": [
+            {
+              "expression": "version_default_album_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_app_cards_v_version_default_version_default_meditation_idx": {
+          "name": "_app_cards_v_version_default_version_default_meditation_idx",
+          "columns": [
+            {
+              "expression": "version_default_meditation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_app_cards_v_version_default_version_default_image_idx": {
+          "name": "_app_cards_v_version_default_version_default_image_idx",
+          "columns": [
+            {
+              "expression": "version_default_image_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_app_cards_v_version_starting_soon_version_starting_soon_idx": {
+          "name": "_app_cards_v_version_starting_soon_version_starting_soon_idx",
+          "columns": [
+            {
+              "expression": "version_starting_soon_button_icon_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_app_cards_v_version_starting_soon_version_starting_so_1_idx": {
+          "name": "_app_cards_v_version_starting_soon_version_starting_so_1_idx",
+          "columns": [
+            {
+              "expression": "version_starting_soon_page_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_app_cards_v_version_starting_soon_version_starting_so_2_idx": {
+          "name": "_app_cards_v_version_starting_soon_version_starting_so_2_idx",
+          "columns": [
+            {
+              "expression": "version_starting_soon_lecture_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_app_cards_v_version_starting_soon_version_starting_so_3_idx": {
+          "name": "_app_cards_v_version_starting_soon_version_starting_so_3_idx",
+          "columns": [
+            {
+              "expression": "version_starting_soon_album_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_app_cards_v_version_starting_soon_version_starting_so_4_idx": {
+          "name": "_app_cards_v_version_starting_soon_version_starting_so_4_idx",
+          "columns": [
+            {
+              "expression": "version_starting_soon_meditation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_app_cards_v_version_starting_soon_version_starting_so_5_idx": {
+          "name": "_app_cards_v_version_starting_soon_version_starting_so_5_idx",
+          "columns": [
+            {
+              "expression": "version_starting_soon_image_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_app_cards_v_version_live_now_version_live_now_button_ic_idx": {
+          "name": "_app_cards_v_version_live_now_version_live_now_button_ic_idx",
+          "columns": [
+            {
+              "expression": "version_live_now_button_icon_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_app_cards_v_version_live_now_version_live_now_page_idx": {
+          "name": "_app_cards_v_version_live_now_version_live_now_page_idx",
+          "columns": [
+            {
+              "expression": "version_live_now_page_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_app_cards_v_version_live_now_version_live_now_lecture_idx": {
+          "name": "_app_cards_v_version_live_now_version_live_now_lecture_idx",
+          "columns": [
+            {
+              "expression": "version_live_now_lecture_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_app_cards_v_version_live_now_version_live_now_album_idx": {
+          "name": "_app_cards_v_version_live_now_version_live_now_album_idx",
+          "columns": [
+            {
+              "expression": "version_live_now_album_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_app_cards_v_version_live_now_version_live_now_meditatio_idx": {
+          "name": "_app_cards_v_version_live_now_version_live_now_meditatio_idx",
+          "columns": [
+            {
+              "expression": "version_live_now_meditation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_app_cards_v_version_live_now_version_live_now_image_idx": {
+          "name": "_app_cards_v_version_live_now_version_live_now_image_idx",
+          "columns": [
+            {
+              "expression": "version_live_now_image_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_app_cards_v_version_version_updated_at_idx": {
+          "name": "_app_cards_v_version_version_updated_at_idx",
+          "columns": [
+            {
+              "expression": "version_updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_app_cards_v_version_version_created_at_idx": {
+          "name": "_app_cards_v_version_version_created_at_idx",
+          "columns": [
+            {
+              "expression": "version_created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_app_cards_v_version_version__status_idx": {
+          "name": "_app_cards_v_version_version__status_idx",
+          "columns": [
+            {
+              "expression": "version__status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_app_cards_v_created_at_idx": {
+          "name": "_app_cards_v_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_app_cards_v_updated_at_idx": {
+          "name": "_app_cards_v_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_app_cards_v_snapshot_idx": {
+          "name": "_app_cards_v_snapshot_idx",
+          "columns": [
+            {
+              "expression": "snapshot",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_app_cards_v_published_locale_idx": {
+          "name": "_app_cards_v_published_locale_idx",
+          "columns": [
+            {
+              "expression": "published_locale",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_app_cards_v_latest_idx": {
+          "name": "_app_cards_v_latest_idx",
+          "columns": [
+            {
+              "expression": "latest",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "_app_cards_v_parent_id_app_cards_id_fk": {
+          "name": "_app_cards_v_parent_id_app_cards_id_fk",
+          "tableFrom": "_app_cards_v",
+          "tableTo": "app_cards",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "_app_cards_v_version_default_button_icon_id_images_id_fk": {
+          "name": "_app_cards_v_version_default_button_icon_id_images_id_fk",
+          "tableFrom": "_app_cards_v",
+          "tableTo": "images",
+          "columnsFrom": [
+            "version_default_button_icon_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "_app_cards_v_version_default_page_id_pages_id_fk": {
+          "name": "_app_cards_v_version_default_page_id_pages_id_fk",
+          "tableFrom": "_app_cards_v",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "version_default_page_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "_app_cards_v_version_default_lecture_id_lectures_id_fk": {
+          "name": "_app_cards_v_version_default_lecture_id_lectures_id_fk",
+          "tableFrom": "_app_cards_v",
+          "tableTo": "lectures",
+          "columnsFrom": [
+            "version_default_lecture_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "_app_cards_v_version_default_album_id_albums_id_fk": {
+          "name": "_app_cards_v_version_default_album_id_albums_id_fk",
+          "tableFrom": "_app_cards_v",
+          "tableTo": "albums",
+          "columnsFrom": [
+            "version_default_album_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "_app_cards_v_version_default_meditation_id_meditations_id_fk": {
+          "name": "_app_cards_v_version_default_meditation_id_meditations_id_fk",
+          "tableFrom": "_app_cards_v",
+          "tableTo": "meditations",
+          "columnsFrom": [
+            "version_default_meditation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "_app_cards_v_version_default_image_id_images_id_fk": {
+          "name": "_app_cards_v_version_default_image_id_images_id_fk",
+          "tableFrom": "_app_cards_v",
+          "tableTo": "images",
+          "columnsFrom": [
+            "version_default_image_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "_app_cards_v_version_starting_soon_button_icon_id_images_id_fk": {
+          "name": "_app_cards_v_version_starting_soon_button_icon_id_images_id_fk",
+          "tableFrom": "_app_cards_v",
+          "tableTo": "images",
+          "columnsFrom": [
+            "version_starting_soon_button_icon_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "_app_cards_v_version_starting_soon_page_id_pages_id_fk": {
+          "name": "_app_cards_v_version_starting_soon_page_id_pages_id_fk",
+          "tableFrom": "_app_cards_v",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "version_starting_soon_page_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "_app_cards_v_version_starting_soon_lecture_id_lectures_id_fk": {
+          "name": "_app_cards_v_version_starting_soon_lecture_id_lectures_id_fk",
+          "tableFrom": "_app_cards_v",
+          "tableTo": "lectures",
+          "columnsFrom": [
+            "version_starting_soon_lecture_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "_app_cards_v_version_starting_soon_album_id_albums_id_fk": {
+          "name": "_app_cards_v_version_starting_soon_album_id_albums_id_fk",
+          "tableFrom": "_app_cards_v",
+          "tableTo": "albums",
+          "columnsFrom": [
+            "version_starting_soon_album_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "_app_cards_v_version_starting_soon_meditation_id_meditations_id_fk": {
+          "name": "_app_cards_v_version_starting_soon_meditation_id_meditations_id_fk",
+          "tableFrom": "_app_cards_v",
+          "tableTo": "meditations",
+          "columnsFrom": [
+            "version_starting_soon_meditation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "_app_cards_v_version_starting_soon_image_id_images_id_fk": {
+          "name": "_app_cards_v_version_starting_soon_image_id_images_id_fk",
+          "tableFrom": "_app_cards_v",
+          "tableTo": "images",
+          "columnsFrom": [
+            "version_starting_soon_image_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "_app_cards_v_version_live_now_button_icon_id_images_id_fk": {
+          "name": "_app_cards_v_version_live_now_button_icon_id_images_id_fk",
+          "tableFrom": "_app_cards_v",
+          "tableTo": "images",
+          "columnsFrom": [
+            "version_live_now_button_icon_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "_app_cards_v_version_live_now_page_id_pages_id_fk": {
+          "name": "_app_cards_v_version_live_now_page_id_pages_id_fk",
+          "tableFrom": "_app_cards_v",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "version_live_now_page_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "_app_cards_v_version_live_now_lecture_id_lectures_id_fk": {
+          "name": "_app_cards_v_version_live_now_lecture_id_lectures_id_fk",
+          "tableFrom": "_app_cards_v",
+          "tableTo": "lectures",
+          "columnsFrom": [
+            "version_live_now_lecture_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "_app_cards_v_version_live_now_album_id_albums_id_fk": {
+          "name": "_app_cards_v_version_live_now_album_id_albums_id_fk",
+          "tableFrom": "_app_cards_v",
+          "tableTo": "albums",
+          "columnsFrom": [
+            "version_live_now_album_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "_app_cards_v_version_live_now_meditation_id_meditations_id_fk": {
+          "name": "_app_cards_v_version_live_now_meditation_id_meditations_id_fk",
+          "tableFrom": "_app_cards_v",
+          "tableTo": "meditations",
+          "columnsFrom": [
+            "version_live_now_meditation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "_app_cards_v_version_live_now_image_id_images_id_fk": {
+          "name": "_app_cards_v_version_live_now_image_id_images_id_fk",
+          "tableFrom": "_app_cards_v",
+          "tableTo": "images",
+          "columnsFrom": [
+            "version_live_now_image_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public._app_cards_v_locales": {
+      "name": "_app_cards_v_locales",
+      "schema": "",
+      "columns": {
+        "version_default_header": {
+          "name": "version_default_header",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_default_title": {
+          "name": "version_default_title",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_default_subtitle": {
+          "name": "version_default_subtitle",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_default_button_text": {
+          "name": "version_default_button_text",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_default_url": {
+          "name": "version_default_url",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_starting_soon_header": {
+          "name": "version_starting_soon_header",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_starting_soon_title": {
+          "name": "version_starting_soon_title",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_starting_soon_subtitle": {
+          "name": "version_starting_soon_subtitle",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_starting_soon_button_text": {
+          "name": "version_starting_soon_button_text",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_starting_soon_url": {
+          "name": "version_starting_soon_url",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_live_now_header": {
+          "name": "version_live_now_header",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_live_now_title": {
+          "name": "version_live_now_title",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_live_now_subtitle": {
+          "name": "version_live_now_subtitle",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_live_now_button_text": {
+          "name": "version_live_now_button_text",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_live_now_url": {
+          "name": "version_live_now_url",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "_locale": {
+          "name": "_locale",
+          "type": "_locales",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "_app_cards_v_locales_locale_parent_id_unique": {
+          "name": "_app_cards_v_locales_locale_parent_id_unique",
+          "columns": [
+            {
+              "expression": "_locale",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "_app_cards_v_locales_parent_id_fk": {
+          "name": "_app_cards_v_locales_parent_id_fk",
+          "tableFrom": "_app_cards_v_locales",
+          "tableTo": "_app_cards_v",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public._app_cards_v_rels": {
+      "name": "_app_cards_v_rels",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "audiences_id": {
+          "name": "audiences_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "_app_cards_v_rels_order_idx": {
+          "name": "_app_cards_v_rels_order_idx",
+          "columns": [
+            {
+              "expression": "order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_app_cards_v_rels_parent_idx": {
+          "name": "_app_cards_v_rels_parent_idx",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_app_cards_v_rels_path_idx": {
+          "name": "_app_cards_v_rels_path_idx",
+          "columns": [
+            {
+              "expression": "path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_app_cards_v_rels_audiences_id_idx": {
+          "name": "_app_cards_v_rels_audiences_id_idx",
+          "columns": [
+            {
+              "expression": "audiences_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "_app_cards_v_rels_parent_fk": {
+          "name": "_app_cards_v_rels_parent_fk",
+          "tableFrom": "_app_cards_v_rels",
+          "tableTo": "_app_cards_v",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "_app_cards_v_rels_audiences_fk": {
+          "name": "_app_cards_v_rels_audiences_fk",
+          "tableFrom": "_app_cards_v_rels",
+          "tableTo": "audiences",
+          "columnsFrom": [
+            "audiences_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.regions_breadcrumbs": {
+      "name": "regions_breadcrumbs",
+      "schema": "",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "doc_id": {
+          "name": "doc_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url": {
+          "name": "url",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "regions_breadcrumbs_order_idx": {
+          "name": "regions_breadcrumbs_order_idx",
+          "columns": [
+            {
+              "expression": "_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "regions_breadcrumbs_parent_id_idx": {
+          "name": "regions_breadcrumbs_parent_id_idx",
+          "columns": [
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "regions_breadcrumbs_doc_idx": {
+          "name": "regions_breadcrumbs_doc_idx",
+          "columns": [
+            {
+              "expression": "doc_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "regions_breadcrumbs_doc_id_regions_id_fk": {
+          "name": "regions_breadcrumbs_doc_id_regions_id_fk",
+          "tableFrom": "regions_breadcrumbs",
+          "tableTo": "regions",
+          "columnsFrom": [
+            "doc_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "regions_breadcrumbs_parent_id_fk": {
+          "name": "regions_breadcrumbs_parent_id_fk",
+          "tableFrom": "regions_breadcrumbs",
+          "tableTo": "regions",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.regions": {
+      "name": "regions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "level": {
+          "name": "level",
+          "type": "enum_regions_level",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'country'"
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mapbox_id": {
+          "name": "mapbox_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subtitle": {
+          "name": "subtitle",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "radius": {
+          "name": "radius",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "generate_slug": {
+          "name": "generate_slug",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "legacy_id": {
+          "name": "legacy_id",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "legacy_data": {
+          "name": "legacy_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "regions_parent_idx": {
+          "name": "regions_parent_idx",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "regions_mapbox_id_idx": {
+          "name": "regions_mapbox_id_idx",
+          "columns": [
+            {
+              "expression": "mapbox_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "regions_slug_idx": {
+          "name": "regions_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "regions_legacy_id_idx": {
+          "name": "regions_legacy_id_idx",
+          "columns": [
+            {
+              "expression": "legacy_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "regions_updated_at_idx": {
+          "name": "regions_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "regions_created_at_idx": {
+          "name": "regions_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "regions_parent_id_regions_id_fk": {
+          "name": "regions_parent_id_regions_id_fk",
+          "tableFrom": "regions",
+          "tableTo": "regions",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.regions_rels": {
+      "name": "regions_rels",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "managers_id": {
+          "name": "managers_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "regions_rels_order_idx": {
+          "name": "regions_rels_order_idx",
+          "columns": [
+            {
+              "expression": "order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "regions_rels_parent_idx": {
+          "name": "regions_rels_parent_idx",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "regions_rels_path_idx": {
+          "name": "regions_rels_path_idx",
+          "columns": [
+            {
+              "expression": "path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "regions_rels_managers_id_idx": {
+          "name": "regions_rels_managers_id_idx",
+          "columns": [
+            {
+              "expression": "managers_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "regions_rels_parent_fk": {
+          "name": "regions_rels_parent_fk",
+          "tableFrom": "regions_rels",
+          "tableTo": "regions",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "regions_rels_managers_fk": {
+          "name": "regions_rels_managers_fk",
+          "tableFrom": "regions_rels",
+          "tableTo": "managers",
+          "columnsFrom": [
+            "managers_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.events_languages": {
+      "name": "events_languages",
+      "schema": "",
+      "columns": {
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "enum_events_languages",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "events_languages_order_idx": {
+          "name": "events_languages_order_idx",
+          "columns": [
+            {
+              "expression": "order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "events_languages_parent_idx": {
+          "name": "events_languages_parent_idx",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "events_languages_parent_fk": {
+          "name": "events_languages_parent_fk",
+          "tableFrom": "events_languages",
+          "tableTo": "events",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.events_schedule_weekdays": {
+      "name": "events_schedule_weekdays",
+      "schema": "",
+      "columns": {
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "enum_events_schedule_weekdays",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "events_schedule_weekdays_order_idx": {
+          "name": "events_schedule_weekdays_order_idx",
+          "columns": [
+            {
+              "expression": "order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "events_schedule_weekdays_parent_idx": {
+          "name": "events_schedule_weekdays_parent_idx",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "events_schedule_weekdays_parent_fk": {
+          "name": "events_schedule_weekdays_parent_fk",
+          "tableFrom": "events_schedule_weekdays",
+          "tableTo": "events",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.events_schedule_exclusions": {
+      "name": "events_schedule_exclusions",
+      "schema": "",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "events_schedule_exclusions_order_idx": {
+          "name": "events_schedule_exclusions_order_idx",
+          "columns": [
+            {
+              "expression": "_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "events_schedule_exclusions_parent_id_idx": {
+          "name": "events_schedule_exclusions_parent_id_idx",
+          "columns": [
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "events_schedule_exclusions_parent_id_fk": {
+          "name": "events_schedule_exclusions_parent_id_fk",
+          "tableFrom": "events_schedule_exclusions",
+          "tableTo": "events",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.events": {
+      "name": "events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "contact_phone": {
+          "name": "contact_phone",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_name": {
+          "name": "contact_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "inactive": {
+          "name": "inactive",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "schedule_first_date": {
+          "name": "schedule_first_date",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "schedule_firstdate_tz": {
+          "name": "schedule_firstdate_tz",
+          "type": "enum_events_schedule_firstdate_tz",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "schedule_end_time": {
+          "name": "schedule_end_time",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "schedule_recurrence_type": {
+          "name": "schedule_recurrence_type",
+          "type": "enum_events_schedule_recurrence_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "schedule_interval": {
+          "name": "schedule_interval",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 1
+        },
+        "schedule_monthly_mode": {
+          "name": "schedule_monthly_mode",
+          "type": "enum_events_schedule_monthly_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'date'"
+        },
+        "schedule_month_day": {
+          "name": "schedule_month_day",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 1
+        },
+        "schedule_week_number": {
+          "name": "schedule_week_number",
+          "type": "enum_events_schedule_week_number",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'1'"
+        },
+        "schedule_weekday_of_month": {
+          "name": "schedule_weekday_of_month",
+          "type": "enum_events_schedule_weekday_of_month",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'MO'"
+        },
+        "schedule_ending_type": {
+          "name": "schedule_ending_type",
+          "type": "enum_events_schedule_ending_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "schedule_count": {
+          "name": "schedule_count",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 10
+        },
+        "schedule_until_date": {
+          "name": "schedule_until_date",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "region_id": {
+          "name": "region_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "enum_events_event_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'offline'"
+        },
+        "online_url": {
+          "name": "online_url",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address_mapbox_id": {
+          "name": "address_mapbox_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address_street": {
+          "name": "address_street",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address_room": {
+          "name": "address_room",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address_post_code": {
+          "name": "address_post_code",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address_country": {
+          "name": "address_country",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address_region": {
+          "name": "address_region",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address_city": {
+          "name": "address_city",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address_latitude": {
+          "name": "address_latitude",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address_longitude": {
+          "name": "address_longitude",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "registration_mode": {
+          "name": "registration_mode",
+          "type": "enum_events_registration_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'sahaj-atlas'"
+        },
+        "external_registration_url": {
+          "name": "external_registration_url",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "registration_limit": {
+          "name": "registration_limit",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "registration_questions_prior_experience": {
+          "name": "registration_questions_prior_experience",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "registration_questions_referral_source": {
+          "name": "registration_questions_referral_source",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "registration_questions_health_info": {
+          "name": "registration_questions_health_info",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "registration_questions_accessibility": {
+          "name": "registration_questions_accessibility",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "registration_questions_guests": {
+          "name": "registration_questions_guests",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "manager_id": {
+          "name": "manager_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verification_stage": {
+          "name": "verification_stage",
+          "type": "enum_events_verification_stage",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'verified'"
+        },
+        "next_check_at": {
+          "name": "next_check_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notification_log": {
+          "name": "notification_log",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "legacy_id": {
+          "name": "legacy_id",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "legacy_data": {
+          "name": "legacy_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "_status": {
+          "name": "_status",
+          "type": "enum_events_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'draft'"
+        }
+      },
+      "indexes": {
+        "events_region_idx": {
+          "name": "events_region_idx",
+          "columns": [
+            {
+              "expression": "region_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "events_manager_idx": {
+          "name": "events_manager_idx",
+          "columns": [
+            {
+              "expression": "manager_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "events_next_check_at_idx": {
+          "name": "events_next_check_at_idx",
+          "columns": [
+            {
+              "expression": "next_check_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "events_legacy_id_idx": {
+          "name": "events_legacy_id_idx",
+          "columns": [
+            {
+              "expression": "legacy_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "events_updated_at_idx": {
+          "name": "events_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "events_created_at_idx": {
+          "name": "events_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "events_deleted_at_idx": {
+          "name": "events_deleted_at_idx",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "events__status_idx": {
+          "name": "events__status_idx",
+          "columns": [
+            {
+              "expression": "_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "events_region_id_regions_id_fk": {
+          "name": "events_region_id_regions_id_fk",
+          "tableFrom": "events",
+          "tableTo": "regions",
+          "columnsFrom": [
+            "region_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "events_manager_id_managers_id_fk": {
+          "name": "events_manager_id_managers_id_fk",
+          "tableFrom": "events",
+          "tableTo": "managers",
+          "columnsFrom": [
+            "manager_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.events_locales": {
+      "name": "events_locales",
+      "schema": "",
+      "columns": {
+        "title": {
+          "name": "title",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "_locale": {
+          "name": "_locale",
+          "type": "_locales",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "events_locales_locale_parent_id_unique": {
+          "name": "events_locales_locale_parent_id_unique",
+          "columns": [
+            {
+              "expression": "_locale",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "events_locales_parent_id_fk": {
+          "name": "events_locales_parent_id_fk",
+          "tableFrom": "events_locales",
+          "tableTo": "events",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.events_rels": {
+      "name": "events_rels",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "images_id": {
+          "name": "images_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "events_rels_order_idx": {
+          "name": "events_rels_order_idx",
+          "columns": [
+            {
+              "expression": "order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "events_rels_parent_idx": {
+          "name": "events_rels_parent_idx",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "events_rels_path_idx": {
+          "name": "events_rels_path_idx",
+          "columns": [
+            {
+              "expression": "path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "events_rels_images_id_idx": {
+          "name": "events_rels_images_id_idx",
+          "columns": [
+            {
+              "expression": "images_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "events_rels_parent_fk": {
+          "name": "events_rels_parent_fk",
+          "tableFrom": "events_rels",
+          "tableTo": "events",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "events_rels_images_fk": {
+          "name": "events_rels_images_fk",
+          "tableFrom": "events_rels",
+          "tableTo": "images",
+          "columnsFrom": [
+            "images_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public._events_v_version_languages": {
+      "name": "_events_v_version_languages",
+      "schema": "",
+      "columns": {
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "enum__events_v_version_languages",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "_events_v_version_languages_order_idx": {
+          "name": "_events_v_version_languages_order_idx",
+          "columns": [
+            {
+              "expression": "order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_events_v_version_languages_parent_idx": {
+          "name": "_events_v_version_languages_parent_idx",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "_events_v_version_languages_parent_fk": {
+          "name": "_events_v_version_languages_parent_fk",
+          "tableFrom": "_events_v_version_languages",
+          "tableTo": "_events_v",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public._events_v_version_schedule_weekdays": {
+      "name": "_events_v_version_schedule_weekdays",
+      "schema": "",
+      "columns": {
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "enum__events_v_version_schedule_weekdays",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "_events_v_version_schedule_weekdays_order_idx": {
+          "name": "_events_v_version_schedule_weekdays_order_idx",
+          "columns": [
+            {
+              "expression": "order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_events_v_version_schedule_weekdays_parent_idx": {
+          "name": "_events_v_version_schedule_weekdays_parent_idx",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "_events_v_version_schedule_weekdays_parent_fk": {
+          "name": "_events_v_version_schedule_weekdays_parent_fk",
+          "tableFrom": "_events_v_version_schedule_weekdays",
+          "tableTo": "_events_v",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public._events_v_version_schedule_exclusions": {
+      "name": "_events_v_version_schedule_exclusions",
+      "schema": "",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "_uuid": {
+          "name": "_uuid",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "_events_v_version_schedule_exclusions_order_idx": {
+          "name": "_events_v_version_schedule_exclusions_order_idx",
+          "columns": [
+            {
+              "expression": "_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_events_v_version_schedule_exclusions_parent_id_idx": {
+          "name": "_events_v_version_schedule_exclusions_parent_id_idx",
+          "columns": [
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "_events_v_version_schedule_exclusions_parent_id_fk": {
+          "name": "_events_v_version_schedule_exclusions_parent_id_fk",
+          "tableFrom": "_events_v_version_schedule_exclusions",
+          "tableTo": "_events_v",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public._events_v": {
+      "name": "_events_v",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_contact_phone": {
+          "name": "version_contact_phone",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_contact_name": {
+          "name": "version_contact_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_description": {
+          "name": "version_description",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_inactive": {
+          "name": "version_inactive",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "version_schedule_first_date": {
+          "name": "version_schedule_first_date",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_schedule_firstdate_tz": {
+          "name": "version_schedule_firstdate_tz",
+          "type": "enum__events_v_version_schedule_firstdate_tz",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_schedule_end_time": {
+          "name": "version_schedule_end_time",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_schedule_recurrence_type": {
+          "name": "version_schedule_recurrence_type",
+          "type": "enum__events_v_version_schedule_recurrence_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_schedule_interval": {
+          "name": "version_schedule_interval",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 1
+        },
+        "version_schedule_monthly_mode": {
+          "name": "version_schedule_monthly_mode",
+          "type": "enum__events_v_version_schedule_monthly_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'date'"
+        },
+        "version_schedule_month_day": {
+          "name": "version_schedule_month_day",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 1
+        },
+        "version_schedule_week_number": {
+          "name": "version_schedule_week_number",
+          "type": "enum__events_v_version_schedule_week_number",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'1'"
+        },
+        "version_schedule_weekday_of_month": {
+          "name": "version_schedule_weekday_of_month",
+          "type": "enum__events_v_version_schedule_weekday_of_month",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'MO'"
+        },
+        "version_schedule_ending_type": {
+          "name": "version_schedule_ending_type",
+          "type": "enum__events_v_version_schedule_ending_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_schedule_count": {
+          "name": "version_schedule_count",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 10
+        },
+        "version_schedule_until_date": {
+          "name": "version_schedule_until_date",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_region_id": {
+          "name": "version_region_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_event_type": {
+          "name": "version_event_type",
+          "type": "enum__events_v_version_event_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'offline'"
+        },
+        "version_online_url": {
+          "name": "version_online_url",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_address_mapbox_id": {
+          "name": "version_address_mapbox_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_address_street": {
+          "name": "version_address_street",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_address_room": {
+          "name": "version_address_room",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_address_post_code": {
+          "name": "version_address_post_code",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_address_country": {
+          "name": "version_address_country",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_address_region": {
+          "name": "version_address_region",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_address_city": {
+          "name": "version_address_city",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_address_latitude": {
+          "name": "version_address_latitude",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_address_longitude": {
+          "name": "version_address_longitude",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_registration_mode": {
+          "name": "version_registration_mode",
+          "type": "enum__events_v_version_registration_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'sahaj-atlas'"
+        },
+        "version_external_registration_url": {
+          "name": "version_external_registration_url",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_registration_limit": {
+          "name": "version_registration_limit",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_registration_questions_prior_experience": {
+          "name": "version_registration_questions_prior_experience",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_registration_questions_referral_source": {
+          "name": "version_registration_questions_referral_source",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_registration_questions_health_info": {
+          "name": "version_registration_questions_health_info",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_registration_questions_accessibility": {
+          "name": "version_registration_questions_accessibility",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_registration_questions_guests": {
+          "name": "version_registration_questions_guests",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_manager_id": {
+          "name": "version_manager_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_verification_stage": {
+          "name": "version_verification_stage",
+          "type": "enum_events_verification_stage",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'verified'"
+        },
+        "version_next_check_at": {
+          "name": "version_next_check_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_notification_log": {
+          "name": "version_notification_log",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_legacy_id": {
+          "name": "version_legacy_id",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_legacy_data": {
+          "name": "version_legacy_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_updated_at": {
+          "name": "version_updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_created_at": {
+          "name": "version_created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_deleted_at": {
+          "name": "version_deleted_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version__status": {
+          "name": "version__status",
+          "type": "enum__events_v_version_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'draft'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "snapshot": {
+          "name": "snapshot",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_locale": {
+          "name": "published_locale",
+          "type": "enum__events_v_published_locale",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latest": {
+          "name": "latest",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "_events_v_parent_idx": {
+          "name": "_events_v_parent_idx",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_events_v_version_version_region_idx": {
+          "name": "_events_v_version_version_region_idx",
+          "columns": [
+            {
+              "expression": "version_region_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_events_v_version_version_manager_idx": {
+          "name": "_events_v_version_version_manager_idx",
+          "columns": [
+            {
+              "expression": "version_manager_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_events_v_version_version_next_check_at_idx": {
+          "name": "_events_v_version_version_next_check_at_idx",
+          "columns": [
+            {
+              "expression": "version_next_check_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_events_v_version_version_legacy_id_idx": {
+          "name": "_events_v_version_version_legacy_id_idx",
+          "columns": [
+            {
+              "expression": "version_legacy_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_events_v_version_version_updated_at_idx": {
+          "name": "_events_v_version_version_updated_at_idx",
+          "columns": [
+            {
+              "expression": "version_updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_events_v_version_version_created_at_idx": {
+          "name": "_events_v_version_version_created_at_idx",
+          "columns": [
+            {
+              "expression": "version_created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_events_v_version_version_deleted_at_idx": {
+          "name": "_events_v_version_version_deleted_at_idx",
+          "columns": [
+            {
+              "expression": "version_deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_events_v_version_version__status_idx": {
+          "name": "_events_v_version_version__status_idx",
+          "columns": [
+            {
+              "expression": "version__status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_events_v_created_at_idx": {
+          "name": "_events_v_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_events_v_updated_at_idx": {
+          "name": "_events_v_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_events_v_snapshot_idx": {
+          "name": "_events_v_snapshot_idx",
+          "columns": [
+            {
+              "expression": "snapshot",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_events_v_published_locale_idx": {
+          "name": "_events_v_published_locale_idx",
+          "columns": [
+            {
+              "expression": "published_locale",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_events_v_latest_idx": {
+          "name": "_events_v_latest_idx",
+          "columns": [
+            {
+              "expression": "latest",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "_events_v_parent_id_events_id_fk": {
+          "name": "_events_v_parent_id_events_id_fk",
+          "tableFrom": "_events_v",
+          "tableTo": "events",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "_events_v_version_region_id_regions_id_fk": {
+          "name": "_events_v_version_region_id_regions_id_fk",
+          "tableFrom": "_events_v",
+          "tableTo": "regions",
+          "columnsFrom": [
+            "version_region_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "_events_v_version_manager_id_managers_id_fk": {
+          "name": "_events_v_version_manager_id_managers_id_fk",
+          "tableFrom": "_events_v",
+          "tableTo": "managers",
+          "columnsFrom": [
+            "version_manager_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public._events_v_locales": {
+      "name": "_events_v_locales",
+      "schema": "",
+      "columns": {
+        "version_title": {
+          "name": "version_title",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "_locale": {
+          "name": "_locale",
+          "type": "_locales",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "_events_v_locales_locale_parent_id_unique": {
+          "name": "_events_v_locales_locale_parent_id_unique",
+          "columns": [
+            {
+              "expression": "_locale",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "_events_v_locales_parent_id_fk": {
+          "name": "_events_v_locales_parent_id_fk",
+          "tableFrom": "_events_v_locales",
+          "tableTo": "_events_v",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public._events_v_rels": {
+      "name": "_events_v_rels",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "images_id": {
+          "name": "images_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "_events_v_rels_order_idx": {
+          "name": "_events_v_rels_order_idx",
+          "columns": [
+            {
+              "expression": "order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_events_v_rels_parent_idx": {
+          "name": "_events_v_rels_parent_idx",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_events_v_rels_path_idx": {
+          "name": "_events_v_rels_path_idx",
+          "columns": [
+            {
+              "expression": "path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_events_v_rels_images_id_idx": {
+          "name": "_events_v_rels_images_id_idx",
+          "columns": [
+            {
+              "expression": "images_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "_events_v_rels_parent_fk": {
+          "name": "_events_v_rels_parent_fk",
+          "tableFrom": "_events_v_rels",
+          "tableTo": "_events_v",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "_events_v_rels_images_fk": {
+          "name": "_events_v_rels_images_fk",
+          "tableFrom": "_events_v_rels",
+          "tableTo": "images",
+          "columnsFrom": [
+            "images_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.registrations": {
+      "name": "registrations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "starting_at": {
+          "name": "starting_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "startingat_tz": {
+          "name": "startingat_tz",
+          "type": "enum_registrations_startingat_tz",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "questions": {
+          "name": "questions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uuid": {
+          "name": "uuid",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mailing_list_subscribed_at": {
+          "name": "mailing_list_subscribed_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "legacy_id": {
+          "name": "legacy_id",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "legacy_data": {
+          "name": "legacy_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "registrations_event_idx": {
+          "name": "registrations_event_idx",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "registrations_user_idx": {
+          "name": "registrations_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "registrations_uuid_idx": {
+          "name": "registrations_uuid_idx",
+          "columns": [
+            {
+              "expression": "uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "registrations_legacy_id_idx": {
+          "name": "registrations_legacy_id_idx",
+          "columns": [
+            {
+              "expression": "legacy_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "registrations_updated_at_idx": {
+          "name": "registrations_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "registrations_created_at_idx": {
+          "name": "registrations_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "registrations_event_id_events_id_fk": {
+          "name": "registrations_event_id_events_id_fk",
+          "tableFrom": "registrations",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "registrations_user_id_users_id_fk": {
+          "name": "registrations_user_id_users_id_fk",
+          "tableFrom": "registrations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "legacy_id": {
+          "name": "legacy_id",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "legacy_data": {
+          "name": "legacy_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_email_idx": {
+          "name": "users_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_legacy_id_idx": {
+          "name": "users_legacy_id_idx",
+          "columns": [
+            {
+              "expression": "legacy_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_updated_at_idx": {
+          "name": "users_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_created_at_idx": {
+          "name": "users_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.forms_blocks_checkbox": {
+      "name": "forms_blocks_checkbox",
+      "schema": "",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_path": {
+          "name": "_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "width": {
+          "name": "width",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "required": {
+          "name": "required",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_value": {
+          "name": "default_value",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "block_name": {
+          "name": "block_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "forms_blocks_checkbox_order_idx": {
+          "name": "forms_blocks_checkbox_order_idx",
+          "columns": [
+            {
+              "expression": "_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "forms_blocks_checkbox_parent_id_idx": {
+          "name": "forms_blocks_checkbox_parent_id_idx",
+          "columns": [
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "forms_blocks_checkbox_path_idx": {
+          "name": "forms_blocks_checkbox_path_idx",
+          "columns": [
+            {
+              "expression": "_path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "forms_blocks_checkbox_parent_id_fk": {
+          "name": "forms_blocks_checkbox_parent_id_fk",
+          "tableFrom": "forms_blocks_checkbox",
+          "tableTo": "forms",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.forms_blocks_checkbox_locales": {
+      "name": "forms_blocks_checkbox_locales",
+      "schema": "",
+      "columns": {
+        "label": {
+          "name": "label",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "_locale": {
+          "name": "_locale",
+          "type": "_locales",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "forms_blocks_checkbox_locales_locale_parent_id_unique": {
+          "name": "forms_blocks_checkbox_locales_locale_parent_id_unique",
+          "columns": [
+            {
+              "expression": "_locale",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "forms_blocks_checkbox_locales_parent_id_fk": {
+          "name": "forms_blocks_checkbox_locales_parent_id_fk",
+          "tableFrom": "forms_blocks_checkbox_locales",
+          "tableTo": "forms_blocks_checkbox",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.forms_blocks_country": {
+      "name": "forms_blocks_country",
+      "schema": "",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_path": {
+          "name": "_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "width": {
+          "name": "width",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "required": {
+          "name": "required",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "block_name": {
+          "name": "block_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "forms_blocks_country_order_idx": {
+          "name": "forms_blocks_country_order_idx",
+          "columns": [
+            {
+              "expression": "_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "forms_blocks_country_parent_id_idx": {
+          "name": "forms_blocks_country_parent_id_idx",
+          "columns": [
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "forms_blocks_country_path_idx": {
+          "name": "forms_blocks_country_path_idx",
+          "columns": [
+            {
+              "expression": "_path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "forms_blocks_country_parent_id_fk": {
+          "name": "forms_blocks_country_parent_id_fk",
+          "tableFrom": "forms_blocks_country",
+          "tableTo": "forms",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.forms_blocks_country_locales": {
+      "name": "forms_blocks_country_locales",
+      "schema": "",
+      "columns": {
+        "label": {
+          "name": "label",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "_locale": {
+          "name": "_locale",
+          "type": "_locales",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "forms_blocks_country_locales_locale_parent_id_unique": {
+          "name": "forms_blocks_country_locales_locale_parent_id_unique",
+          "columns": [
+            {
+              "expression": "_locale",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "forms_blocks_country_locales_parent_id_fk": {
+          "name": "forms_blocks_country_locales_parent_id_fk",
+          "tableFrom": "forms_blocks_country_locales",
+          "tableTo": "forms_blocks_country",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.forms_blocks_email": {
+      "name": "forms_blocks_email",
+      "schema": "",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_path": {
+          "name": "_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "width": {
+          "name": "width",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "required": {
+          "name": "required",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "block_name": {
+          "name": "block_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "forms_blocks_email_order_idx": {
+          "name": "forms_blocks_email_order_idx",
+          "columns": [
+            {
+              "expression": "_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "forms_blocks_email_parent_id_idx": {
+          "name": "forms_blocks_email_parent_id_idx",
+          "columns": [
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "forms_blocks_email_path_idx": {
+          "name": "forms_blocks_email_path_idx",
+          "columns": [
+            {
+              "expression": "_path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "forms_blocks_email_parent_id_fk": {
+          "name": "forms_blocks_email_parent_id_fk",
+          "tableFrom": "forms_blocks_email",
+          "tableTo": "forms",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.forms_blocks_email_locales": {
+      "name": "forms_blocks_email_locales",
+      "schema": "",
+      "columns": {
+        "label": {
+          "name": "label",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "_locale": {
+          "name": "_locale",
+          "type": "_locales",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "forms_blocks_email_locales_locale_parent_id_unique": {
+          "name": "forms_blocks_email_locales_locale_parent_id_unique",
+          "columns": [
+            {
+              "expression": "_locale",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "forms_blocks_email_locales_parent_id_fk": {
+          "name": "forms_blocks_email_locales_parent_id_fk",
+          "tableFrom": "forms_blocks_email_locales",
+          "tableTo": "forms_blocks_email",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.forms_blocks_message": {
+      "name": "forms_blocks_message",
+      "schema": "",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_path": {
+          "name": "_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "block_name": {
+          "name": "block_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "forms_blocks_message_order_idx": {
+          "name": "forms_blocks_message_order_idx",
+          "columns": [
+            {
+              "expression": "_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "forms_blocks_message_parent_id_idx": {
+          "name": "forms_blocks_message_parent_id_idx",
+          "columns": [
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "forms_blocks_message_path_idx": {
+          "name": "forms_blocks_message_path_idx",
+          "columns": [
+            {
+              "expression": "_path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "forms_blocks_message_parent_id_fk": {
+          "name": "forms_blocks_message_parent_id_fk",
+          "tableFrom": "forms_blocks_message",
+          "tableTo": "forms",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.forms_blocks_message_locales": {
+      "name": "forms_blocks_message_locales",
+      "schema": "",
+      "columns": {
+        "message": {
+          "name": "message",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "_locale": {
+          "name": "_locale",
+          "type": "_locales",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "forms_blocks_message_locales_locale_parent_id_unique": {
+          "name": "forms_blocks_message_locales_locale_parent_id_unique",
+          "columns": [
+            {
+              "expression": "_locale",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "forms_blocks_message_locales_parent_id_fk": {
+          "name": "forms_blocks_message_locales_parent_id_fk",
+          "tableFrom": "forms_blocks_message_locales",
+          "tableTo": "forms_blocks_message",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.forms_blocks_number": {
+      "name": "forms_blocks_number",
+      "schema": "",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_path": {
+          "name": "_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "width": {
+          "name": "width",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_value": {
+          "name": "default_value",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "required": {
+          "name": "required",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "block_name": {
+          "name": "block_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "forms_blocks_number_order_idx": {
+          "name": "forms_blocks_number_order_idx",
+          "columns": [
+            {
+              "expression": "_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "forms_blocks_number_parent_id_idx": {
+          "name": "forms_blocks_number_parent_id_idx",
+          "columns": [
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "forms_blocks_number_path_idx": {
+          "name": "forms_blocks_number_path_idx",
+          "columns": [
+            {
+              "expression": "_path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "forms_blocks_number_parent_id_fk": {
+          "name": "forms_blocks_number_parent_id_fk",
+          "tableFrom": "forms_blocks_number",
+          "tableTo": "forms",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.forms_blocks_number_locales": {
+      "name": "forms_blocks_number_locales",
+      "schema": "",
+      "columns": {
+        "label": {
+          "name": "label",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "_locale": {
+          "name": "_locale",
+          "type": "_locales",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "forms_blocks_number_locales_locale_parent_id_unique": {
+          "name": "forms_blocks_number_locales_locale_parent_id_unique",
+          "columns": [
+            {
+              "expression": "_locale",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "forms_blocks_number_locales_parent_id_fk": {
+          "name": "forms_blocks_number_locales_parent_id_fk",
+          "tableFrom": "forms_blocks_number_locales",
+          "tableTo": "forms_blocks_number",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.forms_blocks_select_options": {
+      "name": "forms_blocks_select_options",
+      "schema": "",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "forms_blocks_select_options_order_idx": {
+          "name": "forms_blocks_select_options_order_idx",
+          "columns": [
+            {
+              "expression": "_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "forms_blocks_select_options_parent_id_idx": {
+          "name": "forms_blocks_select_options_parent_id_idx",
+          "columns": [
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "forms_blocks_select_options_parent_id_fk": {
+          "name": "forms_blocks_select_options_parent_id_fk",
+          "tableFrom": "forms_blocks_select_options",
+          "tableTo": "forms_blocks_select",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.forms_blocks_select_options_locales": {
+      "name": "forms_blocks_select_options_locales",
+      "schema": "",
+      "columns": {
+        "label": {
+          "name": "label",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "_locale": {
+          "name": "_locale",
+          "type": "_locales",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "forms_blocks_select_options_locales_locale_parent_id_unique": {
+          "name": "forms_blocks_select_options_locales_locale_parent_id_unique",
+          "columns": [
+            {
+              "expression": "_locale",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "forms_blocks_select_options_locales_parent_id_fk": {
+          "name": "forms_blocks_select_options_locales_parent_id_fk",
+          "tableFrom": "forms_blocks_select_options_locales",
+          "tableTo": "forms_blocks_select_options",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.forms_blocks_select": {
+      "name": "forms_blocks_select",
+      "schema": "",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_path": {
+          "name": "_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "width": {
+          "name": "width",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "placeholder": {
+          "name": "placeholder",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "required": {
+          "name": "required",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "block_name": {
+          "name": "block_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "forms_blocks_select_order_idx": {
+          "name": "forms_blocks_select_order_idx",
+          "columns": [
+            {
+              "expression": "_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "forms_blocks_select_parent_id_idx": {
+          "name": "forms_blocks_select_parent_id_idx",
+          "columns": [
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "forms_blocks_select_path_idx": {
+          "name": "forms_blocks_select_path_idx",
+          "columns": [
+            {
+              "expression": "_path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "forms_blocks_select_parent_id_fk": {
+          "name": "forms_blocks_select_parent_id_fk",
+          "tableFrom": "forms_blocks_select",
+          "tableTo": "forms",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.forms_blocks_select_locales": {
+      "name": "forms_blocks_select_locales",
+      "schema": "",
+      "columns": {
+        "label": {
+          "name": "label",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_value": {
+          "name": "default_value",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "_locale": {
+          "name": "_locale",
+          "type": "_locales",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "forms_blocks_select_locales_locale_parent_id_unique": {
+          "name": "forms_blocks_select_locales_locale_parent_id_unique",
+          "columns": [
+            {
+              "expression": "_locale",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "forms_blocks_select_locales_parent_id_fk": {
+          "name": "forms_blocks_select_locales_parent_id_fk",
+          "tableFrom": "forms_blocks_select_locales",
+          "tableTo": "forms_blocks_select",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.forms_blocks_state": {
+      "name": "forms_blocks_state",
+      "schema": "",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_path": {
+          "name": "_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "width": {
+          "name": "width",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "required": {
+          "name": "required",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "block_name": {
+          "name": "block_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "forms_blocks_state_order_idx": {
+          "name": "forms_blocks_state_order_idx",
+          "columns": [
+            {
+              "expression": "_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "forms_blocks_state_parent_id_idx": {
+          "name": "forms_blocks_state_parent_id_idx",
+          "columns": [
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "forms_blocks_state_path_idx": {
+          "name": "forms_blocks_state_path_idx",
+          "columns": [
+            {
+              "expression": "_path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "forms_blocks_state_parent_id_fk": {
+          "name": "forms_blocks_state_parent_id_fk",
+          "tableFrom": "forms_blocks_state",
+          "tableTo": "forms",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.forms_blocks_state_locales": {
+      "name": "forms_blocks_state_locales",
+      "schema": "",
+      "columns": {
+        "label": {
+          "name": "label",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "_locale": {
+          "name": "_locale",
+          "type": "_locales",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "forms_blocks_state_locales_locale_parent_id_unique": {
+          "name": "forms_blocks_state_locales_locale_parent_id_unique",
+          "columns": [
+            {
+              "expression": "_locale",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "forms_blocks_state_locales_parent_id_fk": {
+          "name": "forms_blocks_state_locales_parent_id_fk",
+          "tableFrom": "forms_blocks_state_locales",
+          "tableTo": "forms_blocks_state",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.forms_blocks_text": {
+      "name": "forms_blocks_text",
+      "schema": "",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_path": {
+          "name": "_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "width": {
+          "name": "width",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "required": {
+          "name": "required",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "block_name": {
+          "name": "block_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "forms_blocks_text_order_idx": {
+          "name": "forms_blocks_text_order_idx",
+          "columns": [
+            {
+              "expression": "_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "forms_blocks_text_parent_id_idx": {
+          "name": "forms_blocks_text_parent_id_idx",
+          "columns": [
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "forms_blocks_text_path_idx": {
+          "name": "forms_blocks_text_path_idx",
+          "columns": [
+            {
+              "expression": "_path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "forms_blocks_text_parent_id_fk": {
+          "name": "forms_blocks_text_parent_id_fk",
+          "tableFrom": "forms_blocks_text",
+          "tableTo": "forms",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.forms_blocks_text_locales": {
+      "name": "forms_blocks_text_locales",
+      "schema": "",
+      "columns": {
+        "label": {
+          "name": "label",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_value": {
+          "name": "default_value",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "_locale": {
+          "name": "_locale",
+          "type": "_locales",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "forms_blocks_text_locales_locale_parent_id_unique": {
+          "name": "forms_blocks_text_locales_locale_parent_id_unique",
+          "columns": [
+            {
+              "expression": "_locale",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "forms_blocks_text_locales_parent_id_fk": {
+          "name": "forms_blocks_text_locales_parent_id_fk",
+          "tableFrom": "forms_blocks_text_locales",
+          "tableTo": "forms_blocks_text",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.forms_blocks_textarea": {
+      "name": "forms_blocks_textarea",
+      "schema": "",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_path": {
+          "name": "_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "width": {
+          "name": "width",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "required": {
+          "name": "required",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "block_name": {
+          "name": "block_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "forms_blocks_textarea_order_idx": {
+          "name": "forms_blocks_textarea_order_idx",
+          "columns": [
+            {
+              "expression": "_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "forms_blocks_textarea_parent_id_idx": {
+          "name": "forms_blocks_textarea_parent_id_idx",
+          "columns": [
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "forms_blocks_textarea_path_idx": {
+          "name": "forms_blocks_textarea_path_idx",
+          "columns": [
+            {
+              "expression": "_path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "forms_blocks_textarea_parent_id_fk": {
+          "name": "forms_blocks_textarea_parent_id_fk",
+          "tableFrom": "forms_blocks_textarea",
+          "tableTo": "forms",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.forms_blocks_textarea_locales": {
+      "name": "forms_blocks_textarea_locales",
+      "schema": "",
+      "columns": {
+        "label": {
+          "name": "label",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_value": {
+          "name": "default_value",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "_locale": {
+          "name": "_locale",
+          "type": "_locales",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "forms_blocks_textarea_locales_locale_parent_id_unique": {
+          "name": "forms_blocks_textarea_locales_locale_parent_id_unique",
+          "columns": [
+            {
+              "expression": "_locale",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "forms_blocks_textarea_locales_parent_id_fk": {
+          "name": "forms_blocks_textarea_locales_parent_id_fk",
+          "tableFrom": "forms_blocks_textarea_locales",
+          "tableTo": "forms_blocks_textarea",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.forms_emails": {
+      "name": "forms_emails",
+      "schema": "",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email_to": {
+          "name": "email_to",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cc": {
+          "name": "cc",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bcc": {
+          "name": "bcc",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reply_to": {
+          "name": "reply_to",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_from": {
+          "name": "email_from",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "forms_emails_order_idx": {
+          "name": "forms_emails_order_idx",
+          "columns": [
+            {
+              "expression": "_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "forms_emails_parent_id_idx": {
+          "name": "forms_emails_parent_id_idx",
+          "columns": [
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "forms_emails_parent_id_fk": {
+          "name": "forms_emails_parent_id_fk",
+          "tableFrom": "forms_emails",
+          "tableTo": "forms",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.forms_emails_locales": {
+      "name": "forms_emails_locales",
+      "schema": "",
+      "columns": {
+        "subject": {
+          "name": "subject",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'You''ve received a new message.'"
+        },
+        "message": {
+          "name": "message",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "_locale": {
+          "name": "_locale",
+          "type": "_locales",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "forms_emails_locales_locale_parent_id_unique": {
+          "name": "forms_emails_locales_locale_parent_id_unique",
+          "columns": [
+            {
+              "expression": "_locale",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "forms_emails_locales_parent_id_fk": {
+          "name": "forms_emails_locales_parent_id_fk",
+          "tableFrom": "forms_emails_locales",
+          "tableTo": "forms_emails",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.forms": {
+      "name": "forms",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confirmation_type": {
+          "name": "confirmation_type",
+          "type": "enum_forms_confirmation_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'message'"
+        },
+        "redirect_url": {
+          "name": "redirect_url",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "forms_updated_at_idx": {
+          "name": "forms_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "forms_created_at_idx": {
+          "name": "forms_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.forms_locales": {
+      "name": "forms_locales",
+      "schema": "",
+      "columns": {
+        "submit_button_label": {
+          "name": "submit_button_label",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confirmation_message": {
+          "name": "confirmation_message",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "_locale": {
+          "name": "_locale",
+          "type": "_locales",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "forms_locales_locale_parent_id_unique": {
+          "name": "forms_locales_locale_parent_id_unique",
+          "columns": [
+            {
+              "expression": "_locale",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "forms_locales_parent_id_fk": {
+          "name": "forms_locales_parent_id_fk",
+          "tableFrom": "forms_locales",
+          "tableTo": "forms",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.form_submissions_submission_data": {
+      "name": "form_submissions_submission_data",
+      "schema": "",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "field": {
+          "name": "field",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "form_submissions_submission_data_order_idx": {
+          "name": "form_submissions_submission_data_order_idx",
+          "columns": [
+            {
+              "expression": "_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "form_submissions_submission_data_parent_id_idx": {
+          "name": "form_submissions_submission_data_parent_id_idx",
+          "columns": [
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "form_submissions_submission_data_parent_id_fk": {
+          "name": "form_submissions_submission_data_parent_id_fk",
+          "tableFrom": "form_submissions_submission_data",
+          "tableTo": "form_submissions",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.form_submissions": {
+      "name": "form_submissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "form_id": {
+          "name": "form_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "form_submissions_form_idx": {
+          "name": "form_submissions_form_idx",
+          "columns": [
+            {
+              "expression": "form_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "form_submissions_updated_at_idx": {
+          "name": "form_submissions_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "form_submissions_created_at_idx": {
+          "name": "form_submissions_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "form_submissions_form_id_forms_id_fk": {
+          "name": "form_submissions_form_id_forms_id_fk",
+          "tableFrom": "form_submissions",
+          "tableTo": "forms",
+          "columnsFrom": [
+            "form_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payload_kv": {
+      "name": "payload_kv",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "payload_kv_key_idx": {
+          "name": "payload_kv_key_idx",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payload_jobs_log": {
+      "name": "payload_jobs_log",
+      "schema": "",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "executed_at": {
+          "name": "executed_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "task_slug": {
+          "name": "task_slug",
+          "type": "enum_payload_jobs_log_task_slug",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "task_i_d": {
+          "name": "task_i_d",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input": {
+          "name": "input",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output": {
+          "name": "output",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "enum_payload_jobs_log_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error": {
+          "name": "error",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "payload_jobs_log_order_idx": {
+          "name": "payload_jobs_log_order_idx",
+          "columns": [
+            {
+              "expression": "_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_jobs_log_parent_id_idx": {
+          "name": "payload_jobs_log_parent_id_idx",
+          "columns": [
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "payload_jobs_log_parent_id_fk": {
+          "name": "payload_jobs_log_parent_id_fk",
+          "tableFrom": "payload_jobs_log",
+          "tableTo": "payload_jobs",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payload_jobs": {
+      "name": "payload_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "input": {
+          "name": "input",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_tried": {
+          "name": "total_tried",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "has_error": {
+          "name": "has_error",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "error": {
+          "name": "error",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "task_slug": {
+          "name": "task_slug",
+          "type": "enum_payload_jobs_task_slug",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "queue": {
+          "name": "queue",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'default'"
+        },
+        "wait_until": {
+          "name": "wait_until",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processing": {
+          "name": "processing",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "payload_jobs_completed_at_idx": {
+          "name": "payload_jobs_completed_at_idx",
+          "columns": [
+            {
+              "expression": "completed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_jobs_total_tried_idx": {
+          "name": "payload_jobs_total_tried_idx",
+          "columns": [
+            {
+              "expression": "total_tried",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_jobs_has_error_idx": {
+          "name": "payload_jobs_has_error_idx",
+          "columns": [
+            {
+              "expression": "has_error",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_jobs_task_slug_idx": {
+          "name": "payload_jobs_task_slug_idx",
+          "columns": [
+            {
+              "expression": "task_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_jobs_queue_idx": {
+          "name": "payload_jobs_queue_idx",
+          "columns": [
+            {
+              "expression": "queue",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_jobs_wait_until_idx": {
+          "name": "payload_jobs_wait_until_idx",
+          "columns": [
+            {
+              "expression": "wait_until",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_jobs_processing_idx": {
+          "name": "payload_jobs_processing_idx",
+          "columns": [
+            {
+              "expression": "processing",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_jobs_updated_at_idx": {
+          "name": "payload_jobs_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_jobs_created_at_idx": {
+          "name": "payload_jobs_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payload_locked_documents": {
+      "name": "payload_locked_documents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "global_slug": {
+          "name": "global_slug",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "payload_locked_documents_global_slug_idx": {
+          "name": "payload_locked_documents_global_slug_idx",
+          "columns": [
+            {
+              "expression": "global_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_updated_at_idx": {
+          "name": "payload_locked_documents_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_created_at_idx": {
+          "name": "payload_locked_documents_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payload_locked_documents_rels": {
+      "name": "payload_locked_documents_rels",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pages_id": {
+          "name": "pages_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meditations_id": {
+          "name": "meditations_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "songs_id": {
+          "name": "songs_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "albums_id": {
+          "name": "albums_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "videos_id": {
+          "name": "videos_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lessons_id": {
+          "name": "lessons_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lectures_id": {
+          "name": "lectures_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "frames_id": {
+          "name": "frames_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "narrators_id": {
+          "name": "narrators_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "authors_id": {
+          "name": "authors_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "images_id": {
+          "name": "images_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "files_id": {
+          "name": "files_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "audiences_id": {
+          "name": "audiences_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_choices_id": {
+          "name": "user_choices_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subtle_system_nodes_id": {
+          "name": "subtle_system_nodes_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "song_tags_id": {
+          "name": "song_tags_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "managers_id": {
+          "name": "managers_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "clients_id": {
+          "name": "clients_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "app_cards_id": {
+          "name": "app_cards_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "regions_id": {
+          "name": "regions_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "events_id": {
+          "name": "events_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "registrations_id": {
+          "name": "registrations_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "users_id": {
+          "name": "users_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "forms_id": {
+          "name": "forms_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "form_submissions_id": {
+          "name": "form_submissions_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "payload_locked_documents_rels_order_idx": {
+          "name": "payload_locked_documents_rels_order_idx",
+          "columns": [
+            {
+              "expression": "order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_parent_idx": {
+          "name": "payload_locked_documents_rels_parent_idx",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_path_idx": {
+          "name": "payload_locked_documents_rels_path_idx",
+          "columns": [
+            {
+              "expression": "path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_pages_id_idx": {
+          "name": "payload_locked_documents_rels_pages_id_idx",
+          "columns": [
+            {
+              "expression": "pages_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_meditations_id_idx": {
+          "name": "payload_locked_documents_rels_meditations_id_idx",
+          "columns": [
+            {
+              "expression": "meditations_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_songs_id_idx": {
+          "name": "payload_locked_documents_rels_songs_id_idx",
+          "columns": [
+            {
+              "expression": "songs_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_albums_id_idx": {
+          "name": "payload_locked_documents_rels_albums_id_idx",
+          "columns": [
+            {
+              "expression": "albums_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_videos_id_idx": {
+          "name": "payload_locked_documents_rels_videos_id_idx",
+          "columns": [
+            {
+              "expression": "videos_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_lessons_id_idx": {
+          "name": "payload_locked_documents_rels_lessons_id_idx",
+          "columns": [
+            {
+              "expression": "lessons_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_lectures_id_idx": {
+          "name": "payload_locked_documents_rels_lectures_id_idx",
+          "columns": [
+            {
+              "expression": "lectures_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_frames_id_idx": {
+          "name": "payload_locked_documents_rels_frames_id_idx",
+          "columns": [
+            {
+              "expression": "frames_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_narrators_id_idx": {
+          "name": "payload_locked_documents_rels_narrators_id_idx",
+          "columns": [
+            {
+              "expression": "narrators_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_authors_id_idx": {
+          "name": "payload_locked_documents_rels_authors_id_idx",
+          "columns": [
+            {
+              "expression": "authors_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_images_id_idx": {
+          "name": "payload_locked_documents_rels_images_id_idx",
+          "columns": [
+            {
+              "expression": "images_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_files_id_idx": {
+          "name": "payload_locked_documents_rels_files_id_idx",
+          "columns": [
+            {
+              "expression": "files_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_audiences_id_idx": {
+          "name": "payload_locked_documents_rels_audiences_id_idx",
+          "columns": [
+            {
+              "expression": "audiences_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_user_choices_id_idx": {
+          "name": "payload_locked_documents_rels_user_choices_id_idx",
+          "columns": [
+            {
+              "expression": "user_choices_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_subtle_system_nodes_id_idx": {
+          "name": "payload_locked_documents_rels_subtle_system_nodes_id_idx",
+          "columns": [
+            {
+              "expression": "subtle_system_nodes_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_song_tags_id_idx": {
+          "name": "payload_locked_documents_rels_song_tags_id_idx",
+          "columns": [
+            {
+              "expression": "song_tags_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_managers_id_idx": {
+          "name": "payload_locked_documents_rels_managers_id_idx",
+          "columns": [
+            {
+              "expression": "managers_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_clients_id_idx": {
+          "name": "payload_locked_documents_rels_clients_id_idx",
+          "columns": [
+            {
+              "expression": "clients_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_app_cards_id_idx": {
+          "name": "payload_locked_documents_rels_app_cards_id_idx",
+          "columns": [
+            {
+              "expression": "app_cards_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_regions_id_idx": {
+          "name": "payload_locked_documents_rels_regions_id_idx",
+          "columns": [
+            {
+              "expression": "regions_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_events_id_idx": {
+          "name": "payload_locked_documents_rels_events_id_idx",
+          "columns": [
+            {
+              "expression": "events_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_registrations_id_idx": {
+          "name": "payload_locked_documents_rels_registrations_id_idx",
+          "columns": [
+            {
+              "expression": "registrations_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_users_id_idx": {
+          "name": "payload_locked_documents_rels_users_id_idx",
+          "columns": [
+            {
+              "expression": "users_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_forms_id_idx": {
+          "name": "payload_locked_documents_rels_forms_id_idx",
+          "columns": [
+            {
+              "expression": "forms_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_locked_documents_rels_form_submissions_id_idx": {
+          "name": "payload_locked_documents_rels_form_submissions_id_idx",
+          "columns": [
+            {
+              "expression": "form_submissions_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "payload_locked_documents_rels_parent_fk": {
+          "name": "payload_locked_documents_rels_parent_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "payload_locked_documents",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_pages_fk": {
+          "name": "payload_locked_documents_rels_pages_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "pages_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_meditations_fk": {
+          "name": "payload_locked_documents_rels_meditations_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "meditations",
+          "columnsFrom": [
+            "meditations_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_songs_fk": {
+          "name": "payload_locked_documents_rels_songs_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "songs",
+          "columnsFrom": [
+            "songs_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_albums_fk": {
+          "name": "payload_locked_documents_rels_albums_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "albums",
+          "columnsFrom": [
+            "albums_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_videos_fk": {
+          "name": "payload_locked_documents_rels_videos_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "videos",
+          "columnsFrom": [
+            "videos_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_lessons_fk": {
+          "name": "payload_locked_documents_rels_lessons_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "lessons",
+          "columnsFrom": [
+            "lessons_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_lectures_fk": {
+          "name": "payload_locked_documents_rels_lectures_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "lectures",
+          "columnsFrom": [
+            "lectures_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_frames_fk": {
+          "name": "payload_locked_documents_rels_frames_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "frames",
+          "columnsFrom": [
+            "frames_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_narrators_fk": {
+          "name": "payload_locked_documents_rels_narrators_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "narrators",
+          "columnsFrom": [
+            "narrators_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_authors_fk": {
+          "name": "payload_locked_documents_rels_authors_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "authors",
+          "columnsFrom": [
+            "authors_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_images_fk": {
+          "name": "payload_locked_documents_rels_images_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "images",
+          "columnsFrom": [
+            "images_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_files_fk": {
+          "name": "payload_locked_documents_rels_files_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "files",
+          "columnsFrom": [
+            "files_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_audiences_fk": {
+          "name": "payload_locked_documents_rels_audiences_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "audiences",
+          "columnsFrom": [
+            "audiences_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_user_choices_fk": {
+          "name": "payload_locked_documents_rels_user_choices_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "user_choices",
+          "columnsFrom": [
+            "user_choices_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_subtle_system_nodes_fk": {
+          "name": "payload_locked_documents_rels_subtle_system_nodes_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "subtle_system_nodes",
+          "columnsFrom": [
+            "subtle_system_nodes_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_song_tags_fk": {
+          "name": "payload_locked_documents_rels_song_tags_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "song_tags",
+          "columnsFrom": [
+            "song_tags_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_managers_fk": {
+          "name": "payload_locked_documents_rels_managers_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "managers",
+          "columnsFrom": [
+            "managers_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_clients_fk": {
+          "name": "payload_locked_documents_rels_clients_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "clients_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_app_cards_fk": {
+          "name": "payload_locked_documents_rels_app_cards_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "app_cards",
+          "columnsFrom": [
+            "app_cards_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_regions_fk": {
+          "name": "payload_locked_documents_rels_regions_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "regions",
+          "columnsFrom": [
+            "regions_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_events_fk": {
+          "name": "payload_locked_documents_rels_events_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "events",
+          "columnsFrom": [
+            "events_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_registrations_fk": {
+          "name": "payload_locked_documents_rels_registrations_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "registrations",
+          "columnsFrom": [
+            "registrations_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_users_fk": {
+          "name": "payload_locked_documents_rels_users_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "users",
+          "columnsFrom": [
+            "users_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_forms_fk": {
+          "name": "payload_locked_documents_rels_forms_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "forms",
+          "columnsFrom": [
+            "forms_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_locked_documents_rels_form_submissions_fk": {
+          "name": "payload_locked_documents_rels_form_submissions_fk",
+          "tableFrom": "payload_locked_documents_rels",
+          "tableTo": "form_submissions",
+          "columnsFrom": [
+            "form_submissions_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payload_preferences": {
+      "name": "payload_preferences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "value": {
+          "name": "value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "payload_preferences_key_idx": {
+          "name": "payload_preferences_key_idx",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_preferences_updated_at_idx": {
+          "name": "payload_preferences_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_preferences_created_at_idx": {
+          "name": "payload_preferences_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payload_preferences_rels": {
+      "name": "payload_preferences_rels",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "managers_id": {
+          "name": "managers_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "clients_id": {
+          "name": "clients_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "payload_preferences_rels_order_idx": {
+          "name": "payload_preferences_rels_order_idx",
+          "columns": [
+            {
+              "expression": "order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_preferences_rels_parent_idx": {
+          "name": "payload_preferences_rels_parent_idx",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_preferences_rels_path_idx": {
+          "name": "payload_preferences_rels_path_idx",
+          "columns": [
+            {
+              "expression": "path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_preferences_rels_managers_id_idx": {
+          "name": "payload_preferences_rels_managers_id_idx",
+          "columns": [
+            {
+              "expression": "managers_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_preferences_rels_clients_id_idx": {
+          "name": "payload_preferences_rels_clients_id_idx",
+          "columns": [
+            {
+              "expression": "clients_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "payload_preferences_rels_parent_fk": {
+          "name": "payload_preferences_rels_parent_fk",
+          "tableFrom": "payload_preferences_rels",
+          "tableTo": "payload_preferences",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_preferences_rels_managers_fk": {
+          "name": "payload_preferences_rels_managers_fk",
+          "tableFrom": "payload_preferences_rels",
+          "tableTo": "managers",
+          "columnsFrom": [
+            "managers_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_preferences_rels_clients_fk": {
+          "name": "payload_preferences_rels_clients_fk",
+          "tableFrom": "payload_preferences_rels",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "clients_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payload_migrations": {
+      "name": "payload_migrations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "batch": {
+          "name": "batch",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "payload_migrations_updated_at_idx": {
+          "name": "payload_migrations_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payload_migrations_created_at_idx": {
+          "name": "payload_migrations_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wm_web_config": {
+      "name": "wm_web_config",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "home_page_id": {
+          "name": "home_page_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "wm_web_config_home_page_idx": {
+          "name": "wm_web_config_home_page_idx",
+          "columns": [
+            {
+              "expression": "home_page_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "wm_web_config_home_page_id_pages_id_fk": {
+          "name": "wm_web_config_home_page_id_pages_id_fk",
+          "tableFrom": "wm_web_config",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "home_page_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wm_web_config_rels": {
+      "name": "wm_web_config_rels",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "audiences_id": {
+          "name": "audiences_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pages_id": {
+          "name": "pages_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "wm_web_config_rels_order_idx": {
+          "name": "wm_web_config_rels_order_idx",
+          "columns": [
+            {
+              "expression": "order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wm_web_config_rels_parent_idx": {
+          "name": "wm_web_config_rels_parent_idx",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wm_web_config_rels_path_idx": {
+          "name": "wm_web_config_rels_path_idx",
+          "columns": [
+            {
+              "expression": "path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wm_web_config_rels_audiences_id_idx": {
+          "name": "wm_web_config_rels_audiences_id_idx",
+          "columns": [
+            {
+              "expression": "audiences_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wm_web_config_rels_pages_id_idx": {
+          "name": "wm_web_config_rels_pages_id_idx",
+          "columns": [
+            {
+              "expression": "pages_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "wm_web_config_rels_parent_fk": {
+          "name": "wm_web_config_rels_parent_fk",
+          "tableFrom": "wm_web_config_rels",
+          "tableTo": "wm_web_config",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "wm_web_config_rels_audiences_fk": {
+          "name": "wm_web_config_rels_audiences_fk",
+          "tableFrom": "wm_web_config_rels",
+          "tableTo": "audiences",
+          "columnsFrom": [
+            "audiences_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "wm_web_config_rels_pages_fk": {
+          "name": "wm_web_config_rels_pages_fk",
+          "tableFrom": "wm_web_config_rels",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "pages_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wm_web_translations": {
+      "name": "wm_web_translations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "_status": {
+          "name": "_status",
+          "type": "enum_wm_web_translations_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'draft'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "wm_web_translations__status_idx": {
+          "name": "wm_web_translations__status_idx",
+          "columns": [
+            {
+              "expression": "_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wm_web_translations_locales": {
+      "name": "wm_web_translations_locales",
+      "schema": "",
+      "columns": {
+        "common": {
+          "name": "common",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "navigation": {
+          "name": "navigation",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "footer": {
+          "name": "footer",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "page_tags": {
+          "name": "page_tags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "errors": {
+          "name": "errors",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "_locale": {
+          "name": "_locale",
+          "type": "_locales",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "wm_web_translations_locales_locale_parent_id_unique": {
+          "name": "wm_web_translations_locales_locale_parent_id_unique",
+          "columns": [
+            {
+              "expression": "_locale",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "wm_web_translations_locales_parent_id_fk": {
+          "name": "wm_web_translations_locales_parent_id_fk",
+          "tableFrom": "wm_web_translations_locales",
+          "tableTo": "wm_web_translations",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public._wm_web_translations_v": {
+      "name": "_wm_web_translations_v",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "version__status": {
+          "name": "version__status",
+          "type": "enum__wm_web_translations_v_version_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'draft'"
+        },
+        "version_updated_at": {
+          "name": "version_updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_created_at": {
+          "name": "version_created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "snapshot": {
+          "name": "snapshot",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_locale": {
+          "name": "published_locale",
+          "type": "enum__wm_web_translations_v_published_locale",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latest": {
+          "name": "latest",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "_wm_web_translations_v_version_version__status_idx": {
+          "name": "_wm_web_translations_v_version_version__status_idx",
+          "columns": [
+            {
+              "expression": "version__status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_wm_web_translations_v_created_at_idx": {
+          "name": "_wm_web_translations_v_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_wm_web_translations_v_updated_at_idx": {
+          "name": "_wm_web_translations_v_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_wm_web_translations_v_snapshot_idx": {
+          "name": "_wm_web_translations_v_snapshot_idx",
+          "columns": [
+            {
+              "expression": "snapshot",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_wm_web_translations_v_published_locale_idx": {
+          "name": "_wm_web_translations_v_published_locale_idx",
+          "columns": [
+            {
+              "expression": "published_locale",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_wm_web_translations_v_latest_idx": {
+          "name": "_wm_web_translations_v_latest_idx",
+          "columns": [
+            {
+              "expression": "latest",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public._wm_web_translations_v_locales": {
+      "name": "_wm_web_translations_v_locales",
+      "schema": "",
+      "columns": {
+        "version_common": {
+          "name": "version_common",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_navigation": {
+          "name": "version_navigation",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_footer": {
+          "name": "version_footer",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_page_tags": {
+          "name": "version_page_tags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_errors": {
+          "name": "version_errors",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "_locale": {
+          "name": "_locale",
+          "type": "_locales",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "_wm_web_translations_v_locales_locale_parent_id_unique": {
+          "name": "_wm_web_translations_v_locales_locale_parent_id_unique",
+          "columns": [
+            {
+              "expression": "_locale",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "_wm_web_translations_v_locales_parent_id_fk": {
+          "name": "_wm_web_translations_v_locales_parent_id_fk",
+          "tableFrom": "_wm_web_translations_v_locales",
+          "tableTo": "_wm_web_translations_v",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wm_app_config_vibe_check_tracks": {
+      "name": "wm_app_config_vibe_check_tracks",
+      "schema": "",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_locale": {
+          "name": "_locale",
+          "type": "_locales",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "enum_wm_app_config_vibe_check_tracks_identifier",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "audio_id": {
+          "name": "audio_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subtitles_id": {
+          "name": "subtitles_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "wm_app_config_vibe_check_tracks_order_idx": {
+          "name": "wm_app_config_vibe_check_tracks_order_idx",
+          "columns": [
+            {
+              "expression": "_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wm_app_config_vibe_check_tracks_parent_id_idx": {
+          "name": "wm_app_config_vibe_check_tracks_parent_id_idx",
+          "columns": [
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wm_app_config_vibe_check_tracks_locale_idx": {
+          "name": "wm_app_config_vibe_check_tracks_locale_idx",
+          "columns": [
+            {
+              "expression": "_locale",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wm_app_config_vibe_check_tracks_audio_idx": {
+          "name": "wm_app_config_vibe_check_tracks_audio_idx",
+          "columns": [
+            {
+              "expression": "audio_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wm_app_config_vibe_check_tracks_subtitles_idx": {
+          "name": "wm_app_config_vibe_check_tracks_subtitles_idx",
+          "columns": [
+            {
+              "expression": "subtitles_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "wm_app_config_vibe_check_tracks_audio_id_files_id_fk": {
+          "name": "wm_app_config_vibe_check_tracks_audio_id_files_id_fk",
+          "tableFrom": "wm_app_config_vibe_check_tracks",
+          "tableTo": "files",
+          "columnsFrom": [
+            "audio_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "wm_app_config_vibe_check_tracks_subtitles_id_files_id_fk": {
+          "name": "wm_app_config_vibe_check_tracks_subtitles_id_files_id_fk",
+          "tableFrom": "wm_app_config_vibe_check_tracks",
+          "tableTo": "files",
+          "columnsFrom": [
+            "subtitles_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "wm_app_config_vibe_check_tracks_parent_id_fk": {
+          "name": "wm_app_config_vibe_check_tracks_parent_id_fk",
+          "tableFrom": "wm_app_config_vibe_check_tracks",
+          "tableTo": "wm_app_config",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wm_app_config": {
+      "name": "wm_app_config",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "classes_page_id": {
+          "name": "classes_page_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "live_meditations_page_id": {
+          "name": "live_meditations_page_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "explore_page_id": {
+          "name": "explore_page_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "explore_deeper_page_id": {
+          "name": "explore_deeper_page_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "meditate_together_page_id": {
+          "name": "meditate_together_page_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "techniques_page_id": {
+          "name": "techniques_page_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lectures_page_id": {
+          "name": "lectures_page_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lessons_page_id": {
+          "name": "lessons_page_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "music_page_id": {
+          "name": "music_page_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "shri_mataji_page_id": {
+          "name": "shri_mataji_page_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sahaja_yoga_page_id": {
+          "name": "sahaja_yoga_page_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subtle_system_page_id": {
+          "name": "subtle_system_page_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "privacy_page_id": {
+          "name": "privacy_page_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "terms_page_id": {
+          "name": "terms_page_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fallback_lecture_id": {
+          "name": "fallback_lecture_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ios_app_url": {
+          "name": "ios_app_url",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "android_app_url": {
+          "name": "android_app_url",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "wm_app_config_classes_page_idx": {
+          "name": "wm_app_config_classes_page_idx",
+          "columns": [
+            {
+              "expression": "classes_page_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wm_app_config_live_meditations_page_idx": {
+          "name": "wm_app_config_live_meditations_page_idx",
+          "columns": [
+            {
+              "expression": "live_meditations_page_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wm_app_config_explore_page_idx": {
+          "name": "wm_app_config_explore_page_idx",
+          "columns": [
+            {
+              "expression": "explore_page_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wm_app_config_explore_deeper_page_idx": {
+          "name": "wm_app_config_explore_deeper_page_idx",
+          "columns": [
+            {
+              "expression": "explore_deeper_page_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wm_app_config_meditate_together_page_idx": {
+          "name": "wm_app_config_meditate_together_page_idx",
+          "columns": [
+            {
+              "expression": "meditate_together_page_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wm_app_config_techniques_page_idx": {
+          "name": "wm_app_config_techniques_page_idx",
+          "columns": [
+            {
+              "expression": "techniques_page_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wm_app_config_lectures_page_idx": {
+          "name": "wm_app_config_lectures_page_idx",
+          "columns": [
+            {
+              "expression": "lectures_page_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wm_app_config_lessons_page_idx": {
+          "name": "wm_app_config_lessons_page_idx",
+          "columns": [
+            {
+              "expression": "lessons_page_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wm_app_config_music_page_idx": {
+          "name": "wm_app_config_music_page_idx",
+          "columns": [
+            {
+              "expression": "music_page_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wm_app_config_shri_mataji_page_idx": {
+          "name": "wm_app_config_shri_mataji_page_idx",
+          "columns": [
+            {
+              "expression": "shri_mataji_page_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wm_app_config_sahaja_yoga_page_idx": {
+          "name": "wm_app_config_sahaja_yoga_page_idx",
+          "columns": [
+            {
+              "expression": "sahaja_yoga_page_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wm_app_config_subtle_system_page_idx": {
+          "name": "wm_app_config_subtle_system_page_idx",
+          "columns": [
+            {
+              "expression": "subtle_system_page_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wm_app_config_privacy_page_idx": {
+          "name": "wm_app_config_privacy_page_idx",
+          "columns": [
+            {
+              "expression": "privacy_page_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wm_app_config_terms_page_idx": {
+          "name": "wm_app_config_terms_page_idx",
+          "columns": [
+            {
+              "expression": "terms_page_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wm_app_config_fallback_lecture_idx": {
+          "name": "wm_app_config_fallback_lecture_idx",
+          "columns": [
+            {
+              "expression": "fallback_lecture_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "wm_app_config_classes_page_id_pages_id_fk": {
+          "name": "wm_app_config_classes_page_id_pages_id_fk",
+          "tableFrom": "wm_app_config",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "classes_page_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "wm_app_config_live_meditations_page_id_pages_id_fk": {
+          "name": "wm_app_config_live_meditations_page_id_pages_id_fk",
+          "tableFrom": "wm_app_config",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "live_meditations_page_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "wm_app_config_explore_page_id_pages_id_fk": {
+          "name": "wm_app_config_explore_page_id_pages_id_fk",
+          "tableFrom": "wm_app_config",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "explore_page_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "wm_app_config_explore_deeper_page_id_pages_id_fk": {
+          "name": "wm_app_config_explore_deeper_page_id_pages_id_fk",
+          "tableFrom": "wm_app_config",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "explore_deeper_page_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "wm_app_config_meditate_together_page_id_pages_id_fk": {
+          "name": "wm_app_config_meditate_together_page_id_pages_id_fk",
+          "tableFrom": "wm_app_config",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "meditate_together_page_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "wm_app_config_techniques_page_id_pages_id_fk": {
+          "name": "wm_app_config_techniques_page_id_pages_id_fk",
+          "tableFrom": "wm_app_config",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "techniques_page_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "wm_app_config_lectures_page_id_pages_id_fk": {
+          "name": "wm_app_config_lectures_page_id_pages_id_fk",
+          "tableFrom": "wm_app_config",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "lectures_page_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "wm_app_config_lessons_page_id_pages_id_fk": {
+          "name": "wm_app_config_lessons_page_id_pages_id_fk",
+          "tableFrom": "wm_app_config",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "lessons_page_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "wm_app_config_music_page_id_pages_id_fk": {
+          "name": "wm_app_config_music_page_id_pages_id_fk",
+          "tableFrom": "wm_app_config",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "music_page_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "wm_app_config_shri_mataji_page_id_pages_id_fk": {
+          "name": "wm_app_config_shri_mataji_page_id_pages_id_fk",
+          "tableFrom": "wm_app_config",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "shri_mataji_page_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "wm_app_config_sahaja_yoga_page_id_pages_id_fk": {
+          "name": "wm_app_config_sahaja_yoga_page_id_pages_id_fk",
+          "tableFrom": "wm_app_config",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "sahaja_yoga_page_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "wm_app_config_subtle_system_page_id_pages_id_fk": {
+          "name": "wm_app_config_subtle_system_page_id_pages_id_fk",
+          "tableFrom": "wm_app_config",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "subtle_system_page_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "wm_app_config_privacy_page_id_pages_id_fk": {
+          "name": "wm_app_config_privacy_page_id_pages_id_fk",
+          "tableFrom": "wm_app_config",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "privacy_page_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "wm_app_config_terms_page_id_pages_id_fk": {
+          "name": "wm_app_config_terms_page_id_pages_id_fk",
+          "tableFrom": "wm_app_config",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "terms_page_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "wm_app_config_fallback_lecture_id_lectures_id_fk": {
+          "name": "wm_app_config_fallback_lecture_id_lectures_id_fk",
+          "tableFrom": "wm_app_config",
+          "tableTo": "lectures",
+          "columnsFrom": [
+            "fallback_lecture_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wm_app_config_locales": {
+      "name": "wm_app_config_locales",
+      "schema": "",
+      "columns": {
+        "self_realization_meditation_id": {
+          "name": "self_realization_meditation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "post_realization_lecture_id": {
+          "name": "post_realization_lecture_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "_locale": {
+          "name": "_locale",
+          "type": "_locales",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "wm_app_config_self_realization_meditation_idx": {
+          "name": "wm_app_config_self_realization_meditation_idx",
+          "columns": [
+            {
+              "expression": "self_realization_meditation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "_locale",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wm_app_config_post_realization_lecture_idx": {
+          "name": "wm_app_config_post_realization_lecture_idx",
+          "columns": [
+            {
+              "expression": "post_realization_lecture_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "_locale",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wm_app_config_locales_locale_parent_id_unique": {
+          "name": "wm_app_config_locales_locale_parent_id_unique",
+          "columns": [
+            {
+              "expression": "_locale",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "wm_app_config_locales_self_realization_meditation_id_meditations_id_fk": {
+          "name": "wm_app_config_locales_self_realization_meditation_id_meditations_id_fk",
+          "tableFrom": "wm_app_config_locales",
+          "tableTo": "meditations",
+          "columnsFrom": [
+            "self_realization_meditation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "wm_app_config_locales_post_realization_lecture_id_lectures_id_fk": {
+          "name": "wm_app_config_locales_post_realization_lecture_id_lectures_id_fk",
+          "tableFrom": "wm_app_config_locales",
+          "tableTo": "lectures",
+          "columnsFrom": [
+            "post_realization_lecture_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "wm_app_config_locales_parent_id_fk": {
+          "name": "wm_app_config_locales_parent_id_fk",
+          "tableFrom": "wm_app_config_locales",
+          "tableTo": "wm_app_config",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wm_app_translations": {
+      "name": "wm_app_translations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "_status": {
+          "name": "_status",
+          "type": "enum_wm_app_translations_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'draft'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "wm_app_translations__status_idx": {
+          "name": "wm_app_translations__status_idx",
+          "columns": [
+            {
+              "expression": "_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wm_app_translations_locales": {
+      "name": "wm_app_translations_locales",
+      "schema": "",
+      "columns": {
+        "onboarding_welcome": {
+          "name": "onboarding_welcome",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboarding_welcome_legal_disclaimer": {
+          "name": "onboarding_welcome_legal_disclaimer",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboarding_name": {
+          "name": "onboarding_name",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboarding_greeting": {
+          "name": "onboarding_greeting",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboarding_user_type": {
+          "name": "onboarding_user_type",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboarding_user_type_title": {
+          "name": "onboarding_user_type_title",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboarding_carousel": {
+          "name": "onboarding_carousel",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboarding_carousel_page_true_self_title": {
+          "name": "onboarding_carousel_page_true_self_title",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboarding_consent_modal": {
+          "name": "onboarding_consent_modal",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboarding_consent_modal_body_never_share": {
+          "name": "onboarding_consent_modal_body_never_share",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboarding_consent_modal_body_never_sell": {
+          "name": "onboarding_consent_modal_body_never_sell",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboarding_consent_modal_body_intro": {
+          "name": "onboarding_consent_modal_body_intro",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "daily_main": {
+          "name": "daily_main",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "daily_common": {
+          "name": "daily_common",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "daily_load_info": {
+          "name": "daily_load_info",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "path_overview": {
+          "name": "path_overview",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "path_info": {
+          "name": "path_info",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "path_step_1": {
+          "name": "path_step_1",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "path_step_2": {
+          "name": "path_step_2",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "path_step_3": {
+          "name": "path_step_3",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "path_step_4": {
+          "name": "path_step_4",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "path_step_complete": {
+          "name": "path_step_complete",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "explore_overview": {
+          "name": "explore_overview",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "explore_subtle_system": {
+          "name": "explore_subtle_system",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "explore_talks_intro": {
+          "name": "explore_talks_intro",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "explore_talks_list": {
+          "name": "explore_talks_list",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "explore_talks_player": {
+          "name": "explore_talks_player",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profile_main": {
+          "name": "profile_main",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profile_favourites": {
+          "name": "profile_favourites",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profile_history": {
+          "name": "profile_history",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profile_account": {
+          "name": "profile_account",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profile_privacy": {
+          "name": "profile_privacy",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profile_privacy_advertising_body_never_share": {
+          "name": "profile_privacy_advertising_body_never_share",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profile_privacy_advertising_body_intro": {
+          "name": "profile_privacy_advertising_body_intro",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profile_contact": {
+          "name": "profile_contact",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meditation_intent": {
+          "name": "meditation_intent",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meditation_reminder": {
+          "name": "meditation_reminder",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meditation_footsoak": {
+          "name": "meditation_footsoak",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meditation_footsoak_description": {
+          "name": "meditation_footsoak_description",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meditation_player": {
+          "name": "meditation_player",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meditation_vibes_check": {
+          "name": "meditation_vibes_check",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meditation_feedback": {
+          "name": "meditation_feedback",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auth_common": {
+          "name": "auth_common",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auth_login": {
+          "name": "auth_login",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auth_restore_password": {
+          "name": "auth_restore_password",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auth_restore_password_email_sent": {
+          "name": "auth_restore_password_email_sent",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auth_create_account": {
+          "name": "auth_create_account",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auth_create_account_consent_label": {
+          "name": "auth_create_account_consent_label",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "navigation": {
+          "name": "navigation",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "general": {
+          "name": "general",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "_locale": {
+          "name": "_locale",
+          "type": "_locales",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "wm_app_translations_locales_locale_parent_id_unique": {
+          "name": "wm_app_translations_locales_locale_parent_id_unique",
+          "columns": [
+            {
+              "expression": "_locale",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "wm_app_translations_locales_parent_id_fk": {
+          "name": "wm_app_translations_locales_parent_id_fk",
+          "tableFrom": "wm_app_translations_locales",
+          "tableTo": "wm_app_translations",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public._wm_app_translations_v": {
+      "name": "_wm_app_translations_v",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "version__status": {
+          "name": "version__status",
+          "type": "enum__wm_app_translations_v_version_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'draft'"
+        },
+        "version_updated_at": {
+          "name": "version_updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_created_at": {
+          "name": "version_created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "snapshot": {
+          "name": "snapshot",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_locale": {
+          "name": "published_locale",
+          "type": "enum__wm_app_translations_v_published_locale",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latest": {
+          "name": "latest",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "_wm_app_translations_v_version_version__status_idx": {
+          "name": "_wm_app_translations_v_version_version__status_idx",
+          "columns": [
+            {
+              "expression": "version__status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_wm_app_translations_v_created_at_idx": {
+          "name": "_wm_app_translations_v_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_wm_app_translations_v_updated_at_idx": {
+          "name": "_wm_app_translations_v_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_wm_app_translations_v_snapshot_idx": {
+          "name": "_wm_app_translations_v_snapshot_idx",
+          "columns": [
+            {
+              "expression": "snapshot",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_wm_app_translations_v_published_locale_idx": {
+          "name": "_wm_app_translations_v_published_locale_idx",
+          "columns": [
+            {
+              "expression": "published_locale",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_wm_app_translations_v_latest_idx": {
+          "name": "_wm_app_translations_v_latest_idx",
+          "columns": [
+            {
+              "expression": "latest",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public._wm_app_translations_v_locales": {
+      "name": "_wm_app_translations_v_locales",
+      "schema": "",
+      "columns": {
+        "version_onboarding_welcome": {
+          "name": "version_onboarding_welcome",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_onboarding_welcome_legal_disclaimer": {
+          "name": "version_onboarding_welcome_legal_disclaimer",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_onboarding_name": {
+          "name": "version_onboarding_name",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_onboarding_greeting": {
+          "name": "version_onboarding_greeting",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_onboarding_user_type": {
+          "name": "version_onboarding_user_type",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_onboarding_user_type_title": {
+          "name": "version_onboarding_user_type_title",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_onboarding_carousel": {
+          "name": "version_onboarding_carousel",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_onboarding_carousel_page_true_self_title": {
+          "name": "version_onboarding_carousel_page_true_self_title",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_onboarding_consent_modal": {
+          "name": "version_onboarding_consent_modal",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_onboarding_consent_modal_body_never_share": {
+          "name": "version_onboarding_consent_modal_body_never_share",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_onboarding_consent_modal_body_never_sell": {
+          "name": "version_onboarding_consent_modal_body_never_sell",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_onboarding_consent_modal_body_intro": {
+          "name": "version_onboarding_consent_modal_body_intro",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_daily_main": {
+          "name": "version_daily_main",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_daily_common": {
+          "name": "version_daily_common",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_daily_load_info": {
+          "name": "version_daily_load_info",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_path_overview": {
+          "name": "version_path_overview",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_path_info": {
+          "name": "version_path_info",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_path_step_1": {
+          "name": "version_path_step_1",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_path_step_2": {
+          "name": "version_path_step_2",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_path_step_3": {
+          "name": "version_path_step_3",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_path_step_4": {
+          "name": "version_path_step_4",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_path_step_complete": {
+          "name": "version_path_step_complete",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_explore_overview": {
+          "name": "version_explore_overview",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_explore_subtle_system": {
+          "name": "version_explore_subtle_system",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_explore_talks_intro": {
+          "name": "version_explore_talks_intro",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_explore_talks_list": {
+          "name": "version_explore_talks_list",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_explore_talks_player": {
+          "name": "version_explore_talks_player",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_profile_main": {
+          "name": "version_profile_main",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_profile_favourites": {
+          "name": "version_profile_favourites",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_profile_history": {
+          "name": "version_profile_history",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_profile_account": {
+          "name": "version_profile_account",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_profile_privacy": {
+          "name": "version_profile_privacy",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_profile_privacy_advertising_body_never_share": {
+          "name": "version_profile_privacy_advertising_body_never_share",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_profile_privacy_advertising_body_intro": {
+          "name": "version_profile_privacy_advertising_body_intro",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_profile_contact": {
+          "name": "version_profile_contact",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_meditation_intent": {
+          "name": "version_meditation_intent",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_meditation_reminder": {
+          "name": "version_meditation_reminder",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_meditation_footsoak": {
+          "name": "version_meditation_footsoak",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_meditation_footsoak_description": {
+          "name": "version_meditation_footsoak_description",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_meditation_player": {
+          "name": "version_meditation_player",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_meditation_vibes_check": {
+          "name": "version_meditation_vibes_check",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_meditation_feedback": {
+          "name": "version_meditation_feedback",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_auth_common": {
+          "name": "version_auth_common",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_auth_login": {
+          "name": "version_auth_login",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_auth_restore_password": {
+          "name": "version_auth_restore_password",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_auth_restore_password_email_sent": {
+          "name": "version_auth_restore_password_email_sent",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_auth_create_account": {
+          "name": "version_auth_create_account",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_auth_create_account_consent_label": {
+          "name": "version_auth_create_account_consent_label",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_navigation": {
+          "name": "version_navigation",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_general": {
+          "name": "version_general",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "_locale": {
+          "name": "_locale",
+          "type": "_locales",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "_wm_app_translations_v_locales_locale_parent_id_unique": {
+          "name": "_wm_app_translations_v_locales_locale_parent_id_unique",
+          "columns": [
+            {
+              "expression": "_locale",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "_wm_app_translations_v_locales_parent_id_fk": {
+          "name": "_wm_app_translations_v_locales_parent_id_fk",
+          "tableFrom": "_wm_app_translations_v_locales",
+          "tableTo": "_wm_app_translations_v",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wm_app_status": {
+      "name": "wm_app_status",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wm_app_status_locales": {
+      "name": "wm_app_status_locales",
+      "schema": "",
+      "columns": {
+        "baseline_country": {
+          "name": "baseline_country",
+          "type": "enum_wm_app_status_baseline_country",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'GB'"
+        },
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "_locale": {
+          "name": "_locale",
+          "type": "_locales",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "wm_app_status_locales_locale_parent_id_unique": {
+          "name": "wm_app_status_locales_locale_parent_id_unique",
+          "columns": [
+            {
+              "expression": "_locale",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "wm_app_status_locales_parent_id_fk": {
+          "name": "wm_app_status_locales_parent_id_fk",
+          "tableFrom": "wm_app_status_locales",
+          "tableTo": "wm_app_status",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wm_app_status_rels": {
+      "name": "wm_app_status_rels",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "app_cards_id": {
+          "name": "app_cards_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "wm_app_status_rels_order_idx": {
+          "name": "wm_app_status_rels_order_idx",
+          "columns": [
+            {
+              "expression": "order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wm_app_status_rels_parent_idx": {
+          "name": "wm_app_status_rels_parent_idx",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wm_app_status_rels_path_idx": {
+          "name": "wm_app_status_rels_path_idx",
+          "columns": [
+            {
+              "expression": "path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "wm_app_status_rels_app_cards_id_idx": {
+          "name": "wm_app_status_rels_app_cards_id_idx",
+          "columns": [
+            {
+              "expression": "app_cards_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "wm_app_status_rels_parent_fk": {
+          "name": "wm_app_status_rels_parent_fk",
+          "tableFrom": "wm_app_status_rels",
+          "tableTo": "wm_app_status",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "wm_app_status_rels_app_cards_fk": {
+          "name": "wm_app_status_rels_app_cards_fk",
+          "tableFrom": "wm_app_status_rels",
+          "tableTo": "app_cards",
+          "columnsFrom": [
+            "app_cards_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sy_atlas_config": {
+      "name": "sy_atlas_config",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "default_map_center_latitude": {
+          "name": "default_map_center_latitude",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "default_map_center_longitude": {
+          "name": "default_map_center_longitude",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "default_zoom_level": {
+          "name": "default_zoom_level",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 10
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sy_atlas_translations": {
+      "name": "sy_atlas_translations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "_status": {
+          "name": "_status",
+          "type": "enum_sy_atlas_translations_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'draft'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "sy_atlas_translations__status_idx": {
+          "name": "sy_atlas_translations__status_idx",
+          "columns": [
+            {
+              "expression": "_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sy_atlas_translations_locales": {
+      "name": "sy_atlas_translations_locales",
+      "schema": "",
+      "columns": {
+        "common": {
+          "name": "common",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "map": {
+          "name": "map",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event": {
+          "name": "event",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "_locale": {
+          "name": "_locale",
+          "type": "_locales",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "sy_atlas_translations_locales_locale_parent_id_unique": {
+          "name": "sy_atlas_translations_locales_locale_parent_id_unique",
+          "columns": [
+            {
+              "expression": "_locale",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sy_atlas_translations_locales_parent_id_fk": {
+          "name": "sy_atlas_translations_locales_parent_id_fk",
+          "tableFrom": "sy_atlas_translations_locales",
+          "tableTo": "sy_atlas_translations",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public._sy_atlas_translations_v": {
+      "name": "_sy_atlas_translations_v",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "version__status": {
+          "name": "version__status",
+          "type": "enum__sy_atlas_translations_v_version_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'draft'"
+        },
+        "version_updated_at": {
+          "name": "version_updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_created_at": {
+          "name": "version_created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "snapshot": {
+          "name": "snapshot",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_locale": {
+          "name": "published_locale",
+          "type": "enum__sy_atlas_translations_v_published_locale",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latest": {
+          "name": "latest",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "_sy_atlas_translations_v_version_version__status_idx": {
+          "name": "_sy_atlas_translations_v_version_version__status_idx",
+          "columns": [
+            {
+              "expression": "version__status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_sy_atlas_translations_v_created_at_idx": {
+          "name": "_sy_atlas_translations_v_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_sy_atlas_translations_v_updated_at_idx": {
+          "name": "_sy_atlas_translations_v_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_sy_atlas_translations_v_snapshot_idx": {
+          "name": "_sy_atlas_translations_v_snapshot_idx",
+          "columns": [
+            {
+              "expression": "snapshot",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_sy_atlas_translations_v_published_locale_idx": {
+          "name": "_sy_atlas_translations_v_published_locale_idx",
+          "columns": [
+            {
+              "expression": "published_locale",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "_sy_atlas_translations_v_latest_idx": {
+          "name": "_sy_atlas_translations_v_latest_idx",
+          "columns": [
+            {
+              "expression": "latest",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public._sy_atlas_translations_v_locales": {
+      "name": "_sy_atlas_translations_v_locales",
+      "schema": "",
+      "columns": {
+        "version_common": {
+          "name": "version_common",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_map": {
+          "name": "version_map",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_location": {
+          "name": "version_location",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_event": {
+          "name": "version_event",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "_locale": {
+          "name": "_locale",
+          "type": "_locales",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "_sy_atlas_translations_v_locales_locale_parent_id_unique": {
+          "name": "_sy_atlas_translations_v_locales_locale_parent_id_unique",
+          "columns": [
+            {
+              "expression": "_locale",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "_parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "_sy_atlas_translations_v_locales_parent_id_fk": {
+          "name": "_sy_atlas_translations_v_locales_parent_id_fk",
+          "tableFrom": "_sy_atlas_translations_v_locales",
+          "tableTo": "_sy_atlas_translations_v",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payload_jobs_stats": {
+      "name": "payload_jobs_stats",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "stats": {
+          "name": "stats",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public._locales": {
+      "name": "_locales",
+      "schema": "public",
+      "values": [
+        "en",
+        "es",
+        "de",
+        "it",
+        "fr",
+        "ru",
+        "ro",
+        "cs",
+        "uk",
+        "el",
+        "hy",
+        "pl",
+        "pt-BR",
+        "fa",
+        "bg",
+        "tr",
+        "en-AU"
+      ]
+    },
+    "public.enum_pages_tags": {
+      "name": "enum_pages_tags",
+      "schema": "public",
+      "values": [
+        "wisdom",
+        "lifestyle",
+        "creativity",
+        "event",
+        "technique"
+      ]
+    },
+    "public.enum_pages_status": {
+      "name": "enum_pages_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "published"
+      ]
+    },
+    "public.enum__pages_v_version_tags": {
+      "name": "enum__pages_v_version_tags",
+      "schema": "public",
+      "values": [
+        "wisdom",
+        "lifestyle",
+        "creativity",
+        "event",
+        "technique"
+      ]
+    },
+    "public.enum__pages_v_version_status": {
+      "name": "enum__pages_v_version_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "published"
+      ]
+    },
+    "public.enum__pages_v_published_locale": {
+      "name": "enum__pages_v_published_locale",
+      "schema": "public",
+      "values": [
+        "en",
+        "es",
+        "de",
+        "it",
+        "fr",
+        "ru",
+        "ro",
+        "cs",
+        "uk",
+        "el",
+        "hy",
+        "pl",
+        "pt-BR",
+        "fa",
+        "bg",
+        "tr",
+        "en-AU"
+      ]
+    },
+    "public.enum_meditations_locale": {
+      "name": "enum_meditations_locale",
+      "schema": "public",
+      "values": [
+        "en",
+        "es",
+        "de",
+        "it",
+        "fr",
+        "ru",
+        "ro",
+        "cs",
+        "uk",
+        "el",
+        "hy",
+        "pl",
+        "pt-BR",
+        "fa",
+        "bg",
+        "tr",
+        "en-AU"
+      ]
+    },
+    "public.enum_meditations_type": {
+      "name": "enum_meditations_type",
+      "schema": "public",
+      "values": [
+        "daily",
+        "lesson"
+      ]
+    },
+    "public.enum_meditations_status": {
+      "name": "enum_meditations_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "published"
+      ]
+    },
+    "public.enum__meditations_v_version_locale": {
+      "name": "enum__meditations_v_version_locale",
+      "schema": "public",
+      "values": [
+        "en",
+        "es",
+        "de",
+        "it",
+        "fr",
+        "ru",
+        "ro",
+        "cs",
+        "uk",
+        "el",
+        "hy",
+        "pl",
+        "pt-BR",
+        "fa",
+        "bg",
+        "tr",
+        "en-AU"
+      ]
+    },
+    "public.enum__meditations_v_version_type": {
+      "name": "enum__meditations_v_version_type",
+      "schema": "public",
+      "values": [
+        "daily",
+        "lesson"
+      ]
+    },
+    "public.enum__meditations_v_version_status": {
+      "name": "enum__meditations_v_version_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "published"
+      ]
+    },
+    "public.enum__meditations_v_published_locale": {
+      "name": "enum__meditations_v_published_locale",
+      "schema": "public",
+      "values": [
+        "en",
+        "es",
+        "de",
+        "it",
+        "fr",
+        "ru",
+        "ro",
+        "cs",
+        "uk",
+        "el",
+        "hy",
+        "pl",
+        "pt-BR",
+        "fa",
+        "bg",
+        "tr",
+        "en-AU"
+      ]
+    },
+    "public.enum_videos_tags": {
+      "name": "enum_videos_tags",
+      "schema": "public",
+      "values": [
+        "testimonial",
+        "workshop",
+        "event",
+        "technique"
+      ]
+    },
+    "public.enum_lessons_unit": {
+      "name": "enum_lessons_unit",
+      "schema": "public",
+      "values": [
+        "Unit 1",
+        "Unit 2",
+        "Unit 3",
+        "Unit 4",
+        "Unit 5",
+        "Unit 6",
+        "Unit 7"
+      ]
+    },
+    "public.enum_lectures_subtitles_locale": {
+      "name": "enum_lectures_subtitles_locale",
+      "schema": "public",
+      "values": [
+        "en",
+        "es",
+        "de",
+        "it",
+        "fr",
+        "ru",
+        "ro",
+        "cs",
+        "uk",
+        "el",
+        "hy",
+        "pl",
+        "pt-BR",
+        "fa",
+        "bg",
+        "tr",
+        "en-AU"
+      ]
+    },
+    "public.enum_lectures_type": {
+      "name": "enum_lectures_type",
+      "schema": "public",
+      "values": [
+        "full",
+        "clip"
+      ]
+    },
+    "public.enum_frames_tags": {
+      "name": "enum_frames_tags",
+      "schema": "public",
+      "values": [
+        "anahat",
+        "back",
+        "bandhan",
+        "both hands",
+        "center",
+        "channel",
+        "clearing",
+        "earth",
+        "ego",
+        "feel",
+        "ham ksham",
+        "hamsa",
+        "hand",
+        "hands",
+        "left",
+        "lefthanded",
+        "massage",
+        "meditate",
+        "namaste",
+        "raise",
+        "ready",
+        "right",
+        "righthanded",
+        "rising",
+        "silent",
+        "superego",
+        "tapping"
+      ]
+    },
+    "public.enum_frames_image_set": {
+      "name": "enum_frames_image_set",
+      "schema": "public",
+      "values": [
+        "male",
+        "female"
+      ]
+    },
+    "public.enum_narrators_gender": {
+      "name": "enum_narrators_gender",
+      "schema": "public",
+      "values": [
+        "male",
+        "female"
+      ]
+    },
+    "public.enum_images_tags": {
+      "name": "enum_images_tags",
+      "schema": "public",
+      "values": [
+        "landscape",
+        "portrait",
+        "square",
+        "thumbnail",
+        "author",
+        "icon",
+        "stock-photo",
+        "technique",
+        "meditation",
+        "placeholder",
+        "lesson",
+        "app-card"
+      ]
+    },
+    "public.enum_audiences_location_countries": {
+      "name": "enum_audiences_location_countries",
+      "schema": "public",
+      "values": [
+        "AF",
+        "AX",
+        "AL",
+        "DZ",
+        "AS",
+        "AD",
+        "AO",
+        "AI",
+        "AQ",
+        "AG",
+        "AR",
+        "AM",
+        "AW",
+        "AU",
+        "AT",
+        "AZ",
+        "BS",
+        "BH",
+        "BD",
+        "BB",
+        "BY",
+        "BE",
+        "BZ",
+        "BJ",
+        "BM",
+        "BT",
+        "BO",
+        "BQ",
+        "BA",
+        "BW",
+        "BV",
+        "BR",
+        "IO",
+        "BN",
+        "BG",
+        "BF",
+        "BI",
+        "KH",
+        "CM",
+        "CA",
+        "CV",
+        "KY",
+        "CF",
+        "TD",
+        "CL",
+        "CN",
+        "CX",
+        "CC",
+        "CO",
+        "KM",
+        "CG",
+        "CD",
+        "CK",
+        "CR",
+        "CI",
+        "HR",
+        "CU",
+        "CW",
+        "CY",
+        "CZ",
+        "DK",
+        "DJ",
+        "DM",
+        "DO",
+        "EC",
+        "EG",
+        "SV",
+        "GQ",
+        "ER",
+        "EE",
+        "SZ",
+        "ET",
+        "FK",
+        "FO",
+        "FJ",
+        "FI",
+        "FR",
+        "GF",
+        "PF",
+        "TF",
+        "GA",
+        "GM",
+        "GE",
+        "DE",
+        "GH",
+        "GI",
+        "GR",
+        "GL",
+        "GD",
+        "GP",
+        "GU",
+        "GT",
+        "GG",
+        "GN",
+        "GW",
+        "GY",
+        "HT",
+        "HM",
+        "VA",
+        "HN",
+        "HK",
+        "HU",
+        "IS",
+        "IN",
+        "ID",
+        "IR",
+        "IQ",
+        "IE",
+        "IM",
+        "IL",
+        "IT",
+        "JM",
+        "JP",
+        "JE",
+        "JO",
+        "KZ",
+        "KE",
+        "KI",
+        "KP",
+        "KR",
+        "XK",
+        "KW",
+        "KG",
+        "LA",
+        "LV",
+        "LB",
+        "LS",
+        "LR",
+        "LY",
+        "LI",
+        "LT",
+        "LU",
+        "MO",
+        "MK",
+        "MG",
+        "MW",
+        "MY",
+        "MV",
+        "ML",
+        "MT",
+        "MH",
+        "MQ",
+        "MR",
+        "MU",
+        "YT",
+        "MX",
+        "FM",
+        "MD",
+        "MC",
+        "MN",
+        "ME",
+        "MS",
+        "MA",
+        "MZ",
+        "MM",
+        "NA",
+        "NR",
+        "NP",
+        "NL",
+        "NC",
+        "NZ",
+        "NI",
+        "NE",
+        "NG",
+        "NU",
+        "NF",
+        "MP",
+        "NO",
+        "OM",
+        "PK",
+        "PW",
+        "PS",
+        "PA",
+        "PG",
+        "PY",
+        "PE",
+        "PH",
+        "PN",
+        "PL",
+        "PT",
+        "PR",
+        "QA",
+        "RE",
+        "RO",
+        "RU",
+        "RW",
+        "BL",
+        "SH",
+        "KN",
+        "LC",
+        "MF",
+        "PM",
+        "VC",
+        "WS",
+        "SM",
+        "ST",
+        "SA",
+        "SN",
+        "RS",
+        "SC",
+        "SL",
+        "SG",
+        "SX",
+        "SK",
+        "SI",
+        "SB",
+        "SO",
+        "ZA",
+        "GS",
+        "SS",
+        "ES",
+        "LK",
+        "SD",
+        "SR",
+        "SE",
+        "CH",
+        "SY",
+        "TW",
+        "TJ",
+        "TZ",
+        "TH",
+        "TL",
+        "TG",
+        "TK",
+        "TO",
+        "TT",
+        "TN",
+        "TR",
+        "TM",
+        "TC",
+        "TV",
+        "UG",
+        "UA",
+        "AE",
+        "GB",
+        "US",
+        "UM",
+        "UY",
+        "UZ",
+        "VU",
+        "VE",
+        "VN",
+        "VG",
+        "VI",
+        "WF",
+        "EH",
+        "YE",
+        "ZM",
+        "ZW"
+      ]
+    },
+    "public.enum_user_choices_timings": {
+      "name": "enum_user_choices_timings",
+      "schema": "public",
+      "values": [
+        "morning",
+        "afternoon",
+        "evening",
+        "night"
+      ]
+    },
+    "public.enum_user_choices_type": {
+      "name": "enum_user_choices_type",
+      "schema": "public",
+      "values": [
+        "mood",
+        "goal",
+        "duration"
+      ]
+    },
+    "public.enum_subtle_system_nodes_slug": {
+      "name": "enum_subtle_system_nodes_slug",
+      "schema": "public",
+      "values": [
+        "mooladhara",
+        "swadhistan",
+        "nabhi",
+        "void",
+        "anahat",
+        "vishuddhi",
+        "agnya",
+        "sahasrara",
+        "kundalini",
+        "pingala",
+        "ida",
+        "sushumna"
+      ]
+    },
+    "public.enum_managers_roles": {
+      "name": "enum_managers_roles",
+      "schema": "public",
+      "values": [
+        "meditations-editor",
+        "path-editor",
+        "web-translator",
+        "atlas-manager"
+      ]
+    },
+    "public.enum_managers_contact_details_platform": {
+      "name": "enum_managers_contact_details_platform",
+      "schema": "public",
+      "values": [
+        "whatsapp",
+        "telegram",
+        "wechat"
+      ]
+    },
+    "public.enum_managers_current_project": {
+      "name": "enum_managers_current_project",
+      "schema": "public",
+      "values": [
+        "",
+        "wemeditate-web",
+        "wemeditate-app",
+        "sahaj-atlas"
+      ]
+    },
+    "public.enum_managers_type": {
+      "name": "enum_managers_type",
+      "schema": "public",
+      "values": [
+        "inactive",
+        "manager",
+        "admin"
+      ]
+    },
+    "public.enum_managers_language": {
+      "name": "enum_managers_language",
+      "schema": "public",
+      "values": [
+        "ab",
+        "aa",
+        "af",
+        "ak",
+        "sq",
+        "am",
+        "ar",
+        "an",
+        "hy",
+        "as",
+        "av",
+        "ae",
+        "ay",
+        "az",
+        "bm",
+        "ba",
+        "eu",
+        "be",
+        "bn",
+        "bi",
+        "bs",
+        "br",
+        "bg",
+        "my",
+        "ca",
+        "ch",
+        "ce",
+        "ny",
+        "zh",
+        "cv",
+        "kw",
+        "co",
+        "cr",
+        "hr",
+        "cs",
+        "da",
+        "dv",
+        "nl",
+        "dz",
+        "en",
+        "eo",
+        "et",
+        "ee",
+        "fo",
+        "fj",
+        "fi",
+        "fr",
+        "ff",
+        "gl",
+        "lg",
+        "ka",
+        "de",
+        "el",
+        "gn",
+        "gu",
+        "ht",
+        "ha",
+        "he",
+        "hz",
+        "hi",
+        "ho",
+        "hu",
+        "is",
+        "io",
+        "ig",
+        "id",
+        "ia",
+        "ie",
+        "iu",
+        "ik",
+        "ga",
+        "it",
+        "ja",
+        "jv",
+        "kl",
+        "kn",
+        "kr",
+        "ks",
+        "kk",
+        "km",
+        "ki",
+        "rw",
+        "rn",
+        "kv",
+        "kg",
+        "ko",
+        "ku",
+        "kj",
+        "ky",
+        "lo",
+        "la",
+        "lv",
+        "li",
+        "ln",
+        "lt",
+        "lu",
+        "lb",
+        "mk",
+        "mg",
+        "ms",
+        "ml",
+        "mt",
+        "gv",
+        "mi",
+        "mr",
+        "mh",
+        "mn",
+        "na",
+        "nv",
+        "ng",
+        "ne",
+        "nd",
+        "se",
+        "no",
+        "nb",
+        "nn",
+        "ii",
+        "oc",
+        "oj",
+        "cu",
+        "or",
+        "om",
+        "os",
+        "pi",
+        "pa",
+        "ps",
+        "fa",
+        "pl",
+        "pt",
+        "qu",
+        "ro",
+        "rm",
+        "ru",
+        "sm",
+        "sg",
+        "sa",
+        "sc",
+        "gd",
+        "sr",
+        "sn",
+        "sd",
+        "si",
+        "sk",
+        "sl",
+        "so",
+        "nr",
+        "st",
+        "es",
+        "su",
+        "sw",
+        "ss",
+        "sv",
+        "tl",
+        "ty",
+        "tg",
+        "ta",
+        "tt",
+        "te",
+        "th",
+        "bo",
+        "ti",
+        "to",
+        "ts",
+        "tn",
+        "tr",
+        "tk",
+        "tw",
+        "uk",
+        "ur",
+        "ug",
+        "uz",
+        "ve",
+        "vi",
+        "vo",
+        "wa",
+        "cy",
+        "fy",
+        "wo",
+        "xh",
+        "yi",
+        "yo",
+        "za",
+        "zu"
+      ]
+    },
+    "public.enum_clients_roles": {
+      "name": "enum_clients_roles",
+      "schema": "public",
+      "values": [
+        "wemeditate-web-client",
+        "wemeditate-app-client",
+        "sahaj-atlas-client"
+      ]
+    },
+    "public.enum_clients_locale": {
+      "name": "enum_clients_locale",
+      "schema": "public",
+      "values": [
+        "ab",
+        "aa",
+        "af",
+        "ak",
+        "sq",
+        "am",
+        "ar",
+        "an",
+        "hy",
+        "as",
+        "av",
+        "ae",
+        "ay",
+        "az",
+        "bm",
+        "ba",
+        "eu",
+        "be",
+        "bn",
+        "bi",
+        "bs",
+        "br",
+        "bg",
+        "my",
+        "ca",
+        "ch",
+        "ce",
+        "ny",
+        "zh",
+        "cv",
+        "kw",
+        "co",
+        "cr",
+        "hr",
+        "cs",
+        "da",
+        "dv",
+        "nl",
+        "dz",
+        "en",
+        "eo",
+        "et",
+        "ee",
+        "fo",
+        "fj",
+        "fi",
+        "fr",
+        "ff",
+        "gl",
+        "lg",
+        "ka",
+        "de",
+        "el",
+        "gn",
+        "gu",
+        "ht",
+        "ha",
+        "he",
+        "hz",
+        "hi",
+        "ho",
+        "hu",
+        "is",
+        "io",
+        "ig",
+        "id",
+        "ia",
+        "ie",
+        "iu",
+        "ik",
+        "ga",
+        "it",
+        "ja",
+        "jv",
+        "kl",
+        "kn",
+        "kr",
+        "ks",
+        "kk",
+        "km",
+        "ki",
+        "rw",
+        "rn",
+        "kv",
+        "kg",
+        "ko",
+        "ku",
+        "kj",
+        "ky",
+        "lo",
+        "la",
+        "lv",
+        "li",
+        "ln",
+        "lt",
+        "lu",
+        "lb",
+        "mk",
+        "mg",
+        "ms",
+        "ml",
+        "mt",
+        "gv",
+        "mi",
+        "mr",
+        "mh",
+        "mn",
+        "na",
+        "nv",
+        "ng",
+        "ne",
+        "nd",
+        "se",
+        "no",
+        "nb",
+        "nn",
+        "ii",
+        "oc",
+        "oj",
+        "cu",
+        "or",
+        "om",
+        "os",
+        "pi",
+        "pa",
+        "ps",
+        "fa",
+        "pl",
+        "pt",
+        "qu",
+        "ro",
+        "rm",
+        "ru",
+        "sm",
+        "sg",
+        "sa",
+        "sc",
+        "gd",
+        "sr",
+        "sn",
+        "sd",
+        "si",
+        "sk",
+        "sl",
+        "so",
+        "nr",
+        "st",
+        "es",
+        "su",
+        "sw",
+        "ss",
+        "sv",
+        "tl",
+        "ty",
+        "tg",
+        "ta",
+        "tt",
+        "te",
+        "th",
+        "bo",
+        "ti",
+        "to",
+        "ts",
+        "tn",
+        "tr",
+        "tk",
+        "tw",
+        "uk",
+        "ur",
+        "ug",
+        "uz",
+        "ve",
+        "vi",
+        "vo",
+        "wa",
+        "cy",
+        "fy",
+        "wo",
+        "xh",
+        "yi",
+        "yo",
+        "za",
+        "zu"
+      ]
+    },
+    "public.enum_clients_status": {
+      "name": "enum_clients_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "published"
+      ]
+    },
+    "public.enum__clients_v_version_roles": {
+      "name": "enum__clients_v_version_roles",
+      "schema": "public",
+      "values": [
+        "wemeditate-web-client",
+        "wemeditate-app-client",
+        "sahaj-atlas-client"
+      ]
+    },
+    "public.enum__clients_v_version_locale": {
+      "name": "enum__clients_v_version_locale",
+      "schema": "public",
+      "values": [
+        "ab",
+        "aa",
+        "af",
+        "ak",
+        "sq",
+        "am",
+        "ar",
+        "an",
+        "hy",
+        "as",
+        "av",
+        "ae",
+        "ay",
+        "az",
+        "bm",
+        "ba",
+        "eu",
+        "be",
+        "bn",
+        "bi",
+        "bs",
+        "br",
+        "bg",
+        "my",
+        "ca",
+        "ch",
+        "ce",
+        "ny",
+        "zh",
+        "cv",
+        "kw",
+        "co",
+        "cr",
+        "hr",
+        "cs",
+        "da",
+        "dv",
+        "nl",
+        "dz",
+        "en",
+        "eo",
+        "et",
+        "ee",
+        "fo",
+        "fj",
+        "fi",
+        "fr",
+        "ff",
+        "gl",
+        "lg",
+        "ka",
+        "de",
+        "el",
+        "gn",
+        "gu",
+        "ht",
+        "ha",
+        "he",
+        "hz",
+        "hi",
+        "ho",
+        "hu",
+        "is",
+        "io",
+        "ig",
+        "id",
+        "ia",
+        "ie",
+        "iu",
+        "ik",
+        "ga",
+        "it",
+        "ja",
+        "jv",
+        "kl",
+        "kn",
+        "kr",
+        "ks",
+        "kk",
+        "km",
+        "ki",
+        "rw",
+        "rn",
+        "kv",
+        "kg",
+        "ko",
+        "ku",
+        "kj",
+        "ky",
+        "lo",
+        "la",
+        "lv",
+        "li",
+        "ln",
+        "lt",
+        "lu",
+        "lb",
+        "mk",
+        "mg",
+        "ms",
+        "ml",
+        "mt",
+        "gv",
+        "mi",
+        "mr",
+        "mh",
+        "mn",
+        "na",
+        "nv",
+        "ng",
+        "ne",
+        "nd",
+        "se",
+        "no",
+        "nb",
+        "nn",
+        "ii",
+        "oc",
+        "oj",
+        "cu",
+        "or",
+        "om",
+        "os",
+        "pi",
+        "pa",
+        "ps",
+        "fa",
+        "pl",
+        "pt",
+        "qu",
+        "ro",
+        "rm",
+        "ru",
+        "sm",
+        "sg",
+        "sa",
+        "sc",
+        "gd",
+        "sr",
+        "sn",
+        "sd",
+        "si",
+        "sk",
+        "sl",
+        "so",
+        "nr",
+        "st",
+        "es",
+        "su",
+        "sw",
+        "ss",
+        "sv",
+        "tl",
+        "ty",
+        "tg",
+        "ta",
+        "tt",
+        "te",
+        "th",
+        "bo",
+        "ti",
+        "to",
+        "ts",
+        "tn",
+        "tr",
+        "tk",
+        "tw",
+        "uk",
+        "ur",
+        "ug",
+        "uz",
+        "ve",
+        "vi",
+        "vo",
+        "wa",
+        "cy",
+        "fy",
+        "wo",
+        "xh",
+        "yi",
+        "yo",
+        "za",
+        "zu"
+      ]
+    },
+    "public.enum__clients_v_version_status": {
+      "name": "enum__clients_v_version_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "published"
+      ]
+    },
+    "public.enum__clients_v_published_locale": {
+      "name": "enum__clients_v_published_locale",
+      "schema": "public",
+      "values": [
+        "en",
+        "es",
+        "de",
+        "it",
+        "fr",
+        "ru",
+        "ro",
+        "cs",
+        "uk",
+        "el",
+        "hy",
+        "pl",
+        "pt-BR",
+        "fa",
+        "bg",
+        "tr",
+        "en-AU"
+      ]
+    },
+    "public.enum_app_cards_schedule_weekdays": {
+      "name": "enum_app_cards_schedule_weekdays",
+      "schema": "public",
+      "values": [
+        "MO",
+        "TU",
+        "WE",
+        "TH",
+        "FR",
+        "SA",
+        "SU"
+      ]
+    },
+    "public.enum_app_cards_target_sections": {
+      "name": "enum_app_cards_target_sections",
+      "schema": "public",
+      "values": [
+        "hero",
+        "highlights",
+        "lectures"
+      ]
+    },
+    "public.enum_app_cards_timings": {
+      "name": "enum_app_cards_timings",
+      "schema": "public",
+      "values": [
+        "morning",
+        "afternoon",
+        "evening",
+        "night"
+      ]
+    },
+    "public.enum_app_cards_type": {
+      "name": "enum_app_cards_type",
+      "schema": "public",
+      "values": [
+        "standard",
+        "event"
+      ]
+    },
+    "public.enum_app_cards_default_destination": {
+      "name": "enum_app_cards_default_destination",
+      "schema": "public",
+      "values": [
+        "page",
+        "lecture",
+        "album",
+        "meditation",
+        "url"
+      ]
+    },
+    "public.enum_app_cards_default_aspect_ratio": {
+      "name": "enum_app_cards_default_aspect_ratio",
+      "schema": "public",
+      "values": [
+        "square",
+        "flexible"
+      ]
+    },
+    "public.enum_app_cards_default_text_color": {
+      "name": "enum_app_cards_default_text_color",
+      "schema": "public",
+      "values": [
+        "black",
+        "white"
+      ]
+    },
+    "public.enum_app_cards_default_alignment": {
+      "name": "enum_app_cards_default_alignment",
+      "schema": "public",
+      "values": [
+        "left",
+        "center"
+      ]
+    },
+    "public.enum_app_cards_starting_soon_destination": {
+      "name": "enum_app_cards_starting_soon_destination",
+      "schema": "public",
+      "values": [
+        "page",
+        "lecture",
+        "album",
+        "meditation",
+        "url"
+      ]
+    },
+    "public.enum_app_cards_starting_soon_aspect_ratio": {
+      "name": "enum_app_cards_starting_soon_aspect_ratio",
+      "schema": "public",
+      "values": [
+        "square",
+        "flexible"
+      ]
+    },
+    "public.enum_app_cards_starting_soon_text_color": {
+      "name": "enum_app_cards_starting_soon_text_color",
+      "schema": "public",
+      "values": [
+        "black",
+        "white"
+      ]
+    },
+    "public.enum_app_cards_starting_soon_alignment": {
+      "name": "enum_app_cards_starting_soon_alignment",
+      "schema": "public",
+      "values": [
+        "left",
+        "center"
+      ]
+    },
+    "public.enum_app_cards_live_now_destination": {
+      "name": "enum_app_cards_live_now_destination",
+      "schema": "public",
+      "values": [
+        "page",
+        "lecture",
+        "album",
+        "meditation",
+        "url"
+      ]
+    },
+    "public.enum_app_cards_live_now_aspect_ratio": {
+      "name": "enum_app_cards_live_now_aspect_ratio",
+      "schema": "public",
+      "values": [
+        "square",
+        "flexible"
+      ]
+    },
+    "public.enum_app_cards_live_now_text_color": {
+      "name": "enum_app_cards_live_now_text_color",
+      "schema": "public",
+      "values": [
+        "black",
+        "white"
+      ]
+    },
+    "public.enum_app_cards_live_now_alignment": {
+      "name": "enum_app_cards_live_now_alignment",
+      "schema": "public",
+      "values": [
+        "left",
+        "center"
+      ]
+    },
+    "public.enum_app_cards_schedule_firstdate_tz": {
+      "name": "enum_app_cards_schedule_firstdate_tz",
+      "schema": "public",
+      "values": [
+        "UTC",
+        "Pacific/Midway",
+        "Pacific/Niue",
+        "Pacific/Honolulu",
+        "Pacific/Rarotonga",
+        "America/Anchorage",
+        "Pacific/Gambier",
+        "America/Los_Angeles",
+        "America/Tijuana",
+        "America/Denver",
+        "America/Phoenix",
+        "America/Chicago",
+        "America/Guatemala",
+        "America/New_York",
+        "America/Bogota",
+        "America/Caracas",
+        "America/Santiago",
+        "America/Buenos_Aires",
+        "America/Sao_Paulo",
+        "Atlantic/South_Georgia",
+        "Atlantic/Azores",
+        "Atlantic/Cape_Verde",
+        "Europe/London",
+        "Europe/Berlin",
+        "Africa/Lagos",
+        "Europe/Athens",
+        "Africa/Cairo",
+        "Europe/Moscow",
+        "Asia/Riyadh",
+        "Asia/Dubai",
+        "Asia/Baku",
+        "Asia/Karachi",
+        "Asia/Tashkent",
+        "Asia/Calcutta",
+        "Asia/Dhaka",
+        "Asia/Almaty",
+        "Asia/Jakarta",
+        "Asia/Bangkok",
+        "Asia/Shanghai",
+        "Asia/Singapore",
+        "Asia/Tokyo",
+        "Asia/Seoul",
+        "Australia/Brisbane",
+        "Australia/Sydney",
+        "Pacific/Guam",
+        "Pacific/Noumea",
+        "Pacific/Auckland",
+        "Pacific/Fiji",
+        "Pacific/Pago_Pago",
+        "US/Samoa",
+        "Pacific/Samoa",
+        "US/Hawaii",
+        "Pacific/Johnston",
+        "HST",
+        "Pacific/Tahiti",
+        "Pacific/Marquesas",
+        "America/Adak",
+        "US/Aleutian",
+        "America/Atka",
+        "America/Juneau",
+        "America/Metlakatla",
+        "America/Nome",
+        "America/Sitka",
+        "America/Yakutat",
+        "US/Alaska",
+        "Pacific/Pitcairn",
+        "America/Hermosillo",
+        "America/Mazatlan",
+        "Mexico/BajaSur",
+        "MST",
+        "US/Arizona",
+        "America/Creston",
+        "US/Pacific",
+        "PST8PDT",
+        "Mexico/BajaNorte",
+        "America/Ensenada",
+        "America/Santa_Isabel",
+        "America/Vancouver",
+        "Canada/Pacific",
+        "America/Whitehorse",
+        "America/Dawson",
+        "America/Dawson_Creek",
+        "America/Fort_Nelson",
+        "Canada/Yukon",
+        "America/Belize",
+        "America/Managua",
+        "America/Mexico_City",
+        "America/Bahia_Banderas",
+        "America/Chihuahua",
+        "America/Merida",
+        "America/Monterrey",
+        "Mexico/General",
+        "America/Costa_Rica",
+        "America/El_Salvador",
+        "America/Regina",
+        "America/Swift_Current",
+        "Canada/Saskatchewan",
+        "America/Tegucigalpa",
+        "Pacific/Easter",
+        "Chile/EasterIsland",
+        "Pacific/Galapagos",
+        "America/Edmonton",
+        "America/Cambridge_Bay",
+        "America/Inuvik",
+        "Canada/Mountain",
+        "America/Yellowknife",
+        "America/Ciudad_Juarez",
+        "America/Boise",
+        "MST7MDT",
+        "Navajo",
+        "US/Mountain",
+        "America/Shiprock",
+        "America/Rio_Branco",
+        "America/Eirunepe",
+        "Brazil/Acre",
+        "America/Porto_Acre",
+        "America/Indiana/Knox",
+        "America/Indiana/Tell_City",
+        "America/Menominee",
+        "America/North_Dakota/Beulah",
+        "America/North_Dakota/Center",
+        "America/North_Dakota/New_Salem",
+        "CST6CDT",
+        "US/Central",
+        "US/Indiana-Starke",
+        "America/Knox_IN",
+        "America/Matamoros",
+        "America/Ojinaga",
+        "America/Winnipeg",
+        "America/Rankin_Inlet",
+        "America/Resolute",
+        "Canada/Central",
+        "America/Rainy_River",
+        "America/Atikokan",
+        "America/Cancun",
+        "America/Cayman",
+        "America/Jamaica",
+        "Jamaica",
+        "America/Panama",
+        "EST",
+        "America/Coral_Harbour",
+        "America/Guayaquil",
+        "America/Lima",
+        "America/Manaus",
+        "America/Boa_Vista",
+        "America/Campo_Grande",
+        "America/Cuiaba",
+        "America/Porto_Velho",
+        "Brazil/West",
+        "America/St_Kitts",
+        "America/Blanc-Sablon",
+        "America/Montserrat",
+        "America/Barbados",
+        "America/Port_of_Spain",
+        "America/Martinique",
+        "America/St_Lucia",
+        "America/St_Barthelemy",
+        "America/St_Vincent",
+        "America/Kralendijk",
+        "America/Guadeloupe",
+        "America/Marigot",
+        "America/Aruba",
+        "America/Lower_Princes",
+        "America/Tortola",
+        "America/Dominica",
+        "America/St_Thomas",
+        "America/Grenada",
+        "America/Antigua",
+        "America/Puerto_Rico",
+        "America/Virgin",
+        "America/Anguilla",
+        "America/Curacao",
+        "America/Santo_Domingo",
+        "America/La_Paz",
+        "Chile/Continental",
+        "America/Havana",
+        "Cuba",
+        "America/Nassau",
+        "America/Detroit",
+        "America/Indiana/Indianapolis",
+        "America/Indiana/Marengo",
+        "America/Indiana/Petersburg",
+        "America/Indiana/Vevay",
+        "America/Indiana/Vincennes",
+        "America/Indiana/Winamac",
+        "America/Kentucky/Louisville",
+        "America/Kentucky/Monticello",
+        "US/Michigan",
+        "US/East-Indiana",
+        "America/Indianapolis",
+        "America/Fort_Wayne",
+        "America/Louisville",
+        "EST5EDT",
+        "US/Eastern",
+        "America/Port-au-Prince",
+        "America/Grand_Turk",
+        "America/Toronto",
+        "America/Iqaluit",
+        "America/Pangnirtung",
+        "Canada/Eastern",
+        "America/Montreal",
+        "America/Nipigon",
+        "America/Thunder_Bay",
+        "America/Guyana",
+        "America/Argentina/Buenos_Aires",
+        "America/Argentina/Catamarca",
+        "America/Argentina/Cordoba",
+        "America/Argentina/Jujuy",
+        "America/Argentina/La_Rioja",
+        "America/Argentina/Mendoza",
+        "America/Argentina/Rio_Gallegos",
+        "America/Argentina/Salta",
+        "America/Argentina/San_Juan",
+        "America/Argentina/San_Luis",
+        "America/Argentina/Tucuman",
+        "America/Argentina/Ushuaia",
+        "America/Catamarca",
+        "America/Argentina/ComodRivadavia",
+        "America/Cordoba",
+        "America/Rosario",
+        "America/Jujuy",
+        "America/Mendoza",
+        "America/Halifax",
+        "America/Glace_Bay",
+        "America/Goose_Bay",
+        "America/Moncton",
+        "Canada/Atlantic",
+        "Atlantic/Bermuda",
+        "America/Thule",
+        "America/Araguaina",
+        "America/Bahia",
+        "America/Belem",
+        "America/Fortaleza",
+        "America/Maceio",
+        "America/Recife",
+        "America/Santarem",
+        "Brazil/East",
+        "Antarctica/Palmer",
+        "Antarctica/Rothera",
+        "America/Punta_Arenas",
+        "America/Coyhaique",
+        "Atlantic/Stanley",
+        "America/Cayenne",
+        "America/Asuncion",
+        "America/Paramaribo",
+        "America/Montevideo",
+        "America/St_Johns",
+        "Canada/Newfoundland",
+        "America/Noronha",
+        "Brazil/DeNoronha",
+        "America/Miquelon",
+        "America/Nuuk",
+        "America/Scoresbysund",
+        "America/Godthab",
+        "Africa/Abidjan",
+        "Iceland",
+        "Africa/Accra",
+        "Africa/Bamako",
+        "Africa/Banjul",
+        "Africa/Conakry",
+        "Africa/Dakar",
+        "Africa/Freetown",
+        "Africa/Lome",
+        "Africa/Nouakchott",
+        "Africa/Ouagadougou",
+        "Atlantic/Reykjavik",
+        "Atlantic/St_Helena",
+        "Africa/Timbuktu",
+        "Africa/Bissau",
+        "America/Danmarkshavn",
+        "Africa/Monrovia",
+        "Africa/Sao_Tome",
+        "Africa/Algiers",
+        "Africa/Tunis",
+        "Europe/Isle_of_Man",
+        "Europe/Dublin",
+        "Eire",
+        "GB",
+        "GB-Eire",
+        "Europe/Guernsey",
+        "Europe/Jersey",
+        "Europe/Belfast",
+        "Africa/Bangui",
+        "Africa/Malabo",
+        "Africa/Brazzaville",
+        "Africa/Porto-Novo",
+        "Africa/Douala",
+        "Africa/Kinshasa",
+        "Africa/Libreville",
+        "Africa/Luanda",
+        "Africa/Niamey",
+        "Africa/Ndjamena",
+        "Africa/Casablanca",
+        "Africa/El_Aaiun",
+        "Atlantic/Canary",
+        "Europe/Lisbon",
+        "Atlantic/Madeira",
+        "Portugal",
+        "WET",
+        "Atlantic/Faroe",
+        "Atlantic/Faeroe",
+        "Africa/Bujumbura",
+        "Africa/Gaborone",
+        "Africa/Harare",
+        "Africa/Juba",
+        "Africa/Khartoum",
+        "Africa/Kigali",
+        "Africa/Blantyre",
+        "Africa/Lubumbashi",
+        "Africa/Lusaka",
+        "Africa/Maputo",
+        "Africa/Windhoek",
+        "Europe/Andorra",
+        "Europe/Belgrade",
+        "Europe/Ljubljana",
+        "Europe/Podgorica",
+        "Europe/Sarajevo",
+        "Europe/Skopje",
+        "Europe/Zagreb",
+        "Europe/Busingen",
+        "Arctic/Longyearbyen",
+        "Europe/Copenhagen",
+        "Europe/Oslo",
+        "Europe/Stockholm",
+        "Atlantic/Jan_Mayen",
+        "Europe/Bratislava",
+        "Europe/Brussels",
+        "CET",
+        "MET",
+        "Europe/Amsterdam",
+        "Europe/Luxembourg",
+        "Europe/Budapest",
+        "Europe/Gibraltar",
+        "Europe/Madrid",
+        "Africa/Ceuta",
+        "Europe/Monaco",
+        "Europe/Paris",
+        "Europe/Prague",
+        "Europe/Rome",
+        "Europe/San_Marino",
+        "Europe/Vatican",
+        "Europe/Malta",
+        "Europe/Tirane",
+        "Europe/Vaduz",
+        "Europe/Vienna",
+        "Europe/Warsaw",
+        "Poland",
+        "Europe/Zurich",
+        "Europe/Kaliningrad",
+        "Africa/Tripoli",
+        "Libya",
+        "Antarctica/Troll",
+        "Africa/Johannesburg",
+        "Africa/Maseru",
+        "Africa/Mbabane",
+        "Asia/Kuwait",
+        "Asia/Bahrain",
+        "Asia/Baghdad",
+        "Asia/Qatar",
+        "Antarctica/Syowa",
+        "Asia/Aden",
+        "Asia/Amman",
+        "Asia/Damascus",
+        "Africa/Addis_Ababa",
+        "Indian/Antananarivo",
+        "Africa/Asmara",
+        "Africa/Dar_es_Salaam",
+        "Africa/Djibouti",
+        "Africa/Kampala",
+        "Indian/Mayotte",
+        "Africa/Mogadishu",
+        "Indian/Comoro",
+        "Africa/Nairobi",
+        "Africa/Asmera",
+        "EET",
+        "Asia/Beirut",
+        "Europe/Bucharest",
+        "Egypt",
+        "Europe/Chisinau",
+        "Europe/Tiraspol",
+        "Asia/Hebron",
+        "Asia/Gaza",
+        "Europe/Helsinki",
+        "Europe/Mariehamn",
+        "Europe/Kyiv",
+        "Europe/Uzhgorod",
+        "Europe/Zaporozhye",
+        "Europe/Kiev",
+        "Asia/Nicosia",
+        "Asia/Famagusta",
+        "Europe/Nicosia",
+        "Europe/Riga",
+        "Europe/Sofia",
+        "Europe/Tallinn",
+        "Europe/Vilnius",
+        "Asia/Jerusalem",
+        "Israel",
+        "Asia/Tel_Aviv",
+        "Europe/Minsk",
+        "Europe/Kirov",
+        "Europe/Volgograd",
+        "W-SU",
+        "Europe/Simferopol",
+        "Europe/Istanbul",
+        "Turkey",
+        "Asia/Istanbul",
+        "Asia/Tehran",
+        "Iran",
+        "Asia/Yerevan",
+        "Asia/Tbilisi",
+        "Asia/Muscat",
+        "Indian/Mahe",
+        "Indian/Reunion",
+        "Indian/Mauritius",
+        "Europe/Samara",
+        "Europe/Astrakhan",
+        "Europe/Saratov",
+        "Europe/Ulyanovsk",
+        "Asia/Kabul",
+        "Indian/Kerguelen",
+        "Asia/Aqtau",
+        "Asia/Aqtobe",
+        "Asia/Atyrau",
+        "Asia/Oral",
+        "Asia/Qostanay",
+        "Asia/Qyzylorda",
+        "Indian/Maldives",
+        "Antarctica/Mawson",
+        "Antarctica/Vostok",
+        "Asia/Dushanbe",
+        "Asia/Ashgabat",
+        "Asia/Ashkhabad",
+        "Asia/Samarkand",
+        "Asia/Yekaterinburg",
+        "Asia/Colombo",
+        "Asia/Kolkata",
+        "Asia/Kathmandu",
+        "Asia/Katmandu",
+        "Asia/Dacca",
+        "Asia/Thimphu",
+        "Asia/Thimbu",
+        "Asia/Urumqi",
+        "Asia/Kashgar",
+        "Indian/Chagos",
+        "Asia/Bishkek",
+        "Asia/Omsk",
+        "Indian/Cocos",
+        "Asia/Yangon",
+        "Asia/Rangoon",
+        "Indian/Christmas",
+        "Antarctica/Davis",
+        "Asia/Hovd",
+        "Asia/Phnom_Penh",
+        "Asia/Vientiane",
+        "Asia/Ho_Chi_Minh",
+        "Asia/Saigon",
+        "Asia/Novosibirsk",
+        "Asia/Barnaul",
+        "Asia/Krasnoyarsk",
+        "Asia/Novokuznetsk",
+        "Asia/Tomsk",
+        "Asia/Pontianak",
+        "Antarctica/Casey",
+        "Australia/Perth",
+        "Australia/West",
+        "Asia/Brunei",
+        "Asia/Makassar",
+        "Asia/Ujung_Pandang",
+        "Asia/Macau",
+        "Asia/Macao",
+        "PRC",
+        "Asia/Chongqing",
+        "Asia/Harbin",
+        "Asia/Chungking",
+        "Asia/Hong_Kong",
+        "Hongkong",
+        "Asia/Irkutsk",
+        "Asia/Kuala_Lumpur",
+        "Asia/Kuching",
+        "Asia/Manila",
+        "Singapore",
+        "Asia/Taipei",
+        "ROC",
+        "Asia/Ulaanbaatar",
+        "Asia/Choibalsan",
+        "Asia/Ulan_Bator",
+        "Australia/Eucla",
+        "Asia/Jayapura",
+        "Japan",
+        "Asia/Pyongyang",
+        "ROK",
+        "Pacific/Palau",
+        "Asia/Dili",
+        "Asia/Chita",
+        "Asia/Khandyga",
+        "Asia/Yakutsk",
+        "Australia/Adelaide",
+        "Australia/Broken_Hill",
+        "Australia/South",
+        "Australia/Yancowinna",
+        "Australia/Darwin",
+        "Australia/North",
+        "Australia/Lindeman",
+        "Australia/Queensland",
+        "Antarctica/Macquarie",
+        "Australia/Hobart",
+        "Australia/Melbourne",
+        "Australia/Tasmania",
+        "Australia/Currie",
+        "Australia/Victoria",
+        "Australia/ACT",
+        "Australia/NSW",
+        "Australia/Canberra",
+        "Pacific/Saipan",
+        "Pacific/Chuuk",
+        "Antarctica/DumontDUrville",
+        "Pacific/Port_Moresby",
+        "Pacific/Yap",
+        "Pacific/Truk",
+        "Asia/Vladivostok",
+        "Asia/Ust-Nera",
+        "Australia/Lord_Howe",
+        "Australia/LHI",
+        "Pacific/Bougainville",
+        "Pacific/Kosrae",
+        "Pacific/Pohnpei",
+        "Pacific/Norfolk",
+        "Asia/Sakhalin",
+        "Asia/Magadan",
+        "Asia/Srednekolymsk",
+        "Pacific/Guadalcanal",
+        "Pacific/Ponape",
+        "Pacific/Efate",
+        "Pacific/Tarawa",
+        "Pacific/Funafuti",
+        "Pacific/Majuro",
+        "Pacific/Wake",
+        "Pacific/Wallis",
+        "Asia/Kamchatka",
+        "Asia/Anadyr",
+        "Pacific/Kwajalein",
+        "Kwajalein",
+        "Pacific/Nauru",
+        "NZ",
+        "Antarctica/McMurdo",
+        "Antarctica/South_Pole",
+        "Pacific/Chatham",
+        "NZ-CHAT",
+        "Pacific/Kanton",
+        "Pacific/Enderbury",
+        "Pacific/Apia",
+        "Pacific/Fakaofo",
+        "Pacific/Tongatapu",
+        "Pacific/Kiritimati",
+        "Etc/GMT-14",
+        "Etc/GMT-13",
+        "Etc/GMT-12",
+        "Etc/GMT-11",
+        "Etc/GMT-10",
+        "Etc/GMT-9",
+        "Etc/GMT-8",
+        "Etc/GMT-7",
+        "Etc/GMT-6",
+        "Etc/GMT-5",
+        "Etc/GMT-4",
+        "Etc/GMT-3",
+        "Etc/GMT-2",
+        "Etc/GMT-1",
+        "Etc/GMT",
+        "Etc/GMT+1",
+        "Etc/GMT+2",
+        "Etc/GMT+3",
+        "Etc/GMT+4",
+        "Etc/GMT+5",
+        "Etc/GMT+6",
+        "Etc/GMT+7",
+        "Etc/GMT+8",
+        "Etc/GMT+9",
+        "Etc/GMT+10",
+        "Etc/GMT+11",
+        "Etc/GMT+12"
+      ]
+    },
+    "public.enum_app_cards_schedule_recurrence_type": {
+      "name": "enum_app_cards_schedule_recurrence_type",
+      "schema": "public",
+      "values": [
+        "DAILY",
+        "WEEKLY",
+        "MONTHLY"
+      ]
+    },
+    "public.enum_app_cards_status": {
+      "name": "enum_app_cards_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "published"
+      ]
+    },
+    "public.enum__app_cards_v_version_schedule_weekdays": {
+      "name": "enum__app_cards_v_version_schedule_weekdays",
+      "schema": "public",
+      "values": [
+        "MO",
+        "TU",
+        "WE",
+        "TH",
+        "FR",
+        "SA",
+        "SU"
+      ]
+    },
+    "public.enum__app_cards_v_version_target_sections": {
+      "name": "enum__app_cards_v_version_target_sections",
+      "schema": "public",
+      "values": [
+        "hero",
+        "highlights",
+        "lectures"
+      ]
+    },
+    "public.enum__app_cards_v_version_timings": {
+      "name": "enum__app_cards_v_version_timings",
+      "schema": "public",
+      "values": [
+        "morning",
+        "afternoon",
+        "evening",
+        "night"
+      ]
+    },
+    "public.enum__app_cards_v_version_type": {
+      "name": "enum__app_cards_v_version_type",
+      "schema": "public",
+      "values": [
+        "standard",
+        "event"
+      ]
+    },
+    "public.enum__app_cards_v_version_default_destination": {
+      "name": "enum__app_cards_v_version_default_destination",
+      "schema": "public",
+      "values": [
+        "page",
+        "lecture",
+        "album",
+        "meditation",
+        "url"
+      ]
+    },
+    "public.enum__app_cards_v_version_default_aspect_ratio": {
+      "name": "enum__app_cards_v_version_default_aspect_ratio",
+      "schema": "public",
+      "values": [
+        "square",
+        "flexible"
+      ]
+    },
+    "public.enum__app_cards_v_version_default_text_color": {
+      "name": "enum__app_cards_v_version_default_text_color",
+      "schema": "public",
+      "values": [
+        "black",
+        "white"
+      ]
+    },
+    "public.enum__app_cards_v_version_default_alignment": {
+      "name": "enum__app_cards_v_version_default_alignment",
+      "schema": "public",
+      "values": [
+        "left",
+        "center"
+      ]
+    },
+    "public.enum__app_cards_v_version_starting_soon_destination": {
+      "name": "enum__app_cards_v_version_starting_soon_destination",
+      "schema": "public",
+      "values": [
+        "page",
+        "lecture",
+        "album",
+        "meditation",
+        "url"
+      ]
+    },
+    "public.enum__app_cards_v_version_starting_soon_aspect_ratio": {
+      "name": "enum__app_cards_v_version_starting_soon_aspect_ratio",
+      "schema": "public",
+      "values": [
+        "square",
+        "flexible"
+      ]
+    },
+    "public.enum__app_cards_v_version_starting_soon_text_color": {
+      "name": "enum__app_cards_v_version_starting_soon_text_color",
+      "schema": "public",
+      "values": [
+        "black",
+        "white"
+      ]
+    },
+    "public.enum__app_cards_v_version_starting_soon_alignment": {
+      "name": "enum__app_cards_v_version_starting_soon_alignment",
+      "schema": "public",
+      "values": [
+        "left",
+        "center"
+      ]
+    },
+    "public.enum__app_cards_v_version_live_now_destination": {
+      "name": "enum__app_cards_v_version_live_now_destination",
+      "schema": "public",
+      "values": [
+        "page",
+        "lecture",
+        "album",
+        "meditation",
+        "url"
+      ]
+    },
+    "public.enum__app_cards_v_version_live_now_aspect_ratio": {
+      "name": "enum__app_cards_v_version_live_now_aspect_ratio",
+      "schema": "public",
+      "values": [
+        "square",
+        "flexible"
+      ]
+    },
+    "public.enum__app_cards_v_version_live_now_text_color": {
+      "name": "enum__app_cards_v_version_live_now_text_color",
+      "schema": "public",
+      "values": [
+        "black",
+        "white"
+      ]
+    },
+    "public.enum__app_cards_v_version_live_now_alignment": {
+      "name": "enum__app_cards_v_version_live_now_alignment",
+      "schema": "public",
+      "values": [
+        "left",
+        "center"
+      ]
+    },
+    "public.enum__app_cards_v_version_schedule_firstdate_tz": {
+      "name": "enum__app_cards_v_version_schedule_firstdate_tz",
+      "schema": "public",
+      "values": [
+        "UTC",
+        "Pacific/Midway",
+        "Pacific/Niue",
+        "Pacific/Honolulu",
+        "Pacific/Rarotonga",
+        "America/Anchorage",
+        "Pacific/Gambier",
+        "America/Los_Angeles",
+        "America/Tijuana",
+        "America/Denver",
+        "America/Phoenix",
+        "America/Chicago",
+        "America/Guatemala",
+        "America/New_York",
+        "America/Bogota",
+        "America/Caracas",
+        "America/Santiago",
+        "America/Buenos_Aires",
+        "America/Sao_Paulo",
+        "Atlantic/South_Georgia",
+        "Atlantic/Azores",
+        "Atlantic/Cape_Verde",
+        "Europe/London",
+        "Europe/Berlin",
+        "Africa/Lagos",
+        "Europe/Athens",
+        "Africa/Cairo",
+        "Europe/Moscow",
+        "Asia/Riyadh",
+        "Asia/Dubai",
+        "Asia/Baku",
+        "Asia/Karachi",
+        "Asia/Tashkent",
+        "Asia/Calcutta",
+        "Asia/Dhaka",
+        "Asia/Almaty",
+        "Asia/Jakarta",
+        "Asia/Bangkok",
+        "Asia/Shanghai",
+        "Asia/Singapore",
+        "Asia/Tokyo",
+        "Asia/Seoul",
+        "Australia/Brisbane",
+        "Australia/Sydney",
+        "Pacific/Guam",
+        "Pacific/Noumea",
+        "Pacific/Auckland",
+        "Pacific/Fiji",
+        "Pacific/Pago_Pago",
+        "US/Samoa",
+        "Pacific/Samoa",
+        "US/Hawaii",
+        "Pacific/Johnston",
+        "HST",
+        "Pacific/Tahiti",
+        "Pacific/Marquesas",
+        "America/Adak",
+        "US/Aleutian",
+        "America/Atka",
+        "America/Juneau",
+        "America/Metlakatla",
+        "America/Nome",
+        "America/Sitka",
+        "America/Yakutat",
+        "US/Alaska",
+        "Pacific/Pitcairn",
+        "America/Hermosillo",
+        "America/Mazatlan",
+        "Mexico/BajaSur",
+        "MST",
+        "US/Arizona",
+        "America/Creston",
+        "US/Pacific",
+        "PST8PDT",
+        "Mexico/BajaNorte",
+        "America/Ensenada",
+        "America/Santa_Isabel",
+        "America/Vancouver",
+        "Canada/Pacific",
+        "America/Whitehorse",
+        "America/Dawson",
+        "America/Dawson_Creek",
+        "America/Fort_Nelson",
+        "Canada/Yukon",
+        "America/Belize",
+        "America/Managua",
+        "America/Mexico_City",
+        "America/Bahia_Banderas",
+        "America/Chihuahua",
+        "America/Merida",
+        "America/Monterrey",
+        "Mexico/General",
+        "America/Costa_Rica",
+        "America/El_Salvador",
+        "America/Regina",
+        "America/Swift_Current",
+        "Canada/Saskatchewan",
+        "America/Tegucigalpa",
+        "Pacific/Easter",
+        "Chile/EasterIsland",
+        "Pacific/Galapagos",
+        "America/Edmonton",
+        "America/Cambridge_Bay",
+        "America/Inuvik",
+        "Canada/Mountain",
+        "America/Yellowknife",
+        "America/Ciudad_Juarez",
+        "America/Boise",
+        "MST7MDT",
+        "Navajo",
+        "US/Mountain",
+        "America/Shiprock",
+        "America/Rio_Branco",
+        "America/Eirunepe",
+        "Brazil/Acre",
+        "America/Porto_Acre",
+        "America/Indiana/Knox",
+        "America/Indiana/Tell_City",
+        "America/Menominee",
+        "America/North_Dakota/Beulah",
+        "America/North_Dakota/Center",
+        "America/North_Dakota/New_Salem",
+        "CST6CDT",
+        "US/Central",
+        "US/Indiana-Starke",
+        "America/Knox_IN",
+        "America/Matamoros",
+        "America/Ojinaga",
+        "America/Winnipeg",
+        "America/Rankin_Inlet",
+        "America/Resolute",
+        "Canada/Central",
+        "America/Rainy_River",
+        "America/Atikokan",
+        "America/Cancun",
+        "America/Cayman",
+        "America/Jamaica",
+        "Jamaica",
+        "America/Panama",
+        "EST",
+        "America/Coral_Harbour",
+        "America/Guayaquil",
+        "America/Lima",
+        "America/Manaus",
+        "America/Boa_Vista",
+        "America/Campo_Grande",
+        "America/Cuiaba",
+        "America/Porto_Velho",
+        "Brazil/West",
+        "America/St_Kitts",
+        "America/Blanc-Sablon",
+        "America/Montserrat",
+        "America/Barbados",
+        "America/Port_of_Spain",
+        "America/Martinique",
+        "America/St_Lucia",
+        "America/St_Barthelemy",
+        "America/St_Vincent",
+        "America/Kralendijk",
+        "America/Guadeloupe",
+        "America/Marigot",
+        "America/Aruba",
+        "America/Lower_Princes",
+        "America/Tortola",
+        "America/Dominica",
+        "America/St_Thomas",
+        "America/Grenada",
+        "America/Antigua",
+        "America/Puerto_Rico",
+        "America/Virgin",
+        "America/Anguilla",
+        "America/Curacao",
+        "America/Santo_Domingo",
+        "America/La_Paz",
+        "Chile/Continental",
+        "America/Havana",
+        "Cuba",
+        "America/Nassau",
+        "America/Detroit",
+        "America/Indiana/Indianapolis",
+        "America/Indiana/Marengo",
+        "America/Indiana/Petersburg",
+        "America/Indiana/Vevay",
+        "America/Indiana/Vincennes",
+        "America/Indiana/Winamac",
+        "America/Kentucky/Louisville",
+        "America/Kentucky/Monticello",
+        "US/Michigan",
+        "US/East-Indiana",
+        "America/Indianapolis",
+        "America/Fort_Wayne",
+        "America/Louisville",
+        "EST5EDT",
+        "US/Eastern",
+        "America/Port-au-Prince",
+        "America/Grand_Turk",
+        "America/Toronto",
+        "America/Iqaluit",
+        "America/Pangnirtung",
+        "Canada/Eastern",
+        "America/Montreal",
+        "America/Nipigon",
+        "America/Thunder_Bay",
+        "America/Guyana",
+        "America/Argentina/Buenos_Aires",
+        "America/Argentina/Catamarca",
+        "America/Argentina/Cordoba",
+        "America/Argentina/Jujuy",
+        "America/Argentina/La_Rioja",
+        "America/Argentina/Mendoza",
+        "America/Argentina/Rio_Gallegos",
+        "America/Argentina/Salta",
+        "America/Argentina/San_Juan",
+        "America/Argentina/San_Luis",
+        "America/Argentina/Tucuman",
+        "America/Argentina/Ushuaia",
+        "America/Catamarca",
+        "America/Argentina/ComodRivadavia",
+        "America/Cordoba",
+        "America/Rosario",
+        "America/Jujuy",
+        "America/Mendoza",
+        "America/Halifax",
+        "America/Glace_Bay",
+        "America/Goose_Bay",
+        "America/Moncton",
+        "Canada/Atlantic",
+        "Atlantic/Bermuda",
+        "America/Thule",
+        "America/Araguaina",
+        "America/Bahia",
+        "America/Belem",
+        "America/Fortaleza",
+        "America/Maceio",
+        "America/Recife",
+        "America/Santarem",
+        "Brazil/East",
+        "Antarctica/Palmer",
+        "Antarctica/Rothera",
+        "America/Punta_Arenas",
+        "America/Coyhaique",
+        "Atlantic/Stanley",
+        "America/Cayenne",
+        "America/Asuncion",
+        "America/Paramaribo",
+        "America/Montevideo",
+        "America/St_Johns",
+        "Canada/Newfoundland",
+        "America/Noronha",
+        "Brazil/DeNoronha",
+        "America/Miquelon",
+        "America/Nuuk",
+        "America/Scoresbysund",
+        "America/Godthab",
+        "Africa/Abidjan",
+        "Iceland",
+        "Africa/Accra",
+        "Africa/Bamako",
+        "Africa/Banjul",
+        "Africa/Conakry",
+        "Africa/Dakar",
+        "Africa/Freetown",
+        "Africa/Lome",
+        "Africa/Nouakchott",
+        "Africa/Ouagadougou",
+        "Atlantic/Reykjavik",
+        "Atlantic/St_Helena",
+        "Africa/Timbuktu",
+        "Africa/Bissau",
+        "America/Danmarkshavn",
+        "Africa/Monrovia",
+        "Africa/Sao_Tome",
+        "Africa/Algiers",
+        "Africa/Tunis",
+        "Europe/Isle_of_Man",
+        "Europe/Dublin",
+        "Eire",
+        "GB",
+        "GB-Eire",
+        "Europe/Guernsey",
+        "Europe/Jersey",
+        "Europe/Belfast",
+        "Africa/Bangui",
+        "Africa/Malabo",
+        "Africa/Brazzaville",
+        "Africa/Porto-Novo",
+        "Africa/Douala",
+        "Africa/Kinshasa",
+        "Africa/Libreville",
+        "Africa/Luanda",
+        "Africa/Niamey",
+        "Africa/Ndjamena",
+        "Africa/Casablanca",
+        "Africa/El_Aaiun",
+        "Atlantic/Canary",
+        "Europe/Lisbon",
+        "Atlantic/Madeira",
+        "Portugal",
+        "WET",
+        "Atlantic/Faroe",
+        "Atlantic/Faeroe",
+        "Africa/Bujumbura",
+        "Africa/Gaborone",
+        "Africa/Harare",
+        "Africa/Juba",
+        "Africa/Khartoum",
+        "Africa/Kigali",
+        "Africa/Blantyre",
+        "Africa/Lubumbashi",
+        "Africa/Lusaka",
+        "Africa/Maputo",
+        "Africa/Windhoek",
+        "Europe/Andorra",
+        "Europe/Belgrade",
+        "Europe/Ljubljana",
+        "Europe/Podgorica",
+        "Europe/Sarajevo",
+        "Europe/Skopje",
+        "Europe/Zagreb",
+        "Europe/Busingen",
+        "Arctic/Longyearbyen",
+        "Europe/Copenhagen",
+        "Europe/Oslo",
+        "Europe/Stockholm",
+        "Atlantic/Jan_Mayen",
+        "Europe/Bratislava",
+        "Europe/Brussels",
+        "CET",
+        "MET",
+        "Europe/Amsterdam",
+        "Europe/Luxembourg",
+        "Europe/Budapest",
+        "Europe/Gibraltar",
+        "Europe/Madrid",
+        "Africa/Ceuta",
+        "Europe/Monaco",
+        "Europe/Paris",
+        "Europe/Prague",
+        "Europe/Rome",
+        "Europe/San_Marino",
+        "Europe/Vatican",
+        "Europe/Malta",
+        "Europe/Tirane",
+        "Europe/Vaduz",
+        "Europe/Vienna",
+        "Europe/Warsaw",
+        "Poland",
+        "Europe/Zurich",
+        "Europe/Kaliningrad",
+        "Africa/Tripoli",
+        "Libya",
+        "Antarctica/Troll",
+        "Africa/Johannesburg",
+        "Africa/Maseru",
+        "Africa/Mbabane",
+        "Asia/Kuwait",
+        "Asia/Bahrain",
+        "Asia/Baghdad",
+        "Asia/Qatar",
+        "Antarctica/Syowa",
+        "Asia/Aden",
+        "Asia/Amman",
+        "Asia/Damascus",
+        "Africa/Addis_Ababa",
+        "Indian/Antananarivo",
+        "Africa/Asmara",
+        "Africa/Dar_es_Salaam",
+        "Africa/Djibouti",
+        "Africa/Kampala",
+        "Indian/Mayotte",
+        "Africa/Mogadishu",
+        "Indian/Comoro",
+        "Africa/Nairobi",
+        "Africa/Asmera",
+        "EET",
+        "Asia/Beirut",
+        "Europe/Bucharest",
+        "Egypt",
+        "Europe/Chisinau",
+        "Europe/Tiraspol",
+        "Asia/Hebron",
+        "Asia/Gaza",
+        "Europe/Helsinki",
+        "Europe/Mariehamn",
+        "Europe/Kyiv",
+        "Europe/Uzhgorod",
+        "Europe/Zaporozhye",
+        "Europe/Kiev",
+        "Asia/Nicosia",
+        "Asia/Famagusta",
+        "Europe/Nicosia",
+        "Europe/Riga",
+        "Europe/Sofia",
+        "Europe/Tallinn",
+        "Europe/Vilnius",
+        "Asia/Jerusalem",
+        "Israel",
+        "Asia/Tel_Aviv",
+        "Europe/Minsk",
+        "Europe/Kirov",
+        "Europe/Volgograd",
+        "W-SU",
+        "Europe/Simferopol",
+        "Europe/Istanbul",
+        "Turkey",
+        "Asia/Istanbul",
+        "Asia/Tehran",
+        "Iran",
+        "Asia/Yerevan",
+        "Asia/Tbilisi",
+        "Asia/Muscat",
+        "Indian/Mahe",
+        "Indian/Reunion",
+        "Indian/Mauritius",
+        "Europe/Samara",
+        "Europe/Astrakhan",
+        "Europe/Saratov",
+        "Europe/Ulyanovsk",
+        "Asia/Kabul",
+        "Indian/Kerguelen",
+        "Asia/Aqtau",
+        "Asia/Aqtobe",
+        "Asia/Atyrau",
+        "Asia/Oral",
+        "Asia/Qostanay",
+        "Asia/Qyzylorda",
+        "Indian/Maldives",
+        "Antarctica/Mawson",
+        "Antarctica/Vostok",
+        "Asia/Dushanbe",
+        "Asia/Ashgabat",
+        "Asia/Ashkhabad",
+        "Asia/Samarkand",
+        "Asia/Yekaterinburg",
+        "Asia/Colombo",
+        "Asia/Kolkata",
+        "Asia/Kathmandu",
+        "Asia/Katmandu",
+        "Asia/Dacca",
+        "Asia/Thimphu",
+        "Asia/Thimbu",
+        "Asia/Urumqi",
+        "Asia/Kashgar",
+        "Indian/Chagos",
+        "Asia/Bishkek",
+        "Asia/Omsk",
+        "Indian/Cocos",
+        "Asia/Yangon",
+        "Asia/Rangoon",
+        "Indian/Christmas",
+        "Antarctica/Davis",
+        "Asia/Hovd",
+        "Asia/Phnom_Penh",
+        "Asia/Vientiane",
+        "Asia/Ho_Chi_Minh",
+        "Asia/Saigon",
+        "Asia/Novosibirsk",
+        "Asia/Barnaul",
+        "Asia/Krasnoyarsk",
+        "Asia/Novokuznetsk",
+        "Asia/Tomsk",
+        "Asia/Pontianak",
+        "Antarctica/Casey",
+        "Australia/Perth",
+        "Australia/West",
+        "Asia/Brunei",
+        "Asia/Makassar",
+        "Asia/Ujung_Pandang",
+        "Asia/Macau",
+        "Asia/Macao",
+        "PRC",
+        "Asia/Chongqing",
+        "Asia/Harbin",
+        "Asia/Chungking",
+        "Asia/Hong_Kong",
+        "Hongkong",
+        "Asia/Irkutsk",
+        "Asia/Kuala_Lumpur",
+        "Asia/Kuching",
+        "Asia/Manila",
+        "Singapore",
+        "Asia/Taipei",
+        "ROC",
+        "Asia/Ulaanbaatar",
+        "Asia/Choibalsan",
+        "Asia/Ulan_Bator",
+        "Australia/Eucla",
+        "Asia/Jayapura",
+        "Japan",
+        "Asia/Pyongyang",
+        "ROK",
+        "Pacific/Palau",
+        "Asia/Dili",
+        "Asia/Chita",
+        "Asia/Khandyga",
+        "Asia/Yakutsk",
+        "Australia/Adelaide",
+        "Australia/Broken_Hill",
+        "Australia/South",
+        "Australia/Yancowinna",
+        "Australia/Darwin",
+        "Australia/North",
+        "Australia/Lindeman",
+        "Australia/Queensland",
+        "Antarctica/Macquarie",
+        "Australia/Hobart",
+        "Australia/Melbourne",
+        "Australia/Tasmania",
+        "Australia/Currie",
+        "Australia/Victoria",
+        "Australia/ACT",
+        "Australia/NSW",
+        "Australia/Canberra",
+        "Pacific/Saipan",
+        "Pacific/Chuuk",
+        "Antarctica/DumontDUrville",
+        "Pacific/Port_Moresby",
+        "Pacific/Yap",
+        "Pacific/Truk",
+        "Asia/Vladivostok",
+        "Asia/Ust-Nera",
+        "Australia/Lord_Howe",
+        "Australia/LHI",
+        "Pacific/Bougainville",
+        "Pacific/Kosrae",
+        "Pacific/Pohnpei",
+        "Pacific/Norfolk",
+        "Asia/Sakhalin",
+        "Asia/Magadan",
+        "Asia/Srednekolymsk",
+        "Pacific/Guadalcanal",
+        "Pacific/Ponape",
+        "Pacific/Efate",
+        "Pacific/Tarawa",
+        "Pacific/Funafuti",
+        "Pacific/Majuro",
+        "Pacific/Wake",
+        "Pacific/Wallis",
+        "Asia/Kamchatka",
+        "Asia/Anadyr",
+        "Pacific/Kwajalein",
+        "Kwajalein",
+        "Pacific/Nauru",
+        "NZ",
+        "Antarctica/McMurdo",
+        "Antarctica/South_Pole",
+        "Pacific/Chatham",
+        "NZ-CHAT",
+        "Pacific/Kanton",
+        "Pacific/Enderbury",
+        "Pacific/Apia",
+        "Pacific/Fakaofo",
+        "Pacific/Tongatapu",
+        "Pacific/Kiritimati",
+        "Etc/GMT-14",
+        "Etc/GMT-13",
+        "Etc/GMT-12",
+        "Etc/GMT-11",
+        "Etc/GMT-10",
+        "Etc/GMT-9",
+        "Etc/GMT-8",
+        "Etc/GMT-7",
+        "Etc/GMT-6",
+        "Etc/GMT-5",
+        "Etc/GMT-4",
+        "Etc/GMT-3",
+        "Etc/GMT-2",
+        "Etc/GMT-1",
+        "Etc/GMT",
+        "Etc/GMT+1",
+        "Etc/GMT+2",
+        "Etc/GMT+3",
+        "Etc/GMT+4",
+        "Etc/GMT+5",
+        "Etc/GMT+6",
+        "Etc/GMT+7",
+        "Etc/GMT+8",
+        "Etc/GMT+9",
+        "Etc/GMT+10",
+        "Etc/GMT+11",
+        "Etc/GMT+12"
+      ]
+    },
+    "public.enum__app_cards_v_version_schedule_recurrence_type": {
+      "name": "enum__app_cards_v_version_schedule_recurrence_type",
+      "schema": "public",
+      "values": [
+        "DAILY",
+        "WEEKLY",
+        "MONTHLY"
+      ]
+    },
+    "public.enum__app_cards_v_version_status": {
+      "name": "enum__app_cards_v_version_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "published"
+      ]
+    },
+    "public.enum__app_cards_v_published_locale": {
+      "name": "enum__app_cards_v_published_locale",
+      "schema": "public",
+      "values": [
+        "en",
+        "es",
+        "de",
+        "it",
+        "fr",
+        "ru",
+        "ro",
+        "cs",
+        "uk",
+        "el",
+        "hy",
+        "pl",
+        "pt-BR",
+        "fa",
+        "bg",
+        "tr",
+        "en-AU"
+      ]
+    },
+    "public.enum_regions_level": {
+      "name": "enum_regions_level",
+      "schema": "public",
+      "values": [
+        "country",
+        "region",
+        "city",
+        "center"
+      ]
+    },
+    "public.enum_events_languages": {
+      "name": "enum_events_languages",
+      "schema": "public",
+      "values": [
+        "ab",
+        "aa",
+        "af",
+        "ak",
+        "sq",
+        "am",
+        "ar",
+        "an",
+        "hy",
+        "as",
+        "av",
+        "ae",
+        "ay",
+        "az",
+        "bm",
+        "ba",
+        "eu",
+        "be",
+        "bn",
+        "bi",
+        "bs",
+        "br",
+        "bg",
+        "my",
+        "ca",
+        "ch",
+        "ce",
+        "ny",
+        "zh",
+        "cv",
+        "kw",
+        "co",
+        "cr",
+        "hr",
+        "cs",
+        "da",
+        "dv",
+        "nl",
+        "dz",
+        "en",
+        "eo",
+        "et",
+        "ee",
+        "fo",
+        "fj",
+        "fi",
+        "fr",
+        "ff",
+        "gl",
+        "lg",
+        "ka",
+        "de",
+        "el",
+        "gn",
+        "gu",
+        "ht",
+        "ha",
+        "he",
+        "hz",
+        "hi",
+        "ho",
+        "hu",
+        "is",
+        "io",
+        "ig",
+        "id",
+        "ia",
+        "ie",
+        "iu",
+        "ik",
+        "ga",
+        "it",
+        "ja",
+        "jv",
+        "kl",
+        "kn",
+        "kr",
+        "ks",
+        "kk",
+        "km",
+        "ki",
+        "rw",
+        "rn",
+        "kv",
+        "kg",
+        "ko",
+        "ku",
+        "kj",
+        "ky",
+        "lo",
+        "la",
+        "lv",
+        "li",
+        "ln",
+        "lt",
+        "lu",
+        "lb",
+        "mk",
+        "mg",
+        "ms",
+        "ml",
+        "mt",
+        "gv",
+        "mi",
+        "mr",
+        "mh",
+        "mn",
+        "na",
+        "nv",
+        "ng",
+        "ne",
+        "nd",
+        "se",
+        "no",
+        "nb",
+        "nn",
+        "ii",
+        "oc",
+        "oj",
+        "cu",
+        "or",
+        "om",
+        "os",
+        "pi",
+        "pa",
+        "ps",
+        "fa",
+        "pl",
+        "pt",
+        "qu",
+        "ro",
+        "rm",
+        "ru",
+        "sm",
+        "sg",
+        "sa",
+        "sc",
+        "gd",
+        "sr",
+        "sn",
+        "sd",
+        "si",
+        "sk",
+        "sl",
+        "so",
+        "nr",
+        "st",
+        "es",
+        "su",
+        "sw",
+        "ss",
+        "sv",
+        "tl",
+        "ty",
+        "tg",
+        "ta",
+        "tt",
+        "te",
+        "th",
+        "bo",
+        "ti",
+        "to",
+        "ts",
+        "tn",
+        "tr",
+        "tk",
+        "tw",
+        "uk",
+        "ur",
+        "ug",
+        "uz",
+        "ve",
+        "vi",
+        "vo",
+        "wa",
+        "cy",
+        "fy",
+        "wo",
+        "xh",
+        "yi",
+        "yo",
+        "za",
+        "zu"
+      ]
+    },
+    "public.enum_events_schedule_weekdays": {
+      "name": "enum_events_schedule_weekdays",
+      "schema": "public",
+      "values": [
+        "MO",
+        "TU",
+        "WE",
+        "TH",
+        "FR",
+        "SA",
+        "SU"
+      ]
+    },
+    "public.enum_events_schedule_firstdate_tz": {
+      "name": "enum_events_schedule_firstdate_tz",
+      "schema": "public",
+      "values": [
+        "UTC",
+        "Pacific/Midway",
+        "Pacific/Niue",
+        "Pacific/Honolulu",
+        "Pacific/Rarotonga",
+        "America/Anchorage",
+        "Pacific/Gambier",
+        "America/Los_Angeles",
+        "America/Tijuana",
+        "America/Denver",
+        "America/Phoenix",
+        "America/Chicago",
+        "America/Guatemala",
+        "America/New_York",
+        "America/Bogota",
+        "America/Caracas",
+        "America/Santiago",
+        "America/Buenos_Aires",
+        "America/Sao_Paulo",
+        "Atlantic/South_Georgia",
+        "Atlantic/Azores",
+        "Atlantic/Cape_Verde",
+        "Europe/London",
+        "Europe/Berlin",
+        "Africa/Lagos",
+        "Europe/Athens",
+        "Africa/Cairo",
+        "Europe/Moscow",
+        "Asia/Riyadh",
+        "Asia/Dubai",
+        "Asia/Baku",
+        "Asia/Karachi",
+        "Asia/Tashkent",
+        "Asia/Calcutta",
+        "Asia/Dhaka",
+        "Asia/Almaty",
+        "Asia/Jakarta",
+        "Asia/Bangkok",
+        "Asia/Shanghai",
+        "Asia/Singapore",
+        "Asia/Tokyo",
+        "Asia/Seoul",
+        "Australia/Brisbane",
+        "Australia/Sydney",
+        "Pacific/Guam",
+        "Pacific/Noumea",
+        "Pacific/Auckland",
+        "Pacific/Fiji",
+        "Pacific/Pago_Pago",
+        "US/Samoa",
+        "Pacific/Samoa",
+        "US/Hawaii",
+        "Pacific/Johnston",
+        "HST",
+        "Pacific/Tahiti",
+        "Pacific/Marquesas",
+        "America/Adak",
+        "US/Aleutian",
+        "America/Atka",
+        "America/Juneau",
+        "America/Metlakatla",
+        "America/Nome",
+        "America/Sitka",
+        "America/Yakutat",
+        "US/Alaska",
+        "Pacific/Pitcairn",
+        "America/Hermosillo",
+        "America/Mazatlan",
+        "Mexico/BajaSur",
+        "MST",
+        "US/Arizona",
+        "America/Creston",
+        "US/Pacific",
+        "PST8PDT",
+        "Mexico/BajaNorte",
+        "America/Ensenada",
+        "America/Santa_Isabel",
+        "America/Vancouver",
+        "Canada/Pacific",
+        "America/Whitehorse",
+        "America/Dawson",
+        "America/Dawson_Creek",
+        "America/Fort_Nelson",
+        "Canada/Yukon",
+        "America/Belize",
+        "America/Managua",
+        "America/Mexico_City",
+        "America/Bahia_Banderas",
+        "America/Chihuahua",
+        "America/Merida",
+        "America/Monterrey",
+        "Mexico/General",
+        "America/Costa_Rica",
+        "America/El_Salvador",
+        "America/Regina",
+        "America/Swift_Current",
+        "Canada/Saskatchewan",
+        "America/Tegucigalpa",
+        "Pacific/Easter",
+        "Chile/EasterIsland",
+        "Pacific/Galapagos",
+        "America/Edmonton",
+        "America/Cambridge_Bay",
+        "America/Inuvik",
+        "Canada/Mountain",
+        "America/Yellowknife",
+        "America/Ciudad_Juarez",
+        "America/Boise",
+        "MST7MDT",
+        "Navajo",
+        "US/Mountain",
+        "America/Shiprock",
+        "America/Rio_Branco",
+        "America/Eirunepe",
+        "Brazil/Acre",
+        "America/Porto_Acre",
+        "America/Indiana/Knox",
+        "America/Indiana/Tell_City",
+        "America/Menominee",
+        "America/North_Dakota/Beulah",
+        "America/North_Dakota/Center",
+        "America/North_Dakota/New_Salem",
+        "CST6CDT",
+        "US/Central",
+        "US/Indiana-Starke",
+        "America/Knox_IN",
+        "America/Matamoros",
+        "America/Ojinaga",
+        "America/Winnipeg",
+        "America/Rankin_Inlet",
+        "America/Resolute",
+        "Canada/Central",
+        "America/Rainy_River",
+        "America/Atikokan",
+        "America/Cancun",
+        "America/Cayman",
+        "America/Jamaica",
+        "Jamaica",
+        "America/Panama",
+        "EST",
+        "America/Coral_Harbour",
+        "America/Guayaquil",
+        "America/Lima",
+        "America/Manaus",
+        "America/Boa_Vista",
+        "America/Campo_Grande",
+        "America/Cuiaba",
+        "America/Porto_Velho",
+        "Brazil/West",
+        "America/St_Kitts",
+        "America/Blanc-Sablon",
+        "America/Montserrat",
+        "America/Barbados",
+        "America/Port_of_Spain",
+        "America/Martinique",
+        "America/St_Lucia",
+        "America/St_Barthelemy",
+        "America/St_Vincent",
+        "America/Kralendijk",
+        "America/Guadeloupe",
+        "America/Marigot",
+        "America/Aruba",
+        "America/Lower_Princes",
+        "America/Tortola",
+        "America/Dominica",
+        "America/St_Thomas",
+        "America/Grenada",
+        "America/Antigua",
+        "America/Puerto_Rico",
+        "America/Virgin",
+        "America/Anguilla",
+        "America/Curacao",
+        "America/Santo_Domingo",
+        "America/La_Paz",
+        "Chile/Continental",
+        "America/Havana",
+        "Cuba",
+        "America/Nassau",
+        "America/Detroit",
+        "America/Indiana/Indianapolis",
+        "America/Indiana/Marengo",
+        "America/Indiana/Petersburg",
+        "America/Indiana/Vevay",
+        "America/Indiana/Vincennes",
+        "America/Indiana/Winamac",
+        "America/Kentucky/Louisville",
+        "America/Kentucky/Monticello",
+        "US/Michigan",
+        "US/East-Indiana",
+        "America/Indianapolis",
+        "America/Fort_Wayne",
+        "America/Louisville",
+        "EST5EDT",
+        "US/Eastern",
+        "America/Port-au-Prince",
+        "America/Grand_Turk",
+        "America/Toronto",
+        "America/Iqaluit",
+        "America/Pangnirtung",
+        "Canada/Eastern",
+        "America/Montreal",
+        "America/Nipigon",
+        "America/Thunder_Bay",
+        "America/Guyana",
+        "America/Argentina/Buenos_Aires",
+        "America/Argentina/Catamarca",
+        "America/Argentina/Cordoba",
+        "America/Argentina/Jujuy",
+        "America/Argentina/La_Rioja",
+        "America/Argentina/Mendoza",
+        "America/Argentina/Rio_Gallegos",
+        "America/Argentina/Salta",
+        "America/Argentina/San_Juan",
+        "America/Argentina/San_Luis",
+        "America/Argentina/Tucuman",
+        "America/Argentina/Ushuaia",
+        "America/Catamarca",
+        "America/Argentina/ComodRivadavia",
+        "America/Cordoba",
+        "America/Rosario",
+        "America/Jujuy",
+        "America/Mendoza",
+        "America/Halifax",
+        "America/Glace_Bay",
+        "America/Goose_Bay",
+        "America/Moncton",
+        "Canada/Atlantic",
+        "Atlantic/Bermuda",
+        "America/Thule",
+        "America/Araguaina",
+        "America/Bahia",
+        "America/Belem",
+        "America/Fortaleza",
+        "America/Maceio",
+        "America/Recife",
+        "America/Santarem",
+        "Brazil/East",
+        "Antarctica/Palmer",
+        "Antarctica/Rothera",
+        "America/Punta_Arenas",
+        "America/Coyhaique",
+        "Atlantic/Stanley",
+        "America/Cayenne",
+        "America/Asuncion",
+        "America/Paramaribo",
+        "America/Montevideo",
+        "America/St_Johns",
+        "Canada/Newfoundland",
+        "America/Noronha",
+        "Brazil/DeNoronha",
+        "America/Miquelon",
+        "America/Nuuk",
+        "America/Scoresbysund",
+        "America/Godthab",
+        "Africa/Abidjan",
+        "Iceland",
+        "Africa/Accra",
+        "Africa/Bamako",
+        "Africa/Banjul",
+        "Africa/Conakry",
+        "Africa/Dakar",
+        "Africa/Freetown",
+        "Africa/Lome",
+        "Africa/Nouakchott",
+        "Africa/Ouagadougou",
+        "Atlantic/Reykjavik",
+        "Atlantic/St_Helena",
+        "Africa/Timbuktu",
+        "Africa/Bissau",
+        "America/Danmarkshavn",
+        "Africa/Monrovia",
+        "Africa/Sao_Tome",
+        "Africa/Algiers",
+        "Africa/Tunis",
+        "Europe/Isle_of_Man",
+        "Europe/Dublin",
+        "Eire",
+        "GB",
+        "GB-Eire",
+        "Europe/Guernsey",
+        "Europe/Jersey",
+        "Europe/Belfast",
+        "Africa/Bangui",
+        "Africa/Malabo",
+        "Africa/Brazzaville",
+        "Africa/Porto-Novo",
+        "Africa/Douala",
+        "Africa/Kinshasa",
+        "Africa/Libreville",
+        "Africa/Luanda",
+        "Africa/Niamey",
+        "Africa/Ndjamena",
+        "Africa/Casablanca",
+        "Africa/El_Aaiun",
+        "Atlantic/Canary",
+        "Europe/Lisbon",
+        "Atlantic/Madeira",
+        "Portugal",
+        "WET",
+        "Atlantic/Faroe",
+        "Atlantic/Faeroe",
+        "Africa/Bujumbura",
+        "Africa/Gaborone",
+        "Africa/Harare",
+        "Africa/Juba",
+        "Africa/Khartoum",
+        "Africa/Kigali",
+        "Africa/Blantyre",
+        "Africa/Lubumbashi",
+        "Africa/Lusaka",
+        "Africa/Maputo",
+        "Africa/Windhoek",
+        "Europe/Andorra",
+        "Europe/Belgrade",
+        "Europe/Ljubljana",
+        "Europe/Podgorica",
+        "Europe/Sarajevo",
+        "Europe/Skopje",
+        "Europe/Zagreb",
+        "Europe/Busingen",
+        "Arctic/Longyearbyen",
+        "Europe/Copenhagen",
+        "Europe/Oslo",
+        "Europe/Stockholm",
+        "Atlantic/Jan_Mayen",
+        "Europe/Bratislava",
+        "Europe/Brussels",
+        "CET",
+        "MET",
+        "Europe/Amsterdam",
+        "Europe/Luxembourg",
+        "Europe/Budapest",
+        "Europe/Gibraltar",
+        "Europe/Madrid",
+        "Africa/Ceuta",
+        "Europe/Monaco",
+        "Europe/Paris",
+        "Europe/Prague",
+        "Europe/Rome",
+        "Europe/San_Marino",
+        "Europe/Vatican",
+        "Europe/Malta",
+        "Europe/Tirane",
+        "Europe/Vaduz",
+        "Europe/Vienna",
+        "Europe/Warsaw",
+        "Poland",
+        "Europe/Zurich",
+        "Europe/Kaliningrad",
+        "Africa/Tripoli",
+        "Libya",
+        "Antarctica/Troll",
+        "Africa/Johannesburg",
+        "Africa/Maseru",
+        "Africa/Mbabane",
+        "Asia/Kuwait",
+        "Asia/Bahrain",
+        "Asia/Baghdad",
+        "Asia/Qatar",
+        "Antarctica/Syowa",
+        "Asia/Aden",
+        "Asia/Amman",
+        "Asia/Damascus",
+        "Africa/Addis_Ababa",
+        "Indian/Antananarivo",
+        "Africa/Asmara",
+        "Africa/Dar_es_Salaam",
+        "Africa/Djibouti",
+        "Africa/Kampala",
+        "Indian/Mayotte",
+        "Africa/Mogadishu",
+        "Indian/Comoro",
+        "Africa/Nairobi",
+        "Africa/Asmera",
+        "EET",
+        "Asia/Beirut",
+        "Europe/Bucharest",
+        "Egypt",
+        "Europe/Chisinau",
+        "Europe/Tiraspol",
+        "Asia/Hebron",
+        "Asia/Gaza",
+        "Europe/Helsinki",
+        "Europe/Mariehamn",
+        "Europe/Kyiv",
+        "Europe/Uzhgorod",
+        "Europe/Zaporozhye",
+        "Europe/Kiev",
+        "Asia/Nicosia",
+        "Asia/Famagusta",
+        "Europe/Nicosia",
+        "Europe/Riga",
+        "Europe/Sofia",
+        "Europe/Tallinn",
+        "Europe/Vilnius",
+        "Asia/Jerusalem",
+        "Israel",
+        "Asia/Tel_Aviv",
+        "Europe/Minsk",
+        "Europe/Kirov",
+        "Europe/Volgograd",
+        "W-SU",
+        "Europe/Simferopol",
+        "Europe/Istanbul",
+        "Turkey",
+        "Asia/Istanbul",
+        "Asia/Tehran",
+        "Iran",
+        "Asia/Yerevan",
+        "Asia/Tbilisi",
+        "Asia/Muscat",
+        "Indian/Mahe",
+        "Indian/Reunion",
+        "Indian/Mauritius",
+        "Europe/Samara",
+        "Europe/Astrakhan",
+        "Europe/Saratov",
+        "Europe/Ulyanovsk",
+        "Asia/Kabul",
+        "Indian/Kerguelen",
+        "Asia/Aqtau",
+        "Asia/Aqtobe",
+        "Asia/Atyrau",
+        "Asia/Oral",
+        "Asia/Qostanay",
+        "Asia/Qyzylorda",
+        "Indian/Maldives",
+        "Antarctica/Mawson",
+        "Antarctica/Vostok",
+        "Asia/Dushanbe",
+        "Asia/Ashgabat",
+        "Asia/Ashkhabad",
+        "Asia/Samarkand",
+        "Asia/Yekaterinburg",
+        "Asia/Colombo",
+        "Asia/Kolkata",
+        "Asia/Kathmandu",
+        "Asia/Katmandu",
+        "Asia/Dacca",
+        "Asia/Thimphu",
+        "Asia/Thimbu",
+        "Asia/Urumqi",
+        "Asia/Kashgar",
+        "Indian/Chagos",
+        "Asia/Bishkek",
+        "Asia/Omsk",
+        "Indian/Cocos",
+        "Asia/Yangon",
+        "Asia/Rangoon",
+        "Indian/Christmas",
+        "Antarctica/Davis",
+        "Asia/Hovd",
+        "Asia/Phnom_Penh",
+        "Asia/Vientiane",
+        "Asia/Ho_Chi_Minh",
+        "Asia/Saigon",
+        "Asia/Novosibirsk",
+        "Asia/Barnaul",
+        "Asia/Krasnoyarsk",
+        "Asia/Novokuznetsk",
+        "Asia/Tomsk",
+        "Asia/Pontianak",
+        "Antarctica/Casey",
+        "Australia/Perth",
+        "Australia/West",
+        "Asia/Brunei",
+        "Asia/Makassar",
+        "Asia/Ujung_Pandang",
+        "Asia/Macau",
+        "Asia/Macao",
+        "PRC",
+        "Asia/Chongqing",
+        "Asia/Harbin",
+        "Asia/Chungking",
+        "Asia/Hong_Kong",
+        "Hongkong",
+        "Asia/Irkutsk",
+        "Asia/Kuala_Lumpur",
+        "Asia/Kuching",
+        "Asia/Manila",
+        "Singapore",
+        "Asia/Taipei",
+        "ROC",
+        "Asia/Ulaanbaatar",
+        "Asia/Choibalsan",
+        "Asia/Ulan_Bator",
+        "Australia/Eucla",
+        "Asia/Jayapura",
+        "Japan",
+        "Asia/Pyongyang",
+        "ROK",
+        "Pacific/Palau",
+        "Asia/Dili",
+        "Asia/Chita",
+        "Asia/Khandyga",
+        "Asia/Yakutsk",
+        "Australia/Adelaide",
+        "Australia/Broken_Hill",
+        "Australia/South",
+        "Australia/Yancowinna",
+        "Australia/Darwin",
+        "Australia/North",
+        "Australia/Lindeman",
+        "Australia/Queensland",
+        "Antarctica/Macquarie",
+        "Australia/Hobart",
+        "Australia/Melbourne",
+        "Australia/Tasmania",
+        "Australia/Currie",
+        "Australia/Victoria",
+        "Australia/ACT",
+        "Australia/NSW",
+        "Australia/Canberra",
+        "Pacific/Saipan",
+        "Pacific/Chuuk",
+        "Antarctica/DumontDUrville",
+        "Pacific/Port_Moresby",
+        "Pacific/Yap",
+        "Pacific/Truk",
+        "Asia/Vladivostok",
+        "Asia/Ust-Nera",
+        "Australia/Lord_Howe",
+        "Australia/LHI",
+        "Pacific/Bougainville",
+        "Pacific/Kosrae",
+        "Pacific/Pohnpei",
+        "Pacific/Norfolk",
+        "Asia/Sakhalin",
+        "Asia/Magadan",
+        "Asia/Srednekolymsk",
+        "Pacific/Guadalcanal",
+        "Pacific/Ponape",
+        "Pacific/Efate",
+        "Pacific/Tarawa",
+        "Pacific/Funafuti",
+        "Pacific/Majuro",
+        "Pacific/Wake",
+        "Pacific/Wallis",
+        "Asia/Kamchatka",
+        "Asia/Anadyr",
+        "Pacific/Kwajalein",
+        "Kwajalein",
+        "Pacific/Nauru",
+        "NZ",
+        "Antarctica/McMurdo",
+        "Antarctica/South_Pole",
+        "Pacific/Chatham",
+        "NZ-CHAT",
+        "Pacific/Kanton",
+        "Pacific/Enderbury",
+        "Pacific/Apia",
+        "Pacific/Fakaofo",
+        "Pacific/Tongatapu",
+        "Pacific/Kiritimati",
+        "Etc/GMT-14",
+        "Etc/GMT-13",
+        "Etc/GMT-12",
+        "Etc/GMT-11",
+        "Etc/GMT-10",
+        "Etc/GMT-9",
+        "Etc/GMT-8",
+        "Etc/GMT-7",
+        "Etc/GMT-6",
+        "Etc/GMT-5",
+        "Etc/GMT-4",
+        "Etc/GMT-3",
+        "Etc/GMT-2",
+        "Etc/GMT-1",
+        "Etc/GMT",
+        "Etc/GMT+1",
+        "Etc/GMT+2",
+        "Etc/GMT+3",
+        "Etc/GMT+4",
+        "Etc/GMT+5",
+        "Etc/GMT+6",
+        "Etc/GMT+7",
+        "Etc/GMT+8",
+        "Etc/GMT+9",
+        "Etc/GMT+10",
+        "Etc/GMT+11",
+        "Etc/GMT+12"
+      ]
+    },
+    "public.enum_events_schedule_recurrence_type": {
+      "name": "enum_events_schedule_recurrence_type",
+      "schema": "public",
+      "values": [
+        "DAILY",
+        "WEEKLY",
+        "MONTHLY"
+      ]
+    },
+    "public.enum_events_schedule_monthly_mode": {
+      "name": "enum_events_schedule_monthly_mode",
+      "schema": "public",
+      "values": [
+        "date",
+        "weekday"
+      ]
+    },
+    "public.enum_events_schedule_week_number": {
+      "name": "enum_events_schedule_week_number",
+      "schema": "public",
+      "values": [
+        "1",
+        "2",
+        "3",
+        "4",
+        "-1"
+      ]
+    },
+    "public.enum_events_schedule_weekday_of_month": {
+      "name": "enum_events_schedule_weekday_of_month",
+      "schema": "public",
+      "values": [
+        "MO",
+        "TU",
+        "WE",
+        "TH",
+        "FR",
+        "SA",
+        "SU"
+      ]
+    },
+    "public.enum_events_schedule_ending_type": {
+      "name": "enum_events_schedule_ending_type",
+      "schema": "public",
+      "values": [
+        "count",
+        "until"
+      ]
+    },
+    "public.enum_events_event_type": {
+      "name": "enum_events_event_type",
+      "schema": "public",
+      "values": [
+        "offline",
+        "online"
+      ]
+    },
+    "public.enum_events_registration_mode": {
+      "name": "enum_events_registration_mode",
+      "schema": "public",
+      "values": [
+        "sahaj-atlas",
+        "external"
+      ]
+    },
+    "public.enum_events_verification_stage": {
+      "name": "enum_events_verification_stage",
+      "schema": "public",
+      "values": [
+        "verified",
+        "reminded",
+        "escalated",
+        "urgent",
+        "expired",
+        "finished"
+      ]
+    },
+    "public.enum_events_status": {
+      "name": "enum_events_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "published"
+      ]
+    },
+    "public.enum__events_v_version_languages": {
+      "name": "enum__events_v_version_languages",
+      "schema": "public",
+      "values": [
+        "ab",
+        "aa",
+        "af",
+        "ak",
+        "sq",
+        "am",
+        "ar",
+        "an",
+        "hy",
+        "as",
+        "av",
+        "ae",
+        "ay",
+        "az",
+        "bm",
+        "ba",
+        "eu",
+        "be",
+        "bn",
+        "bi",
+        "bs",
+        "br",
+        "bg",
+        "my",
+        "ca",
+        "ch",
+        "ce",
+        "ny",
+        "zh",
+        "cv",
+        "kw",
+        "co",
+        "cr",
+        "hr",
+        "cs",
+        "da",
+        "dv",
+        "nl",
+        "dz",
+        "en",
+        "eo",
+        "et",
+        "ee",
+        "fo",
+        "fj",
+        "fi",
+        "fr",
+        "ff",
+        "gl",
+        "lg",
+        "ka",
+        "de",
+        "el",
+        "gn",
+        "gu",
+        "ht",
+        "ha",
+        "he",
+        "hz",
+        "hi",
+        "ho",
+        "hu",
+        "is",
+        "io",
+        "ig",
+        "id",
+        "ia",
+        "ie",
+        "iu",
+        "ik",
+        "ga",
+        "it",
+        "ja",
+        "jv",
+        "kl",
+        "kn",
+        "kr",
+        "ks",
+        "kk",
+        "km",
+        "ki",
+        "rw",
+        "rn",
+        "kv",
+        "kg",
+        "ko",
+        "ku",
+        "kj",
+        "ky",
+        "lo",
+        "la",
+        "lv",
+        "li",
+        "ln",
+        "lt",
+        "lu",
+        "lb",
+        "mk",
+        "mg",
+        "ms",
+        "ml",
+        "mt",
+        "gv",
+        "mi",
+        "mr",
+        "mh",
+        "mn",
+        "na",
+        "nv",
+        "ng",
+        "ne",
+        "nd",
+        "se",
+        "no",
+        "nb",
+        "nn",
+        "ii",
+        "oc",
+        "oj",
+        "cu",
+        "or",
+        "om",
+        "os",
+        "pi",
+        "pa",
+        "ps",
+        "fa",
+        "pl",
+        "pt",
+        "qu",
+        "ro",
+        "rm",
+        "ru",
+        "sm",
+        "sg",
+        "sa",
+        "sc",
+        "gd",
+        "sr",
+        "sn",
+        "sd",
+        "si",
+        "sk",
+        "sl",
+        "so",
+        "nr",
+        "st",
+        "es",
+        "su",
+        "sw",
+        "ss",
+        "sv",
+        "tl",
+        "ty",
+        "tg",
+        "ta",
+        "tt",
+        "te",
+        "th",
+        "bo",
+        "ti",
+        "to",
+        "ts",
+        "tn",
+        "tr",
+        "tk",
+        "tw",
+        "uk",
+        "ur",
+        "ug",
+        "uz",
+        "ve",
+        "vi",
+        "vo",
+        "wa",
+        "cy",
+        "fy",
+        "wo",
+        "xh",
+        "yi",
+        "yo",
+        "za",
+        "zu"
+      ]
+    },
+    "public.enum__events_v_version_schedule_weekdays": {
+      "name": "enum__events_v_version_schedule_weekdays",
+      "schema": "public",
+      "values": [
+        "MO",
+        "TU",
+        "WE",
+        "TH",
+        "FR",
+        "SA",
+        "SU"
+      ]
+    },
+    "public.enum__events_v_version_schedule_firstdate_tz": {
+      "name": "enum__events_v_version_schedule_firstdate_tz",
+      "schema": "public",
+      "values": [
+        "UTC",
+        "Pacific/Midway",
+        "Pacific/Niue",
+        "Pacific/Honolulu",
+        "Pacific/Rarotonga",
+        "America/Anchorage",
+        "Pacific/Gambier",
+        "America/Los_Angeles",
+        "America/Tijuana",
+        "America/Denver",
+        "America/Phoenix",
+        "America/Chicago",
+        "America/Guatemala",
+        "America/New_York",
+        "America/Bogota",
+        "America/Caracas",
+        "America/Santiago",
+        "America/Buenos_Aires",
+        "America/Sao_Paulo",
+        "Atlantic/South_Georgia",
+        "Atlantic/Azores",
+        "Atlantic/Cape_Verde",
+        "Europe/London",
+        "Europe/Berlin",
+        "Africa/Lagos",
+        "Europe/Athens",
+        "Africa/Cairo",
+        "Europe/Moscow",
+        "Asia/Riyadh",
+        "Asia/Dubai",
+        "Asia/Baku",
+        "Asia/Karachi",
+        "Asia/Tashkent",
+        "Asia/Calcutta",
+        "Asia/Dhaka",
+        "Asia/Almaty",
+        "Asia/Jakarta",
+        "Asia/Bangkok",
+        "Asia/Shanghai",
+        "Asia/Singapore",
+        "Asia/Tokyo",
+        "Asia/Seoul",
+        "Australia/Brisbane",
+        "Australia/Sydney",
+        "Pacific/Guam",
+        "Pacific/Noumea",
+        "Pacific/Auckland",
+        "Pacific/Fiji",
+        "Pacific/Pago_Pago",
+        "US/Samoa",
+        "Pacific/Samoa",
+        "US/Hawaii",
+        "Pacific/Johnston",
+        "HST",
+        "Pacific/Tahiti",
+        "Pacific/Marquesas",
+        "America/Adak",
+        "US/Aleutian",
+        "America/Atka",
+        "America/Juneau",
+        "America/Metlakatla",
+        "America/Nome",
+        "America/Sitka",
+        "America/Yakutat",
+        "US/Alaska",
+        "Pacific/Pitcairn",
+        "America/Hermosillo",
+        "America/Mazatlan",
+        "Mexico/BajaSur",
+        "MST",
+        "US/Arizona",
+        "America/Creston",
+        "US/Pacific",
+        "PST8PDT",
+        "Mexico/BajaNorte",
+        "America/Ensenada",
+        "America/Santa_Isabel",
+        "America/Vancouver",
+        "Canada/Pacific",
+        "America/Whitehorse",
+        "America/Dawson",
+        "America/Dawson_Creek",
+        "America/Fort_Nelson",
+        "Canada/Yukon",
+        "America/Belize",
+        "America/Managua",
+        "America/Mexico_City",
+        "America/Bahia_Banderas",
+        "America/Chihuahua",
+        "America/Merida",
+        "America/Monterrey",
+        "Mexico/General",
+        "America/Costa_Rica",
+        "America/El_Salvador",
+        "America/Regina",
+        "America/Swift_Current",
+        "Canada/Saskatchewan",
+        "America/Tegucigalpa",
+        "Pacific/Easter",
+        "Chile/EasterIsland",
+        "Pacific/Galapagos",
+        "America/Edmonton",
+        "America/Cambridge_Bay",
+        "America/Inuvik",
+        "Canada/Mountain",
+        "America/Yellowknife",
+        "America/Ciudad_Juarez",
+        "America/Boise",
+        "MST7MDT",
+        "Navajo",
+        "US/Mountain",
+        "America/Shiprock",
+        "America/Rio_Branco",
+        "America/Eirunepe",
+        "Brazil/Acre",
+        "America/Porto_Acre",
+        "America/Indiana/Knox",
+        "America/Indiana/Tell_City",
+        "America/Menominee",
+        "America/North_Dakota/Beulah",
+        "America/North_Dakota/Center",
+        "America/North_Dakota/New_Salem",
+        "CST6CDT",
+        "US/Central",
+        "US/Indiana-Starke",
+        "America/Knox_IN",
+        "America/Matamoros",
+        "America/Ojinaga",
+        "America/Winnipeg",
+        "America/Rankin_Inlet",
+        "America/Resolute",
+        "Canada/Central",
+        "America/Rainy_River",
+        "America/Atikokan",
+        "America/Cancun",
+        "America/Cayman",
+        "America/Jamaica",
+        "Jamaica",
+        "America/Panama",
+        "EST",
+        "America/Coral_Harbour",
+        "America/Guayaquil",
+        "America/Lima",
+        "America/Manaus",
+        "America/Boa_Vista",
+        "America/Campo_Grande",
+        "America/Cuiaba",
+        "America/Porto_Velho",
+        "Brazil/West",
+        "America/St_Kitts",
+        "America/Blanc-Sablon",
+        "America/Montserrat",
+        "America/Barbados",
+        "America/Port_of_Spain",
+        "America/Martinique",
+        "America/St_Lucia",
+        "America/St_Barthelemy",
+        "America/St_Vincent",
+        "America/Kralendijk",
+        "America/Guadeloupe",
+        "America/Marigot",
+        "America/Aruba",
+        "America/Lower_Princes",
+        "America/Tortola",
+        "America/Dominica",
+        "America/St_Thomas",
+        "America/Grenada",
+        "America/Antigua",
+        "America/Puerto_Rico",
+        "America/Virgin",
+        "America/Anguilla",
+        "America/Curacao",
+        "America/Santo_Domingo",
+        "America/La_Paz",
+        "Chile/Continental",
+        "America/Havana",
+        "Cuba",
+        "America/Nassau",
+        "America/Detroit",
+        "America/Indiana/Indianapolis",
+        "America/Indiana/Marengo",
+        "America/Indiana/Petersburg",
+        "America/Indiana/Vevay",
+        "America/Indiana/Vincennes",
+        "America/Indiana/Winamac",
+        "America/Kentucky/Louisville",
+        "America/Kentucky/Monticello",
+        "US/Michigan",
+        "US/East-Indiana",
+        "America/Indianapolis",
+        "America/Fort_Wayne",
+        "America/Louisville",
+        "EST5EDT",
+        "US/Eastern",
+        "America/Port-au-Prince",
+        "America/Grand_Turk",
+        "America/Toronto",
+        "America/Iqaluit",
+        "America/Pangnirtung",
+        "Canada/Eastern",
+        "America/Montreal",
+        "America/Nipigon",
+        "America/Thunder_Bay",
+        "America/Guyana",
+        "America/Argentina/Buenos_Aires",
+        "America/Argentina/Catamarca",
+        "America/Argentina/Cordoba",
+        "America/Argentina/Jujuy",
+        "America/Argentina/La_Rioja",
+        "America/Argentina/Mendoza",
+        "America/Argentina/Rio_Gallegos",
+        "America/Argentina/Salta",
+        "America/Argentina/San_Juan",
+        "America/Argentina/San_Luis",
+        "America/Argentina/Tucuman",
+        "America/Argentina/Ushuaia",
+        "America/Catamarca",
+        "America/Argentina/ComodRivadavia",
+        "America/Cordoba",
+        "America/Rosario",
+        "America/Jujuy",
+        "America/Mendoza",
+        "America/Halifax",
+        "America/Glace_Bay",
+        "America/Goose_Bay",
+        "America/Moncton",
+        "Canada/Atlantic",
+        "Atlantic/Bermuda",
+        "America/Thule",
+        "America/Araguaina",
+        "America/Bahia",
+        "America/Belem",
+        "America/Fortaleza",
+        "America/Maceio",
+        "America/Recife",
+        "America/Santarem",
+        "Brazil/East",
+        "Antarctica/Palmer",
+        "Antarctica/Rothera",
+        "America/Punta_Arenas",
+        "America/Coyhaique",
+        "Atlantic/Stanley",
+        "America/Cayenne",
+        "America/Asuncion",
+        "America/Paramaribo",
+        "America/Montevideo",
+        "America/St_Johns",
+        "Canada/Newfoundland",
+        "America/Noronha",
+        "Brazil/DeNoronha",
+        "America/Miquelon",
+        "America/Nuuk",
+        "America/Scoresbysund",
+        "America/Godthab",
+        "Africa/Abidjan",
+        "Iceland",
+        "Africa/Accra",
+        "Africa/Bamako",
+        "Africa/Banjul",
+        "Africa/Conakry",
+        "Africa/Dakar",
+        "Africa/Freetown",
+        "Africa/Lome",
+        "Africa/Nouakchott",
+        "Africa/Ouagadougou",
+        "Atlantic/Reykjavik",
+        "Atlantic/St_Helena",
+        "Africa/Timbuktu",
+        "Africa/Bissau",
+        "America/Danmarkshavn",
+        "Africa/Monrovia",
+        "Africa/Sao_Tome",
+        "Africa/Algiers",
+        "Africa/Tunis",
+        "Europe/Isle_of_Man",
+        "Europe/Dublin",
+        "Eire",
+        "GB",
+        "GB-Eire",
+        "Europe/Guernsey",
+        "Europe/Jersey",
+        "Europe/Belfast",
+        "Africa/Bangui",
+        "Africa/Malabo",
+        "Africa/Brazzaville",
+        "Africa/Porto-Novo",
+        "Africa/Douala",
+        "Africa/Kinshasa",
+        "Africa/Libreville",
+        "Africa/Luanda",
+        "Africa/Niamey",
+        "Africa/Ndjamena",
+        "Africa/Casablanca",
+        "Africa/El_Aaiun",
+        "Atlantic/Canary",
+        "Europe/Lisbon",
+        "Atlantic/Madeira",
+        "Portugal",
+        "WET",
+        "Atlantic/Faroe",
+        "Atlantic/Faeroe",
+        "Africa/Bujumbura",
+        "Africa/Gaborone",
+        "Africa/Harare",
+        "Africa/Juba",
+        "Africa/Khartoum",
+        "Africa/Kigali",
+        "Africa/Blantyre",
+        "Africa/Lubumbashi",
+        "Africa/Lusaka",
+        "Africa/Maputo",
+        "Africa/Windhoek",
+        "Europe/Andorra",
+        "Europe/Belgrade",
+        "Europe/Ljubljana",
+        "Europe/Podgorica",
+        "Europe/Sarajevo",
+        "Europe/Skopje",
+        "Europe/Zagreb",
+        "Europe/Busingen",
+        "Arctic/Longyearbyen",
+        "Europe/Copenhagen",
+        "Europe/Oslo",
+        "Europe/Stockholm",
+        "Atlantic/Jan_Mayen",
+        "Europe/Bratislava",
+        "Europe/Brussels",
+        "CET",
+        "MET",
+        "Europe/Amsterdam",
+        "Europe/Luxembourg",
+        "Europe/Budapest",
+        "Europe/Gibraltar",
+        "Europe/Madrid",
+        "Africa/Ceuta",
+        "Europe/Monaco",
+        "Europe/Paris",
+        "Europe/Prague",
+        "Europe/Rome",
+        "Europe/San_Marino",
+        "Europe/Vatican",
+        "Europe/Malta",
+        "Europe/Tirane",
+        "Europe/Vaduz",
+        "Europe/Vienna",
+        "Europe/Warsaw",
+        "Poland",
+        "Europe/Zurich",
+        "Europe/Kaliningrad",
+        "Africa/Tripoli",
+        "Libya",
+        "Antarctica/Troll",
+        "Africa/Johannesburg",
+        "Africa/Maseru",
+        "Africa/Mbabane",
+        "Asia/Kuwait",
+        "Asia/Bahrain",
+        "Asia/Baghdad",
+        "Asia/Qatar",
+        "Antarctica/Syowa",
+        "Asia/Aden",
+        "Asia/Amman",
+        "Asia/Damascus",
+        "Africa/Addis_Ababa",
+        "Indian/Antananarivo",
+        "Africa/Asmara",
+        "Africa/Dar_es_Salaam",
+        "Africa/Djibouti",
+        "Africa/Kampala",
+        "Indian/Mayotte",
+        "Africa/Mogadishu",
+        "Indian/Comoro",
+        "Africa/Nairobi",
+        "Africa/Asmera",
+        "EET",
+        "Asia/Beirut",
+        "Europe/Bucharest",
+        "Egypt",
+        "Europe/Chisinau",
+        "Europe/Tiraspol",
+        "Asia/Hebron",
+        "Asia/Gaza",
+        "Europe/Helsinki",
+        "Europe/Mariehamn",
+        "Europe/Kyiv",
+        "Europe/Uzhgorod",
+        "Europe/Zaporozhye",
+        "Europe/Kiev",
+        "Asia/Nicosia",
+        "Asia/Famagusta",
+        "Europe/Nicosia",
+        "Europe/Riga",
+        "Europe/Sofia",
+        "Europe/Tallinn",
+        "Europe/Vilnius",
+        "Asia/Jerusalem",
+        "Israel",
+        "Asia/Tel_Aviv",
+        "Europe/Minsk",
+        "Europe/Kirov",
+        "Europe/Volgograd",
+        "W-SU",
+        "Europe/Simferopol",
+        "Europe/Istanbul",
+        "Turkey",
+        "Asia/Istanbul",
+        "Asia/Tehran",
+        "Iran",
+        "Asia/Yerevan",
+        "Asia/Tbilisi",
+        "Asia/Muscat",
+        "Indian/Mahe",
+        "Indian/Reunion",
+        "Indian/Mauritius",
+        "Europe/Samara",
+        "Europe/Astrakhan",
+        "Europe/Saratov",
+        "Europe/Ulyanovsk",
+        "Asia/Kabul",
+        "Indian/Kerguelen",
+        "Asia/Aqtau",
+        "Asia/Aqtobe",
+        "Asia/Atyrau",
+        "Asia/Oral",
+        "Asia/Qostanay",
+        "Asia/Qyzylorda",
+        "Indian/Maldives",
+        "Antarctica/Mawson",
+        "Antarctica/Vostok",
+        "Asia/Dushanbe",
+        "Asia/Ashgabat",
+        "Asia/Ashkhabad",
+        "Asia/Samarkand",
+        "Asia/Yekaterinburg",
+        "Asia/Colombo",
+        "Asia/Kolkata",
+        "Asia/Kathmandu",
+        "Asia/Katmandu",
+        "Asia/Dacca",
+        "Asia/Thimphu",
+        "Asia/Thimbu",
+        "Asia/Urumqi",
+        "Asia/Kashgar",
+        "Indian/Chagos",
+        "Asia/Bishkek",
+        "Asia/Omsk",
+        "Indian/Cocos",
+        "Asia/Yangon",
+        "Asia/Rangoon",
+        "Indian/Christmas",
+        "Antarctica/Davis",
+        "Asia/Hovd",
+        "Asia/Phnom_Penh",
+        "Asia/Vientiane",
+        "Asia/Ho_Chi_Minh",
+        "Asia/Saigon",
+        "Asia/Novosibirsk",
+        "Asia/Barnaul",
+        "Asia/Krasnoyarsk",
+        "Asia/Novokuznetsk",
+        "Asia/Tomsk",
+        "Asia/Pontianak",
+        "Antarctica/Casey",
+        "Australia/Perth",
+        "Australia/West",
+        "Asia/Brunei",
+        "Asia/Makassar",
+        "Asia/Ujung_Pandang",
+        "Asia/Macau",
+        "Asia/Macao",
+        "PRC",
+        "Asia/Chongqing",
+        "Asia/Harbin",
+        "Asia/Chungking",
+        "Asia/Hong_Kong",
+        "Hongkong",
+        "Asia/Irkutsk",
+        "Asia/Kuala_Lumpur",
+        "Asia/Kuching",
+        "Asia/Manila",
+        "Singapore",
+        "Asia/Taipei",
+        "ROC",
+        "Asia/Ulaanbaatar",
+        "Asia/Choibalsan",
+        "Asia/Ulan_Bator",
+        "Australia/Eucla",
+        "Asia/Jayapura",
+        "Japan",
+        "Asia/Pyongyang",
+        "ROK",
+        "Pacific/Palau",
+        "Asia/Dili",
+        "Asia/Chita",
+        "Asia/Khandyga",
+        "Asia/Yakutsk",
+        "Australia/Adelaide",
+        "Australia/Broken_Hill",
+        "Australia/South",
+        "Australia/Yancowinna",
+        "Australia/Darwin",
+        "Australia/North",
+        "Australia/Lindeman",
+        "Australia/Queensland",
+        "Antarctica/Macquarie",
+        "Australia/Hobart",
+        "Australia/Melbourne",
+        "Australia/Tasmania",
+        "Australia/Currie",
+        "Australia/Victoria",
+        "Australia/ACT",
+        "Australia/NSW",
+        "Australia/Canberra",
+        "Pacific/Saipan",
+        "Pacific/Chuuk",
+        "Antarctica/DumontDUrville",
+        "Pacific/Port_Moresby",
+        "Pacific/Yap",
+        "Pacific/Truk",
+        "Asia/Vladivostok",
+        "Asia/Ust-Nera",
+        "Australia/Lord_Howe",
+        "Australia/LHI",
+        "Pacific/Bougainville",
+        "Pacific/Kosrae",
+        "Pacific/Pohnpei",
+        "Pacific/Norfolk",
+        "Asia/Sakhalin",
+        "Asia/Magadan",
+        "Asia/Srednekolymsk",
+        "Pacific/Guadalcanal",
+        "Pacific/Ponape",
+        "Pacific/Efate",
+        "Pacific/Tarawa",
+        "Pacific/Funafuti",
+        "Pacific/Majuro",
+        "Pacific/Wake",
+        "Pacific/Wallis",
+        "Asia/Kamchatka",
+        "Asia/Anadyr",
+        "Pacific/Kwajalein",
+        "Kwajalein",
+        "Pacific/Nauru",
+        "NZ",
+        "Antarctica/McMurdo",
+        "Antarctica/South_Pole",
+        "Pacific/Chatham",
+        "NZ-CHAT",
+        "Pacific/Kanton",
+        "Pacific/Enderbury",
+        "Pacific/Apia",
+        "Pacific/Fakaofo",
+        "Pacific/Tongatapu",
+        "Pacific/Kiritimati",
+        "Etc/GMT-14",
+        "Etc/GMT-13",
+        "Etc/GMT-12",
+        "Etc/GMT-11",
+        "Etc/GMT-10",
+        "Etc/GMT-9",
+        "Etc/GMT-8",
+        "Etc/GMT-7",
+        "Etc/GMT-6",
+        "Etc/GMT-5",
+        "Etc/GMT-4",
+        "Etc/GMT-3",
+        "Etc/GMT-2",
+        "Etc/GMT-1",
+        "Etc/GMT",
+        "Etc/GMT+1",
+        "Etc/GMT+2",
+        "Etc/GMT+3",
+        "Etc/GMT+4",
+        "Etc/GMT+5",
+        "Etc/GMT+6",
+        "Etc/GMT+7",
+        "Etc/GMT+8",
+        "Etc/GMT+9",
+        "Etc/GMT+10",
+        "Etc/GMT+11",
+        "Etc/GMT+12"
+      ]
+    },
+    "public.enum__events_v_version_schedule_recurrence_type": {
+      "name": "enum__events_v_version_schedule_recurrence_type",
+      "schema": "public",
+      "values": [
+        "DAILY",
+        "WEEKLY",
+        "MONTHLY"
+      ]
+    },
+    "public.enum__events_v_version_schedule_monthly_mode": {
+      "name": "enum__events_v_version_schedule_monthly_mode",
+      "schema": "public",
+      "values": [
+        "date",
+        "weekday"
+      ]
+    },
+    "public.enum__events_v_version_schedule_week_number": {
+      "name": "enum__events_v_version_schedule_week_number",
+      "schema": "public",
+      "values": [
+        "1",
+        "2",
+        "3",
+        "4",
+        "-1"
+      ]
+    },
+    "public.enum__events_v_version_schedule_weekday_of_month": {
+      "name": "enum__events_v_version_schedule_weekday_of_month",
+      "schema": "public",
+      "values": [
+        "MO",
+        "TU",
+        "WE",
+        "TH",
+        "FR",
+        "SA",
+        "SU"
+      ]
+    },
+    "public.enum__events_v_version_schedule_ending_type": {
+      "name": "enum__events_v_version_schedule_ending_type",
+      "schema": "public",
+      "values": [
+        "count",
+        "until"
+      ]
+    },
+    "public.enum__events_v_version_event_type": {
+      "name": "enum__events_v_version_event_type",
+      "schema": "public",
+      "values": [
+        "offline",
+        "online"
+      ]
+    },
+    "public.enum__events_v_version_registration_mode": {
+      "name": "enum__events_v_version_registration_mode",
+      "schema": "public",
+      "values": [
+        "sahaj-atlas",
+        "external"
+      ]
+    },
+    "public.enum__events_v_version_status": {
+      "name": "enum__events_v_version_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "published"
+      ]
+    },
+    "public.enum__events_v_published_locale": {
+      "name": "enum__events_v_published_locale",
+      "schema": "public",
+      "values": [
+        "en",
+        "es",
+        "de",
+        "it",
+        "fr",
+        "ru",
+        "ro",
+        "cs",
+        "uk",
+        "el",
+        "hy",
+        "pl",
+        "pt-BR",
+        "fa",
+        "bg",
+        "tr",
+        "en-AU"
+      ]
+    },
+    "public.enum_registrations_startingat_tz": {
+      "name": "enum_registrations_startingat_tz",
+      "schema": "public",
+      "values": [
+        "UTC",
+        "Pacific/Midway",
+        "Pacific/Niue",
+        "Pacific/Honolulu",
+        "Pacific/Rarotonga",
+        "America/Anchorage",
+        "Pacific/Gambier",
+        "America/Los_Angeles",
+        "America/Tijuana",
+        "America/Denver",
+        "America/Phoenix",
+        "America/Chicago",
+        "America/Guatemala",
+        "America/New_York",
+        "America/Bogota",
+        "America/Caracas",
+        "America/Santiago",
+        "America/Buenos_Aires",
+        "America/Sao_Paulo",
+        "Atlantic/South_Georgia",
+        "Atlantic/Azores",
+        "Atlantic/Cape_Verde",
+        "Europe/London",
+        "Europe/Berlin",
+        "Africa/Lagos",
+        "Europe/Athens",
+        "Africa/Cairo",
+        "Europe/Moscow",
+        "Asia/Riyadh",
+        "Asia/Dubai",
+        "Asia/Baku",
+        "Asia/Karachi",
+        "Asia/Tashkent",
+        "Asia/Calcutta",
+        "Asia/Dhaka",
+        "Asia/Almaty",
+        "Asia/Jakarta",
+        "Asia/Bangkok",
+        "Asia/Shanghai",
+        "Asia/Singapore",
+        "Asia/Tokyo",
+        "Asia/Seoul",
+        "Australia/Brisbane",
+        "Australia/Sydney",
+        "Pacific/Guam",
+        "Pacific/Noumea",
+        "Pacific/Auckland",
+        "Pacific/Fiji",
+        "Pacific/Pago_Pago",
+        "US/Samoa",
+        "Pacific/Samoa",
+        "US/Hawaii",
+        "Pacific/Johnston",
+        "HST",
+        "Pacific/Tahiti",
+        "Pacific/Marquesas",
+        "America/Adak",
+        "US/Aleutian",
+        "America/Atka",
+        "America/Juneau",
+        "America/Metlakatla",
+        "America/Nome",
+        "America/Sitka",
+        "America/Yakutat",
+        "US/Alaska",
+        "Pacific/Pitcairn",
+        "America/Hermosillo",
+        "America/Mazatlan",
+        "Mexico/BajaSur",
+        "MST",
+        "US/Arizona",
+        "America/Creston",
+        "US/Pacific",
+        "PST8PDT",
+        "Mexico/BajaNorte",
+        "America/Ensenada",
+        "America/Santa_Isabel",
+        "America/Vancouver",
+        "Canada/Pacific",
+        "America/Whitehorse",
+        "America/Dawson",
+        "America/Dawson_Creek",
+        "America/Fort_Nelson",
+        "Canada/Yukon",
+        "America/Belize",
+        "America/Managua",
+        "America/Mexico_City",
+        "America/Bahia_Banderas",
+        "America/Chihuahua",
+        "America/Merida",
+        "America/Monterrey",
+        "Mexico/General",
+        "America/Costa_Rica",
+        "America/El_Salvador",
+        "America/Regina",
+        "America/Swift_Current",
+        "Canada/Saskatchewan",
+        "America/Tegucigalpa",
+        "Pacific/Easter",
+        "Chile/EasterIsland",
+        "Pacific/Galapagos",
+        "America/Edmonton",
+        "America/Cambridge_Bay",
+        "America/Inuvik",
+        "Canada/Mountain",
+        "America/Yellowknife",
+        "America/Ciudad_Juarez",
+        "America/Boise",
+        "MST7MDT",
+        "Navajo",
+        "US/Mountain",
+        "America/Shiprock",
+        "America/Rio_Branco",
+        "America/Eirunepe",
+        "Brazil/Acre",
+        "America/Porto_Acre",
+        "America/Indiana/Knox",
+        "America/Indiana/Tell_City",
+        "America/Menominee",
+        "America/North_Dakota/Beulah",
+        "America/North_Dakota/Center",
+        "America/North_Dakota/New_Salem",
+        "CST6CDT",
+        "US/Central",
+        "US/Indiana-Starke",
+        "America/Knox_IN",
+        "America/Matamoros",
+        "America/Ojinaga",
+        "America/Winnipeg",
+        "America/Rankin_Inlet",
+        "America/Resolute",
+        "Canada/Central",
+        "America/Rainy_River",
+        "America/Atikokan",
+        "America/Cancun",
+        "America/Cayman",
+        "America/Jamaica",
+        "Jamaica",
+        "America/Panama",
+        "EST",
+        "America/Coral_Harbour",
+        "America/Guayaquil",
+        "America/Lima",
+        "America/Manaus",
+        "America/Boa_Vista",
+        "America/Campo_Grande",
+        "America/Cuiaba",
+        "America/Porto_Velho",
+        "Brazil/West",
+        "America/St_Kitts",
+        "America/Blanc-Sablon",
+        "America/Montserrat",
+        "America/Barbados",
+        "America/Port_of_Spain",
+        "America/Martinique",
+        "America/St_Lucia",
+        "America/St_Barthelemy",
+        "America/St_Vincent",
+        "America/Kralendijk",
+        "America/Guadeloupe",
+        "America/Marigot",
+        "America/Aruba",
+        "America/Lower_Princes",
+        "America/Tortola",
+        "America/Dominica",
+        "America/St_Thomas",
+        "America/Grenada",
+        "America/Antigua",
+        "America/Puerto_Rico",
+        "America/Virgin",
+        "America/Anguilla",
+        "America/Curacao",
+        "America/Santo_Domingo",
+        "America/La_Paz",
+        "Chile/Continental",
+        "America/Havana",
+        "Cuba",
+        "America/Nassau",
+        "America/Detroit",
+        "America/Indiana/Indianapolis",
+        "America/Indiana/Marengo",
+        "America/Indiana/Petersburg",
+        "America/Indiana/Vevay",
+        "America/Indiana/Vincennes",
+        "America/Indiana/Winamac",
+        "America/Kentucky/Louisville",
+        "America/Kentucky/Monticello",
+        "US/Michigan",
+        "US/East-Indiana",
+        "America/Indianapolis",
+        "America/Fort_Wayne",
+        "America/Louisville",
+        "EST5EDT",
+        "US/Eastern",
+        "America/Port-au-Prince",
+        "America/Grand_Turk",
+        "America/Toronto",
+        "America/Iqaluit",
+        "America/Pangnirtung",
+        "Canada/Eastern",
+        "America/Montreal",
+        "America/Nipigon",
+        "America/Thunder_Bay",
+        "America/Guyana",
+        "America/Argentina/Buenos_Aires",
+        "America/Argentina/Catamarca",
+        "America/Argentina/Cordoba",
+        "America/Argentina/Jujuy",
+        "America/Argentina/La_Rioja",
+        "America/Argentina/Mendoza",
+        "America/Argentina/Rio_Gallegos",
+        "America/Argentina/Salta",
+        "America/Argentina/San_Juan",
+        "America/Argentina/San_Luis",
+        "America/Argentina/Tucuman",
+        "America/Argentina/Ushuaia",
+        "America/Catamarca",
+        "America/Argentina/ComodRivadavia",
+        "America/Cordoba",
+        "America/Rosario",
+        "America/Jujuy",
+        "America/Mendoza",
+        "America/Halifax",
+        "America/Glace_Bay",
+        "America/Goose_Bay",
+        "America/Moncton",
+        "Canada/Atlantic",
+        "Atlantic/Bermuda",
+        "America/Thule",
+        "America/Araguaina",
+        "America/Bahia",
+        "America/Belem",
+        "America/Fortaleza",
+        "America/Maceio",
+        "America/Recife",
+        "America/Santarem",
+        "Brazil/East",
+        "Antarctica/Palmer",
+        "Antarctica/Rothera",
+        "America/Punta_Arenas",
+        "America/Coyhaique",
+        "Atlantic/Stanley",
+        "America/Cayenne",
+        "America/Asuncion",
+        "America/Paramaribo",
+        "America/Montevideo",
+        "America/St_Johns",
+        "Canada/Newfoundland",
+        "America/Noronha",
+        "Brazil/DeNoronha",
+        "America/Miquelon",
+        "America/Nuuk",
+        "America/Scoresbysund",
+        "America/Godthab",
+        "Africa/Abidjan",
+        "Iceland",
+        "Africa/Accra",
+        "Africa/Bamako",
+        "Africa/Banjul",
+        "Africa/Conakry",
+        "Africa/Dakar",
+        "Africa/Freetown",
+        "Africa/Lome",
+        "Africa/Nouakchott",
+        "Africa/Ouagadougou",
+        "Atlantic/Reykjavik",
+        "Atlantic/St_Helena",
+        "Africa/Timbuktu",
+        "Africa/Bissau",
+        "America/Danmarkshavn",
+        "Africa/Monrovia",
+        "Africa/Sao_Tome",
+        "Africa/Algiers",
+        "Africa/Tunis",
+        "Europe/Isle_of_Man",
+        "Europe/Dublin",
+        "Eire",
+        "GB",
+        "GB-Eire",
+        "Europe/Guernsey",
+        "Europe/Jersey",
+        "Europe/Belfast",
+        "Africa/Bangui",
+        "Africa/Malabo",
+        "Africa/Brazzaville",
+        "Africa/Porto-Novo",
+        "Africa/Douala",
+        "Africa/Kinshasa",
+        "Africa/Libreville",
+        "Africa/Luanda",
+        "Africa/Niamey",
+        "Africa/Ndjamena",
+        "Africa/Casablanca",
+        "Africa/El_Aaiun",
+        "Atlantic/Canary",
+        "Europe/Lisbon",
+        "Atlantic/Madeira",
+        "Portugal",
+        "WET",
+        "Atlantic/Faroe",
+        "Atlantic/Faeroe",
+        "Africa/Bujumbura",
+        "Africa/Gaborone",
+        "Africa/Harare",
+        "Africa/Juba",
+        "Africa/Khartoum",
+        "Africa/Kigali",
+        "Africa/Blantyre",
+        "Africa/Lubumbashi",
+        "Africa/Lusaka",
+        "Africa/Maputo",
+        "Africa/Windhoek",
+        "Europe/Andorra",
+        "Europe/Belgrade",
+        "Europe/Ljubljana",
+        "Europe/Podgorica",
+        "Europe/Sarajevo",
+        "Europe/Skopje",
+        "Europe/Zagreb",
+        "Europe/Busingen",
+        "Arctic/Longyearbyen",
+        "Europe/Copenhagen",
+        "Europe/Oslo",
+        "Europe/Stockholm",
+        "Atlantic/Jan_Mayen",
+        "Europe/Bratislava",
+        "Europe/Brussels",
+        "CET",
+        "MET",
+        "Europe/Amsterdam",
+        "Europe/Luxembourg",
+        "Europe/Budapest",
+        "Europe/Gibraltar",
+        "Europe/Madrid",
+        "Africa/Ceuta",
+        "Europe/Monaco",
+        "Europe/Paris",
+        "Europe/Prague",
+        "Europe/Rome",
+        "Europe/San_Marino",
+        "Europe/Vatican",
+        "Europe/Malta",
+        "Europe/Tirane",
+        "Europe/Vaduz",
+        "Europe/Vienna",
+        "Europe/Warsaw",
+        "Poland",
+        "Europe/Zurich",
+        "Europe/Kaliningrad",
+        "Africa/Tripoli",
+        "Libya",
+        "Antarctica/Troll",
+        "Africa/Johannesburg",
+        "Africa/Maseru",
+        "Africa/Mbabane",
+        "Asia/Kuwait",
+        "Asia/Bahrain",
+        "Asia/Baghdad",
+        "Asia/Qatar",
+        "Antarctica/Syowa",
+        "Asia/Aden",
+        "Asia/Amman",
+        "Asia/Damascus",
+        "Africa/Addis_Ababa",
+        "Indian/Antananarivo",
+        "Africa/Asmara",
+        "Africa/Dar_es_Salaam",
+        "Africa/Djibouti",
+        "Africa/Kampala",
+        "Indian/Mayotte",
+        "Africa/Mogadishu",
+        "Indian/Comoro",
+        "Africa/Nairobi",
+        "Africa/Asmera",
+        "EET",
+        "Asia/Beirut",
+        "Europe/Bucharest",
+        "Egypt",
+        "Europe/Chisinau",
+        "Europe/Tiraspol",
+        "Asia/Hebron",
+        "Asia/Gaza",
+        "Europe/Helsinki",
+        "Europe/Mariehamn",
+        "Europe/Kyiv",
+        "Europe/Uzhgorod",
+        "Europe/Zaporozhye",
+        "Europe/Kiev",
+        "Asia/Nicosia",
+        "Asia/Famagusta",
+        "Europe/Nicosia",
+        "Europe/Riga",
+        "Europe/Sofia",
+        "Europe/Tallinn",
+        "Europe/Vilnius",
+        "Asia/Jerusalem",
+        "Israel",
+        "Asia/Tel_Aviv",
+        "Europe/Minsk",
+        "Europe/Kirov",
+        "Europe/Volgograd",
+        "W-SU",
+        "Europe/Simferopol",
+        "Europe/Istanbul",
+        "Turkey",
+        "Asia/Istanbul",
+        "Asia/Tehran",
+        "Iran",
+        "Asia/Yerevan",
+        "Asia/Tbilisi",
+        "Asia/Muscat",
+        "Indian/Mahe",
+        "Indian/Reunion",
+        "Indian/Mauritius",
+        "Europe/Samara",
+        "Europe/Astrakhan",
+        "Europe/Saratov",
+        "Europe/Ulyanovsk",
+        "Asia/Kabul",
+        "Indian/Kerguelen",
+        "Asia/Aqtau",
+        "Asia/Aqtobe",
+        "Asia/Atyrau",
+        "Asia/Oral",
+        "Asia/Qostanay",
+        "Asia/Qyzylorda",
+        "Indian/Maldives",
+        "Antarctica/Mawson",
+        "Antarctica/Vostok",
+        "Asia/Dushanbe",
+        "Asia/Ashgabat",
+        "Asia/Ashkhabad",
+        "Asia/Samarkand",
+        "Asia/Yekaterinburg",
+        "Asia/Colombo",
+        "Asia/Kolkata",
+        "Asia/Kathmandu",
+        "Asia/Katmandu",
+        "Asia/Dacca",
+        "Asia/Thimphu",
+        "Asia/Thimbu",
+        "Asia/Urumqi",
+        "Asia/Kashgar",
+        "Indian/Chagos",
+        "Asia/Bishkek",
+        "Asia/Omsk",
+        "Indian/Cocos",
+        "Asia/Yangon",
+        "Asia/Rangoon",
+        "Indian/Christmas",
+        "Antarctica/Davis",
+        "Asia/Hovd",
+        "Asia/Phnom_Penh",
+        "Asia/Vientiane",
+        "Asia/Ho_Chi_Minh",
+        "Asia/Saigon",
+        "Asia/Novosibirsk",
+        "Asia/Barnaul",
+        "Asia/Krasnoyarsk",
+        "Asia/Novokuznetsk",
+        "Asia/Tomsk",
+        "Asia/Pontianak",
+        "Antarctica/Casey",
+        "Australia/Perth",
+        "Australia/West",
+        "Asia/Brunei",
+        "Asia/Makassar",
+        "Asia/Ujung_Pandang",
+        "Asia/Macau",
+        "Asia/Macao",
+        "PRC",
+        "Asia/Chongqing",
+        "Asia/Harbin",
+        "Asia/Chungking",
+        "Asia/Hong_Kong",
+        "Hongkong",
+        "Asia/Irkutsk",
+        "Asia/Kuala_Lumpur",
+        "Asia/Kuching",
+        "Asia/Manila",
+        "Singapore",
+        "Asia/Taipei",
+        "ROC",
+        "Asia/Ulaanbaatar",
+        "Asia/Choibalsan",
+        "Asia/Ulan_Bator",
+        "Australia/Eucla",
+        "Asia/Jayapura",
+        "Japan",
+        "Asia/Pyongyang",
+        "ROK",
+        "Pacific/Palau",
+        "Asia/Dili",
+        "Asia/Chita",
+        "Asia/Khandyga",
+        "Asia/Yakutsk",
+        "Australia/Adelaide",
+        "Australia/Broken_Hill",
+        "Australia/South",
+        "Australia/Yancowinna",
+        "Australia/Darwin",
+        "Australia/North",
+        "Australia/Lindeman",
+        "Australia/Queensland",
+        "Antarctica/Macquarie",
+        "Australia/Hobart",
+        "Australia/Melbourne",
+        "Australia/Tasmania",
+        "Australia/Currie",
+        "Australia/Victoria",
+        "Australia/ACT",
+        "Australia/NSW",
+        "Australia/Canberra",
+        "Pacific/Saipan",
+        "Pacific/Chuuk",
+        "Antarctica/DumontDUrville",
+        "Pacific/Port_Moresby",
+        "Pacific/Yap",
+        "Pacific/Truk",
+        "Asia/Vladivostok",
+        "Asia/Ust-Nera",
+        "Australia/Lord_Howe",
+        "Australia/LHI",
+        "Pacific/Bougainville",
+        "Pacific/Kosrae",
+        "Pacific/Pohnpei",
+        "Pacific/Norfolk",
+        "Asia/Sakhalin",
+        "Asia/Magadan",
+        "Asia/Srednekolymsk",
+        "Pacific/Guadalcanal",
+        "Pacific/Ponape",
+        "Pacific/Efate",
+        "Pacific/Tarawa",
+        "Pacific/Funafuti",
+        "Pacific/Majuro",
+        "Pacific/Wake",
+        "Pacific/Wallis",
+        "Asia/Kamchatka",
+        "Asia/Anadyr",
+        "Pacific/Kwajalein",
+        "Kwajalein",
+        "Pacific/Nauru",
+        "NZ",
+        "Antarctica/McMurdo",
+        "Antarctica/South_Pole",
+        "Pacific/Chatham",
+        "NZ-CHAT",
+        "Pacific/Kanton",
+        "Pacific/Enderbury",
+        "Pacific/Apia",
+        "Pacific/Fakaofo",
+        "Pacific/Tongatapu",
+        "Pacific/Kiritimati",
+        "Etc/GMT-14",
+        "Etc/GMT-13",
+        "Etc/GMT-12",
+        "Etc/GMT-11",
+        "Etc/GMT-10",
+        "Etc/GMT-9",
+        "Etc/GMT-8",
+        "Etc/GMT-7",
+        "Etc/GMT-6",
+        "Etc/GMT-5",
+        "Etc/GMT-4",
+        "Etc/GMT-3",
+        "Etc/GMT-2",
+        "Etc/GMT-1",
+        "Etc/GMT",
+        "Etc/GMT+1",
+        "Etc/GMT+2",
+        "Etc/GMT+3",
+        "Etc/GMT+4",
+        "Etc/GMT+5",
+        "Etc/GMT+6",
+        "Etc/GMT+7",
+        "Etc/GMT+8",
+        "Etc/GMT+9",
+        "Etc/GMT+10",
+        "Etc/GMT+11",
+        "Etc/GMT+12"
+      ]
+    },
+    "public.enum_forms_confirmation_type": {
+      "name": "enum_forms_confirmation_type",
+      "schema": "public",
+      "values": [
+        "message",
+        "redirect"
+      ]
+    },
+    "public.enum_payload_jobs_log_task_slug": {
+      "name": "enum_payload_jobs_log_task_slug",
+      "schema": "public",
+      "values": [
+        "inline",
+        "cleanupOrphanedMedia",
+        "expireEvents",
+        "syncLectureMetadata",
+        "resetUsage",
+        "schedulePublish"
+      ]
+    },
+    "public.enum_payload_jobs_log_state": {
+      "name": "enum_payload_jobs_log_state",
+      "schema": "public",
+      "values": [
+        "failed",
+        "succeeded"
+      ]
+    },
+    "public.enum_payload_jobs_task_slug": {
+      "name": "enum_payload_jobs_task_slug",
+      "schema": "public",
+      "values": [
+        "inline",
+        "cleanupOrphanedMedia",
+        "expireEvents",
+        "syncLectureMetadata",
+        "resetUsage",
+        "schedulePublish"
+      ]
+    },
+    "public.enum_wm_web_translations_status": {
+      "name": "enum_wm_web_translations_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "published"
+      ]
+    },
+    "public.enum__wm_web_translations_v_version_status": {
+      "name": "enum__wm_web_translations_v_version_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "published"
+      ]
+    },
+    "public.enum__wm_web_translations_v_published_locale": {
+      "name": "enum__wm_web_translations_v_published_locale",
+      "schema": "public",
+      "values": [
+        "en",
+        "es",
+        "de",
+        "it",
+        "fr",
+        "ru",
+        "ro",
+        "cs",
+        "uk",
+        "el",
+        "hy",
+        "pl",
+        "pt-BR",
+        "fa",
+        "bg",
+        "tr",
+        "en-AU"
+      ]
+    },
+    "public.enum_wm_app_config_vibe_check_tracks_identifier": {
+      "name": "enum_wm_app_config_vibe_check_tracks_identifier",
+      "schema": "public",
+      "values": [
+        "WHAT-YOU-FEEL-START",
+        "WHAT-YOU-FEEL-LEFT",
+        "WHAT-YOU-FEEL-RIGHT",
+        "INTRO-INTERPRET",
+        "BH-COOL",
+        "SOMETHING-NO-COOL",
+        "SOMETHING-COOL",
+        "BH-NOTHING"
+      ]
+    },
+    "public.enum_wm_app_translations_status": {
+      "name": "enum_wm_app_translations_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "published"
+      ]
+    },
+    "public.enum__wm_app_translations_v_version_status": {
+      "name": "enum__wm_app_translations_v_version_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "published"
+      ]
+    },
+    "public.enum__wm_app_translations_v_published_locale": {
+      "name": "enum__wm_app_translations_v_published_locale",
+      "schema": "public",
+      "values": [
+        "en",
+        "es",
+        "de",
+        "it",
+        "fr",
+        "ru",
+        "ro",
+        "cs",
+        "uk",
+        "el",
+        "hy",
+        "pl",
+        "pt-BR",
+        "fa",
+        "bg",
+        "tr",
+        "en-AU"
+      ]
+    },
+    "public.enum_wm_app_status_baseline_country": {
+      "name": "enum_wm_app_status_baseline_country",
+      "schema": "public",
+      "values": [
+        "AF",
+        "AX",
+        "AL",
+        "DZ",
+        "AS",
+        "AD",
+        "AO",
+        "AI",
+        "AQ",
+        "AG",
+        "AR",
+        "AM",
+        "AW",
+        "AU",
+        "AT",
+        "AZ",
+        "BS",
+        "BH",
+        "BD",
+        "BB",
+        "BY",
+        "BE",
+        "BZ",
+        "BJ",
+        "BM",
+        "BT",
+        "BO",
+        "BQ",
+        "BA",
+        "BW",
+        "BV",
+        "BR",
+        "IO",
+        "BN",
+        "BG",
+        "BF",
+        "BI",
+        "KH",
+        "CM",
+        "CA",
+        "CV",
+        "KY",
+        "CF",
+        "TD",
+        "CL",
+        "CN",
+        "CX",
+        "CC",
+        "CO",
+        "KM",
+        "CG",
+        "CD",
+        "CK",
+        "CR",
+        "CI",
+        "HR",
+        "CU",
+        "CW",
+        "CY",
+        "CZ",
+        "DK",
+        "DJ",
+        "DM",
+        "DO",
+        "EC",
+        "EG",
+        "SV",
+        "GQ",
+        "ER",
+        "EE",
+        "SZ",
+        "ET",
+        "FK",
+        "FO",
+        "FJ",
+        "FI",
+        "FR",
+        "GF",
+        "PF",
+        "TF",
+        "GA",
+        "GM",
+        "GE",
+        "DE",
+        "GH",
+        "GI",
+        "GR",
+        "GL",
+        "GD",
+        "GP",
+        "GU",
+        "GT",
+        "GG",
+        "GN",
+        "GW",
+        "GY",
+        "HT",
+        "HM",
+        "VA",
+        "HN",
+        "HK",
+        "HU",
+        "IS",
+        "IN",
+        "ID",
+        "IR",
+        "IQ",
+        "IE",
+        "IM",
+        "IL",
+        "IT",
+        "JM",
+        "JP",
+        "JE",
+        "JO",
+        "KZ",
+        "KE",
+        "KI",
+        "KP",
+        "KR",
+        "XK",
+        "KW",
+        "KG",
+        "LA",
+        "LV",
+        "LB",
+        "LS",
+        "LR",
+        "LY",
+        "LI",
+        "LT",
+        "LU",
+        "MO",
+        "MK",
+        "MG",
+        "MW",
+        "MY",
+        "MV",
+        "ML",
+        "MT",
+        "MH",
+        "MQ",
+        "MR",
+        "MU",
+        "YT",
+        "MX",
+        "FM",
+        "MD",
+        "MC",
+        "MN",
+        "ME",
+        "MS",
+        "MA",
+        "MZ",
+        "MM",
+        "NA",
+        "NR",
+        "NP",
+        "NL",
+        "NC",
+        "NZ",
+        "NI",
+        "NE",
+        "NG",
+        "NU",
+        "NF",
+        "MP",
+        "NO",
+        "OM",
+        "PK",
+        "PW",
+        "PS",
+        "PA",
+        "PG",
+        "PY",
+        "PE",
+        "PH",
+        "PN",
+        "PL",
+        "PT",
+        "PR",
+        "QA",
+        "RE",
+        "RO",
+        "RU",
+        "RW",
+        "BL",
+        "SH",
+        "KN",
+        "LC",
+        "MF",
+        "PM",
+        "VC",
+        "WS",
+        "SM",
+        "ST",
+        "SA",
+        "SN",
+        "RS",
+        "SC",
+        "SL",
+        "SG",
+        "SX",
+        "SK",
+        "SI",
+        "SB",
+        "SO",
+        "ZA",
+        "GS",
+        "SS",
+        "ES",
+        "LK",
+        "SD",
+        "SR",
+        "SE",
+        "CH",
+        "SY",
+        "TW",
+        "TJ",
+        "TZ",
+        "TH",
+        "TL",
+        "TG",
+        "TK",
+        "TO",
+        "TT",
+        "TN",
+        "TR",
+        "TM",
+        "TC",
+        "TV",
+        "UG",
+        "UA",
+        "AE",
+        "GB",
+        "US",
+        "UM",
+        "UY",
+        "UZ",
+        "VU",
+        "VE",
+        "VN",
+        "VG",
+        "VI",
+        "WF",
+        "EH",
+        "YE",
+        "ZM",
+        "ZW"
+      ]
+    },
+    "public.enum_sy_atlas_translations_status": {
+      "name": "enum_sy_atlas_translations_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "published"
+      ]
+    },
+    "public.enum__sy_atlas_translations_v_version_status": {
+      "name": "enum__sy_atlas_translations_v_version_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "published"
+      ]
+    },
+    "public.enum__sy_atlas_translations_v_published_locale": {
+      "name": "enum__sy_atlas_translations_v_published_locale",
+      "schema": "public",
+      "values": [
+        "en",
+        "es",
+        "de",
+        "it",
+        "fr",
+        "ru",
+        "ro",
+        "cs",
+        "uk",
+        "el",
+        "hy",
+        "pl",
+        "pt-BR",
+        "fa",
+        "bg",
+        "tr",
+        "en-AU"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "id": "ec1b3516-c617-42d5-871c-087fbd99e1d3",
+  "prevId": "00000000-0000-0000-0000-000000000000"
+}

--- a/src/migrations/20260705_161112_bcp47_locales_web_translations.ts
+++ b/src/migrations/20260705_161112_bcp47_locales_web_translations.ts
@@ -1,0 +1,78 @@
+import { MigrateUpArgs, MigrateDownArgs, sql } from '@payloadcms/db-postgres'
+
+// Standardize the compound locale code to BCP-47 (pt-br -> pt-BR) and add the
+// new en-AU locale across every locale enum, plus add the three new
+// wm-web-translations leaf-group columns (footer / page_tags / errors).
+//
+// This intentionally diverges from Payload's default generated SQL. The
+// generator drops and recreates each enum type and casts every _locale column
+// back via `USING "_locale"::"_locales"` — which FAILS on any existing 'pt-br'
+// row because the recreated enum no longer contains that value
+// ("invalid input value for enum"). `ALTER TYPE ... RENAME VALUE` instead
+// updates the label in place, atomically and without touching table data, so
+// no localized-content backfill is required. `RENAME VALUE` / `ADD VALUE` both
+// run inside the migration transaction on Postgres 12+ (the new en-AU value is
+// never referenced in the same transaction).
+//
+// The .json snapshot is left exactly as generated (it already records the
+// pt-BR / en-AU / new-column end state) — only these up/down bodies are
+// hand-written.
+
+export async function up({ db, payload, req }: MigrateUpArgs): Promise<void> {
+  await db.execute(sql`
+    ALTER TYPE "public"."_locales" RENAME VALUE 'pt-br' TO 'pt-BR';
+    ALTER TYPE "public"."_locales" ADD VALUE IF NOT EXISTS 'en-AU';
+    ALTER TYPE "public"."enum__pages_v_published_locale" RENAME VALUE 'pt-br' TO 'pt-BR';
+    ALTER TYPE "public"."enum__pages_v_published_locale" ADD VALUE IF NOT EXISTS 'en-AU';
+    ALTER TYPE "public"."enum_meditations_locale" RENAME VALUE 'pt-br' TO 'pt-BR';
+    ALTER TYPE "public"."enum_meditations_locale" ADD VALUE IF NOT EXISTS 'en-AU';
+    ALTER TYPE "public"."enum__meditations_v_version_locale" RENAME VALUE 'pt-br' TO 'pt-BR';
+    ALTER TYPE "public"."enum__meditations_v_version_locale" ADD VALUE IF NOT EXISTS 'en-AU';
+    ALTER TYPE "public"."enum__meditations_v_published_locale" RENAME VALUE 'pt-br' TO 'pt-BR';
+    ALTER TYPE "public"."enum__meditations_v_published_locale" ADD VALUE IF NOT EXISTS 'en-AU';
+    ALTER TYPE "public"."enum_lectures_subtitles_locale" RENAME VALUE 'pt-br' TO 'pt-BR';
+    ALTER TYPE "public"."enum_lectures_subtitles_locale" ADD VALUE IF NOT EXISTS 'en-AU';
+    ALTER TYPE "public"."enum__clients_v_published_locale" RENAME VALUE 'pt-br' TO 'pt-BR';
+    ALTER TYPE "public"."enum__clients_v_published_locale" ADD VALUE IF NOT EXISTS 'en-AU';
+    ALTER TYPE "public"."enum__app_cards_v_published_locale" RENAME VALUE 'pt-br' TO 'pt-BR';
+    ALTER TYPE "public"."enum__app_cards_v_published_locale" ADD VALUE IF NOT EXISTS 'en-AU';
+    ALTER TYPE "public"."enum__events_v_published_locale" RENAME VALUE 'pt-br' TO 'pt-BR';
+    ALTER TYPE "public"."enum__events_v_published_locale" ADD VALUE IF NOT EXISTS 'en-AU';
+    ALTER TYPE "public"."enum__wm_web_translations_v_published_locale" RENAME VALUE 'pt-br' TO 'pt-BR';
+    ALTER TYPE "public"."enum__wm_web_translations_v_published_locale" ADD VALUE IF NOT EXISTS 'en-AU';
+    ALTER TYPE "public"."enum__wm_app_translations_v_published_locale" RENAME VALUE 'pt-br' TO 'pt-BR';
+    ALTER TYPE "public"."enum__wm_app_translations_v_published_locale" ADD VALUE IF NOT EXISTS 'en-AU';
+    ALTER TYPE "public"."enum__sy_atlas_translations_v_published_locale" RENAME VALUE 'pt-br' TO 'pt-BR';
+    ALTER TYPE "public"."enum__sy_atlas_translations_v_published_locale" ADD VALUE IF NOT EXISTS 'en-AU';
+    ALTER TABLE "wm_web_translations_locales" ADD COLUMN "footer" jsonb;
+    ALTER TABLE "wm_web_translations_locales" ADD COLUMN "page_tags" jsonb;
+    ALTER TABLE "wm_web_translations_locales" ADD COLUMN "errors" jsonb;
+    ALTER TABLE "_wm_web_translations_v_locales" ADD COLUMN "version_footer" jsonb;
+    ALTER TABLE "_wm_web_translations_v_locales" ADD COLUMN "version_page_tags" jsonb;
+    ALTER TABLE "_wm_web_translations_v_locales" ADD COLUMN "version_errors" jsonb;`)
+}
+
+export async function down({ db, payload, req }: MigrateDownArgs): Promise<void> {
+  // Reverse the BCP-47 rename. The added en-AU value is intentionally left in
+  // place: Postgres cannot DROP an enum value without recreating the type, and
+  // production migration flow is forward-only.
+  await db.execute(sql`
+    ALTER TABLE "wm_web_translations_locales" DROP COLUMN "footer";
+    ALTER TABLE "wm_web_translations_locales" DROP COLUMN "page_tags";
+    ALTER TABLE "wm_web_translations_locales" DROP COLUMN "errors";
+    ALTER TABLE "_wm_web_translations_v_locales" DROP COLUMN "version_footer";
+    ALTER TABLE "_wm_web_translations_v_locales" DROP COLUMN "version_page_tags";
+    ALTER TABLE "_wm_web_translations_v_locales" DROP COLUMN "version_errors";
+    ALTER TYPE "public"."_locales" RENAME VALUE 'pt-BR' TO 'pt-br';
+    ALTER TYPE "public"."enum__pages_v_published_locale" RENAME VALUE 'pt-BR' TO 'pt-br';
+    ALTER TYPE "public"."enum_meditations_locale" RENAME VALUE 'pt-BR' TO 'pt-br';
+    ALTER TYPE "public"."enum__meditations_v_version_locale" RENAME VALUE 'pt-BR' TO 'pt-br';
+    ALTER TYPE "public"."enum__meditations_v_published_locale" RENAME VALUE 'pt-BR' TO 'pt-br';
+    ALTER TYPE "public"."enum_lectures_subtitles_locale" RENAME VALUE 'pt-BR' TO 'pt-br';
+    ALTER TYPE "public"."enum__clients_v_published_locale" RENAME VALUE 'pt-BR' TO 'pt-br';
+    ALTER TYPE "public"."enum__app_cards_v_published_locale" RENAME VALUE 'pt-BR' TO 'pt-br';
+    ALTER TYPE "public"."enum__events_v_published_locale" RENAME VALUE 'pt-BR' TO 'pt-br';
+    ALTER TYPE "public"."enum__wm_web_translations_v_published_locale" RENAME VALUE 'pt-BR' TO 'pt-br';
+    ALTER TYPE "public"."enum__wm_app_translations_v_published_locale" RENAME VALUE 'pt-BR' TO 'pt-br';
+    ALTER TYPE "public"."enum__sy_atlas_translations_v_published_locale" RENAME VALUE 'pt-BR' TO 'pt-br';`)
+}

--- a/src/migrations/index.ts
+++ b/src/migrations/index.ts
@@ -20,6 +20,7 @@ import * as migration_20260630_181202 from './20260630_181202';
 import * as migration_20260630_235640 from './20260630_235640';
 import * as migration_20260701_172426 from './20260701_172426';
 import * as migration_20260705_134239_drop_region_event_defaults from './20260705_134239_drop_region_event_defaults';
+import * as migration_20260705_161112_bcp47_locales_web_translations from './20260705_161112_bcp47_locales_web_translations';
 
 export const migrations = [
   {
@@ -130,6 +131,11 @@ export const migrations = [
   {
     up: migration_20260705_134239_drop_region_event_defaults.up,
     down: migration_20260705_134239_drop_region_event_defaults.down,
-    name: '20260705_134239_drop_region_event_defaults'
+    name: '20260705_134239_drop_region_event_defaults',
+  },
+  {
+    up: migration_20260705_161112_bcp47_locales_web_translations.up,
+    down: migration_20260705_161112_bcp47_locales_web_translations.down,
+    name: '20260705_161112_bcp47_locales_web_translations'
   },
 ];

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -4778,6 +4778,33 @@ export interface WmWebTranslation {
     | number
     | boolean
     | null;
+  footer?:
+    | {
+        [k: string]: unknown;
+      }
+    | unknown[]
+    | string
+    | number
+    | boolean
+    | null;
+  page_tags?:
+    | {
+        [k: string]: unknown;
+      }
+    | unknown[]
+    | string
+    | number
+    | boolean
+    | null;
+  errors?:
+    | {
+        [k: string]: unknown;
+      }
+    | unknown[]
+    | string
+    | number
+    | boolean
+    | null;
   _status?: ('draft' | 'published') | null;
   updatedAt?: string | null;
   createdAt?: string | null;
@@ -5898,6 +5925,9 @@ export interface WmWebConfigSelect<T extends boolean = true> {
 export interface WmWebTranslationsSelect<T extends boolean = true> {
   common?: T;
   navigation?: T;
+  footer?: T;
+  page_tags?: T;
+  errors?: T;
   _status?: T;
   updatedAt?: T;
   createdAt?: T;

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -733,7 +733,6 @@ export interface Config {
     | ('false' | 'none' | 'null')
     | false
     | null
-    | ('en' | 'es' | 'de' | 'it' | 'fr' | 'ru' | 'ro' | 'cs' | 'uk' | 'el' | 'hy' | 'pl' | 'pt-br' | 'fa' | 'bg' | 'tr')
     | (
         | 'en'
         | 'es'
@@ -747,10 +746,30 @@ export interface Config {
         | 'el'
         | 'hy'
         | 'pl'
-        | 'pt-br'
+        | 'pt-BR'
         | 'fa'
         | 'bg'
         | 'tr'
+        | 'en-AU'
+      )
+    | (
+        | 'en'
+        | 'es'
+        | 'de'
+        | 'it'
+        | 'fr'
+        | 'ru'
+        | 'ro'
+        | 'cs'
+        | 'uk'
+        | 'el'
+        | 'hy'
+        | 'pl'
+        | 'pt-BR'
+        | 'fa'
+        | 'bg'
+        | 'tr'
+        | 'en-AU'
       )[];
   globals: {
     'wm-web-config': WmWebConfig;
@@ -785,10 +804,11 @@ export interface Config {
     | 'el'
     | 'hy'
     | 'pl'
-    | 'pt-br'
+    | 'pt-BR'
     | 'fa'
     | 'bg'
-    | 'tr';
+    | 'tr'
+    | 'en-AU';
   widgets: {
     collections: CollectionsWidget;
   };
@@ -1864,10 +1884,11 @@ export interface Meditation {
     | 'el'
     | 'hy'
     | 'pl'
-    | 'pt-br'
+    | 'pt-BR'
     | 'fa'
     | 'bg'
-    | 'tr';
+    | 'tr'
+    | 'en-AU';
   /**
    * This should be the name of the yogi who did the recording. We need this for dynamic followup audio clips. Cannot be changed after creation.
    */
@@ -2215,10 +2236,11 @@ export interface Lecture {
           | 'el'
           | 'hy'
           | 'pl'
-          | 'pt-br'
+          | 'pt-BR'
           | 'fa'
           | 'bg'
-          | 'tr';
+          | 'tr'
+          | 'en-AU';
         url: string;
         id?: string | null;
       }[]

--- a/tests/int/lectures.int.spec.ts
+++ b/tests/int/lectures.int.spec.ts
@@ -142,7 +142,7 @@ describe('Lectures Collection', () => {
       })
     })
 
-    it('normalizes "pt" to "pt-br"', async () => {
+    it('normalizes "pt" to "pt-BR"', async () => {
       const { fetchNirmalaVidyaVideo } = await import('@/lib/lectures/nirmalaVidyaApi')
       vi.mocked(fetchNirmalaVidyaVideo).mockResolvedValueOnce({
         title: 'Brazilian Portuguese Lecture',
@@ -156,7 +156,7 @@ describe('Lectures Collection', () => {
         data: { nirmalVidyaVimeoUrl: 'https://vimeo.com/333333333' },
       } as any)
 
-      expect((lecture.metadata as LectureMetadata).subtitles['pt-br']).toBe(
+      expect((lecture.metadata as LectureMetadata).subtitles['pt-BR']).toBe(
         'https://example.com/subs/pt.vtt',
       )
     })

--- a/tests/int/translations-globals.int.spec.ts
+++ b/tests/int/translations-globals.int.spec.ts
@@ -77,10 +77,10 @@ describe('Translations Globals Configuration', () => {
   })
 
   describe('Tab structure', () => {
-    it('wm-web-translations has Common and Navigation tabs', () => {
+    it('wm-web-translations has Common, Navigation, Footer, Page Tags, Errors tabs', () => {
       const tabsField = findGlobal('wm-web-translations').fields[0] as TabsField
       const labels = tabsField.tabs.map((t) => t.label)
-      expect(labels).toEqual(['Common', 'Navigation'])
+      expect(labels).toEqual(['Common', 'Navigation', 'Footer', 'Page Tags', 'Errors'])
     })
 
     it('sy-atlas-translations has Common, Map, Location, Event tabs', () => {
@@ -99,6 +99,9 @@ describe('Translations Globals Configuration', () => {
       const names = jsonFields.map((f) => f.name)
       expect(names).toContain('common')
       expect(names).toContain('navigation')
+      expect(names).toContain('footer')
+      expect(names).toContain('page_tags')
+      expect(names).toContain('errors')
     })
 
     it('sy-atlas-translations emits a JSON field named after each leaf slug', () => {

--- a/tests/unit/filterAvailableLocales.spec.ts
+++ b/tests/unit/filterAvailableLocales.spec.ts
@@ -53,7 +53,7 @@ describe('filterAvailableLocales', () => {
       const req = createMockRequest(adminUser)
       const result = filterAvailableLocales({ locales: allLocales, req })
 
-      expect(result).toHaveLength(16)
+      expect(result).toHaveLength(17)
       expect(result).toEqual(allLocales)
     })
   })
@@ -67,7 +67,7 @@ describe('filterAvailableLocales', () => {
       const req = createMockRequest(clientUser)
       const result = filterAvailableLocales({ locales: allLocales, req })
 
-      expect(result).toHaveLength(16)
+      expect(result).toHaveLength(17)
       expect(result).toEqual(allLocales)
     })
   })

--- a/tests/unit/locales.spec.ts
+++ b/tests/unit/locales.spec.ts
@@ -13,8 +13,8 @@ import { buildPayloadLocales } from '../../src/lib/locales'
 const allLocales = buildPayloadLocales()
 
 describe('Locale Configuration (buildPayloadLocales)', () => {
-  it('builds all 16 locales with proper configuration', () => {
-    expect(allLocales).toHaveLength(16)
+  it('builds all 17 locales with proper configuration', () => {
+    expect(allLocales).toHaveLength(17)
     expect(allLocales.map((l) => l.code)).toEqual([
       'en',
       'es',
@@ -28,10 +28,11 @@ describe('Locale Configuration (buildPayloadLocales)', () => {
       'el',
       'hy',
       'pl',
-      'pt-br',
+      'pt-BR',
       'fa',
       'bg',
       'tr',
+      'en-AU',
     ])
   })
 
@@ -60,8 +61,12 @@ describe('Locale Configuration (buildPayloadLocales)', () => {
     expect(germanLocale?.label).toBe('German')
 
     // Check override for Brazilian Portuguese
-    const ptBrLocale = allLocales.find((l) => l.code === 'pt-br')
+    const ptBrLocale = allLocales.find((l) => l.code === 'pt-BR')
     expect(ptBrLocale?.label).toBe('Brazilian Portuguese')
+
+    // Check override for Australian English
+    const enAuLocale = allLocales.find((l) => l.code === 'en-AU')
+    expect(enAuLocale?.label).toBe('Australian English')
 
     // Check override for Farsi
     const farsiLocale = allLocales.find((l) => l.code === 'fa')

--- a/tests/unit/nirmala-vidya.spec.ts
+++ b/tests/unit/nirmala-vidya.spec.ts
@@ -1,0 +1,49 @@
+/**
+ * Nirmala Vidya API language-code mapping tests.
+ *
+ * apiLanguageToLocale() normalizes NV subtitle language codes to CMS locale
+ * codes. Compound codes must resolve to BCP-47 form (lowercase language,
+ * uppercase region) and never the old, now-invalid 'pt-br' spelling.
+ */
+
+import { describe, it, expect } from 'vitest'
+
+import { apiLanguageToLocale } from '../../src/lib/lectures/nirmalaVidya'
+
+describe('apiLanguageToLocale', () => {
+  it('passes an already-valid locale code through unchanged', () => {
+    expect(apiLanguageToLocale('en')).toBe('en')
+    expect(apiLanguageToLocale('de')).toBe('de')
+    expect(apiLanguageToLocale('pt-BR')).toBe('pt-BR')
+    expect(apiLanguageToLocale('en-AU')).toBe('en-AU')
+  })
+
+  it('normalizes compound codes to BCP-47 shape (uppercase region)', () => {
+    // Underscore separator and/or a lowercased region must resolve to pt-BR.
+    expect(apiLanguageToLocale('pt_BR')).toBe('pt-BR')
+    expect(apiLanguageToLocale('pt-br')).toBe('pt-BR')
+    expect(apiLanguageToLocale('en_AU')).toBe('en-AU')
+    expect(apiLanguageToLocale('en-au')).toBe('en-AU')
+  })
+
+  it('normalizes an uppercased language subtag', () => {
+    expect(apiLanguageToLocale('DE')).toBe('de')
+    expect(apiLanguageToLocale('PT_br')).toBe('pt-BR')
+  })
+
+  it("maps bare 'pt' to Brazilian Portuguese", () => {
+    expect(apiLanguageToLocale('pt')).toBe('pt-BR')
+  })
+
+  it("never produces the old invalid 'pt-br' spelling", () => {
+    for (const code of ['pt', 'pt_BR', 'pt-BR', 'pt-br', 'PT']) {
+      expect(apiLanguageToLocale(code)).toBe('pt-BR')
+    }
+  })
+
+  it('returns null for unrecognized codes', () => {
+    expect(apiLanguageToLocale('xx')).toBeNull()
+    expect(apiLanguageToLocale('zh-Hant')).toBeNull()
+    expect(apiLanguageToLocale('')).toBeNull()
+  })
+})


### PR DESCRIPTION
## Summary

- Expand the `wm-web-translations` CMS global so the WeMeditate Web frontend can source its nav / footer / page-tag / error strings from the CMS instead of hard-coding them.
- Standardize compound locale codes to BCP-47 (`pt-br` → `pt-BR`) and add `en-AU` (Australian English), keeping codes consistent across the CMS and the frontend router (which expects an uppercase region).

## Changes

- `src/globals/WeMeditateWebTranslations/translationsSchema.json` — refine `common`, add `navigation.classes_near_me`, add new `footer` / `page_tags` / `errors` leaf groups. Each key carries a translator-facing description; wired to the admin via the existing `buildTranslationTabs`.
- `src/lib/locales/index.ts` — rename `pt-br` → `pt-BR`, append `en-AU`, add label overrides for both.
- `src/lib/lectures/nirmalaVidya.ts` — `apiLanguageToLocale` normalizes the region subtag to uppercase, so `pt` / `pt_BR` / `pt-BR` all map to `pt-BR` (never the now-invalid `pt-br`).
- Docs updated to 17 locales (`.claude/rules/collections.md`, `seeds/wemeditate/AGENTS.md`, `languageOptions.ts` comment).

## Migration

- New migration: `src/migrations/20260705_161112_bcp47_locales_web_translations.ts`
- Impact: renames `pt-br` → `pt-BR` and adds `en-AU` across all 12 locale enums **in place** via `ALTER TYPE ... RENAME VALUE` (existing localized rows preserved, no backfill); adds `footer` / `page_tags` / `errors` (+ `version_` variants) nullable jsonb columns to the wm-web-translations locales tables.
- Reversible: yes — `down` reverses the rename and drops the columns. `en-AU` is intentionally left in place on `down` (Postgres can't drop an enum value without recreating the type; production migration flow is forward-only).

## Test Results

- Unit: 649 passed (63 files) — includes a new `apiLanguageToLocale` spec plus updated locale-count / label specs.
- Integration (targeted): 43 passed — `translations-globals` + `lectures`.
- Migration: full chain applies cleanly on a fresh PostgreSQL 18 DB; a seeded `pt-br` row reads `pt-BR` after the rename (no data loss); `down` reverses cleanly. Independently reviewed by the migration-reviewer (no findings).
- Lint / Typecheck: ✓ No errors.

## Manual verification

1. In the admin, open the `wm-web-translations` global and confirm five tabs render — Common, Navigation, Footer, Page Tags, Errors — each key showing its contextual description.
2. Confirm the locale selector lists **Brazilian Portuguese** (`pt-BR`) and **Australian English** (`en-AU`).

## Notes for reviewer

- The migration deliberately diverges from Payload's generated output: the generator drops/recreates each enum and casts `_locale` back via `USING`, which would fail on existing `pt-br` rows (`invalid input value for enum`). `RENAME VALUE` is atomic and preserves data. The `.json` snapshot is left exactly as generated.
- Locale label strings follow the ticket's detailed instructions (`Brazilian Portuguese` / `Australian English`); the acceptance criteria's "Portuguese (Brazil)" / "English (Australia)" wording was confirmed with the requester to be informal shorthand.

Closes #528

🤖 Generated with [Claude Code](https://claude.com/claude-code)
