### PR TITLE
perf(user-choices): trace reparent isParent update with Sentry span

### DIFF
--- a/src/collections/UserChoices/hooks/updateIsParent.ts
+++ b/src/collections/UserChoices/hooks/updateIsParent.ts
@@ -1,5 +1,7 @@
 import type { PayloadRequest } from 'payload'
 
+import * as Sentry from '@sentry/nextjs'
+
 /**
  * Update the `isParent` flag on a tag based on whether it has children.
  *
@@ -12,17 +14,32 @@ export async function updateIsParent(
   req: PayloadRequest,
   parentId: number | string,
 ): Promise<void> {
-  const { totalDocs } = await req.payload.count({
-    collection: 'user-choices',
-    where: { parent: { equals: parentId } },
-    req,
-  })
+  // Manual span: the count + self-update is the write-path cost of a reparent.
+  // Wrapping it nests the auto-instrumented `pg` queries under a named node so a
+  // trace attributes the cost to this hook — parity with the #531 write-path
+  // spans (recomputeMeditationNodeWeights, cascadeFrameNodeChange). See #534.
+  await Sentry.startSpan(
+    {
+      name: 'userChoices.updateIsParent',
+      op: 'payload.hook.afterChange',
+      attributes: { 'parent.id': parentId },
+    },
+    async (span) => {
+      const { totalDocs } = await req.payload.count({
+        collection: 'user-choices',
+        where: { parent: { equals: parentId } },
+        req,
+      })
 
-  await req.payload.update({
-    collection: 'user-choices',
-    id: parentId,
-    data: { isParent: totalDocs > 0 },
-    context: { skipIsParentHook: true },
-    req,
-  })
+      span.setAttribute('children.count', totalDocs)
+
+      await req.payload.update({
+        collection: 'user-choices',
+        id: parentId,
+        data: { isParent: totalDocs > 0 },
+        context: { skipIsParentHook: true },
+        req,
+      })
+    },
+  )
 }


### PR DESCRIPTION
## Summary

The code deliverable from the #534 production slow-query capture: wrap the UserChoices reparent `count` + `update` (`updateIsParent`) in a named `Sentry.startSpan` (`op: payload.hook.afterChange`) so a reparent shows up in traces, for parity with the #531 write-path spans (`recomputeMeditationNodeWeights`, `cascadeFrameNodeChange`).

Behaviour-preserving — the same two queries run in the same transaction (`req` is still threaded through), and Sentry executes the callback even without a DSN, so nothing changes in dev/test.

## Context

This is the low-risk code tweak bundled with #534; the measurement work is done:

- **Findings** posted to #534 — bulk-publish **15.5 s / 226 queries**, a meditations virtual-field read **N+1** (25-row list = 432 queries → 6 with `select`), and slow `related-*` endpoints.
- **Follow-up tickets** opened: #541 (meditations N+1 on ungated reads) and #542 (bulk-publish write path).
- `SENTRY_TRACES_SAMPLE_RATE` was raised to 1.0 for a bounded window and **reverted to 0.1**.

## Testing

- `pnpm lint`, `pnpm typecheck` — clean
- `pnpm test:unit` — 643/643
- `tests/int/user-choices.int.spec.ts` — 22/22 (the `isParent` maintenance suite exercises `updateIsParent`)

Refs #534

🤖 Generated with [Claude Code](https://claude.com/claude-code)
