### PR TITLE
perf(pages): speed up bulk-publish write path (wm-app-config dedupe + pool sizing)

### DIFF
--- a/.claude/docs/architecture.md
+++ b/.claude/docs/architecture.md
@@ -178,12 +178,32 @@ Source maps are uploaded to Sentry when `SENTRY_AUTH_TOKEN` is set during build.
 
 `src/payload.config.ts` configures the Postgres adapter pool and global query depth:
 
-- **Pool** — `pool.max` (via `DATABASE_POOL_MAX`, default `10`) plus
+- **Pool** — `pool.max` (via `DATABASE_POOL_MAX`, default `20`) plus
   `idleTimeoutMillis` / `connectionTimeoutMillis`. Size `max` to the **Railway
-  Postgres connection limit divided across running instances** (e.g. a 20-conn
-  limit with 2 instances → `max` ≈ 8–10 each, leaving headroom for in-process
-  migrations and psql). Capping the pool keeps bursts of parallel admin work (a
-  bulk publish runs its per-doc queries concurrently) from exhausting connections.
+  Postgres connection limit divided across running instances**, and cap it so
+  bursts of parallel admin work (a bulk publish runs its per-doc queries
+  concurrently — see #542) can't exhaust connections.
+
+  **Measured production infrastructure (2026-07, verified via Railway CLI + prod
+  `pg_settings`):**
+
+  | Fact | Value |
+  |---|---|
+  | Postgres `max_connections` | **100** (`superuser_reserved_connections=3` → **97 usable**) |
+  | Production app replicas | **1** (`numReplicas` unset, hobby plan, no multi-region / no `railway.toml` scaling) |
+  | DB isolation | Prod Postgres serves **only** the prod app — each PR preview env has its own Postgres |
+  | `DATABASE_POOL_MAX` in prod | **unset** → the code default in `src/lib/env/server.ts` is authoritative |
+
+  **Sizing formula.** Peak connections ≈ `pool.max × replicas` **+ deploy overlap**
+  (Railway boots the new container — which runs in-process migrations on boot —
+  while the old one drains, ≈ up to a second pool for a few seconds) **+ ~5–10**
+  Postgres internals/admin (`psql`, autovacuum, walwriter…). Keep that peak under
+  the 97 usable. At `max=20`, 1 replica → steady 20, deploy-overlap ~40, +internal
+  ~10 ≈ **~50 peak** — comfortable. **Before adding a 2nd replica** revisit: `2 ×
+  20` steady = 40 and deploy-overlap can approach 80, so drop `max` (≈ 30–35 for 2
+  replicas) or raise the server's `max_connections`. Future bulk-write
+  optimizations (batched endpoint, serialized writes) should re-measure with the
+  Drizzle logger / Sentry `pg`-span capture rather than simply raising `max`.
 - **Depth caps** — `defaultDepth: 2` (Payload's own default, set explicitly) and
   `maxDepth: 3` (down from Payload's default 10). `maxDepth` clamps any explicit
   `depth` a caller asks for, guarding against runaway edit-view / API

--- a/src/collections/Pages/Pages.ts
+++ b/src/collections/Pages/Pages.ts
@@ -8,6 +8,8 @@ import { pageBlocks } from '@/lib/richEditor/blocks'
 import { removeDanglingLexicalReferencesAfterRead } from '@/lib/richEditor/lexicalHooks'
 import { adminOnlyFieldAccess } from '@/plugins/access'
 
+import { loadAppConfigOnce } from './appConfigCache'
+
 export const Pages: CollectionConfig = {
   slug: 'pages',
   defaultPopulate: { appUrl: false },
@@ -126,21 +128,13 @@ export const Pages: CollectionConfig = {
         const id = data?.id
         if (!id) return false
 
-        const ctx = (req?.context ?? {}) as Record<string, unknown>
-        const CACHE_KEY = 'appUrlWmConfig'
-        let config = ctx[CACHE_KEY] as Record<string, unknown> | undefined
-        if (!config) {
-          config = (await req.payload.findGlobal({
-            slug: 'wm-app-config',
-            depth: 0,
-            req,
-          })) as unknown as Record<string, unknown>
-          ctx[CACHE_KEY] = config
-          req.context = ctx
-        }
+        // Load wm-app-config once per request (memoized), not once per doc — a
+        // bulk publish fans this afterRead across every page concurrently. See
+        // loadAppConfigOnce for why the cache holds the promise, not the value.
+        const config = await loadAppConfigOnce(req)
 
         return APP_REQUIRED_PAGE_FIELDS.some((field) => {
-          const val = config![field]
+          const val = config[field]
           if (val === id) return true
           return typeof val === 'object' && val !== null && (val as { id: unknown }).id === id
         })

--- a/src/collections/Pages/appConfigCache.ts
+++ b/src/collections/Pages/appConfigCache.ts
@@ -20,6 +20,10 @@ const CACHE_KEY = 'appUrlWmConfig'
  * Storing the promise synchronously (no await between the check and the store)
  * means every later caller in the request awaits the same one, collapsing the
  * load to exactly one. Also dedupes parallel relationship/list reads.
+ *
+ * A sibling value-cache (`getWmAppConfig`, keyed by `locale:depth`) loads the
+ * same global for the app-status global reads; folding both behind one shared
+ * single-flight loader in `src/lib/` is a reasonable follow-up, out of scope here.
  */
 export function loadAppConfigOnce(req: PayloadRequest): Promise<Record<string, unknown>> {
   const ctx = (req.context ?? {}) as Record<string, unknown>

--- a/src/collections/Pages/appConfigCache.ts
+++ b/src/collections/Pages/appConfigCache.ts
@@ -19,7 +19,8 @@ const CACHE_KEY = 'appUrlWmConfig'
  *
  * Storing the promise synchronously (no await between the check and the store)
  * means every later caller in the request awaits the same one, collapsing the
- * load to exactly one. Also dedupes parallel relationship/list reads.
+ * load to exactly one. Also dedupes parallel relationship/list reads. A failed
+ * load is evicted so a later read in the same request can still retry.
  *
  * A sibling value-cache (`getWmAppConfig`, keyed by `locale:depth`) loads the
  * same global for the app-status global reads; folding both behind one shared
@@ -36,6 +37,12 @@ export function loadAppConfigOnce(req: PayloadRequest): Promise<Record<string, u
     }) as unknown as Promise<Record<string, unknown>>
     ctx[CACHE_KEY] = configPromise
     req.context = ctx
+    // Evict on failure so a transient error doesn't poison the rest of the
+    // request (restores the un-memoized retry behaviour). Callers already
+    // awaiting this in-flight promise still reject together — the load did fail.
+    void configPromise.catch(() => {
+      if (ctx[CACHE_KEY] === configPromise) delete ctx[CACHE_KEY]
+    })
   }
   return configPromise
 }

--- a/src/collections/Pages/appConfigCache.ts
+++ b/src/collections/Pages/appConfigCache.ts
@@ -1,0 +1,37 @@
+import type { PayloadRequest } from 'payload'
+
+/** Where the in-flight `wm-app-config` load is stashed on `req.context`. */
+const CACHE_KEY = 'appUrlWmConfig'
+
+/**
+ * Load the `wm-app-config` global at most once per request, shared across the
+ * many `appUrl` afterRead hooks a single request fans out (one per page).
+ *
+ * Why memoize the in-flight *promise* rather than the resolved value: a bulk
+ * publish runs every doc's afterRead concurrently — Payload's bulk update awaits
+ * them with `Promise.all` because `bulkOperationsSingleTransaction` defaults to
+ * false. A resolved-value cache stampedes under that concurrency: all N hooks
+ * clear the "not cached yet" check before the first load settles, so each issues
+ * its own `findGlobal` — the per-doc reload #542/#534 measured in production
+ * (10× for a 10-page publish). The stampede only surfaces when the load is slow
+ * (prod saw ~900 ms of connection-pool wait per query), so it hides on a fast
+ * local DB — hence the deterministic unit test rather than a timing-dependent one.
+ *
+ * Storing the promise synchronously (no await between the check and the store)
+ * means every later caller in the request awaits the same one, collapsing the
+ * load to exactly one. Also dedupes parallel relationship/list reads.
+ */
+export function loadAppConfigOnce(req: PayloadRequest): Promise<Record<string, unknown>> {
+  const ctx = (req.context ?? {}) as Record<string, unknown>
+  let configPromise = ctx[CACHE_KEY] as Promise<Record<string, unknown>> | undefined
+  if (!configPromise) {
+    configPromise = req.payload.findGlobal({
+      slug: 'wm-app-config',
+      depth: 0,
+      req,
+    }) as unknown as Promise<Record<string, unknown>>
+    ctx[CACHE_KEY] = configPromise
+    req.context = ctx
+  }
+  return configPromise
+}

--- a/src/lib/env/server.ts
+++ b/src/lib/env/server.ts
@@ -52,9 +52,11 @@ const ServerEnvSchema = ClientEnvSchema.extend({
    * Consumed by the Payload Postgres adapter in `src/payload.config.ts`.
    * Size to the Railway Postgres connection limit divided across running
    * instances — see the pool-sizing notes in `.claude/docs/architecture.md`.
-   * @default 10
+   * Prod (2026-07): Postgres `max_connections=100` (97 usable), 1 app replica →
+   * default 20 leaves ample headroom while doubling bulk-publish burst capacity.
+   * @default 20
    */
-  DATABASE_POOL_MAX: z.coerce.number().int().min(1).default(10),
+  DATABASE_POOL_MAX: z.coerce.number().int().min(1).default(20),
 
   /**
    * Enable Drizzle query logging (SQL + params to the console). Opt-in and

--- a/tests/int/pages.int.spec.ts
+++ b/tests/int/pages.int.spec.ts
@@ -456,7 +456,14 @@ describe('Pages Collection', () => {
       })
 
       expect(result.docs).toHaveLength(ids.length)
-      result.docs.forEach((doc) => expect(doc._status).toBe('published'))
+      result.docs.forEach((doc) => {
+        expect(doc._status).toBe('published')
+        // Proves the appUrl afterRead — and thus loadAppConfigOnce — actually ran
+        // through the real bulk path: webPath computes from the published gate +
+        // slug, and appUrl is gated off (test pages aren't in wm-app-config).
+        expect(doc.webPath).toBeTruthy()
+        expect(doc.appUrl).toBeFalsy()
+      })
 
       for (const id of ids) {
         const versions = await payload.findVersions({

--- a/tests/int/pages.int.spec.ts
+++ b/tests/int/pages.int.spec.ts
@@ -435,4 +435,39 @@ describe('Pages Collection', () => {
       expect(draft.webUrl).toBeNull()
     })
   })
+
+  // #542: a bulk publish fans the appUrl afterRead across every doc; guard that
+  // it publishes each and leaves version history intact. The once-per-request
+  // wm-app-config load is guarded deterministically in
+  // tests/unit/pages-app-config-cache.spec.ts — the stampede reproduces only
+  // under production's connection-pool wait, not against a fast local DB, so a
+  // black-box count here would pass on the buggy code too.
+  describe('bulk publish (#542)', () => {
+    it('publishes each doc and leaves one published latest version per doc', async () => {
+      const drafts = await Promise.all(
+        Array.from({ length: 3 }, () => testData.createPage(payload)),
+      )
+      const ids = drafts.map((p) => p.id)
+
+      const result = await payload.update({
+        collection: 'pages',
+        where: { id: { in: ids } },
+        data: { _status: 'published' },
+      })
+
+      expect(result.docs).toHaveLength(ids.length)
+      result.docs.forEach((doc) => expect(doc._status).toBe('published'))
+
+      for (const id of ids) {
+        const versions = await payload.findVersions({
+          collection: 'pages',
+          where: { parent: { equals: id } },
+          limit: 100,
+        })
+        const latest = versions.docs.filter((v) => v.latest)
+        expect(latest).toHaveLength(1)
+        expect(latest[0]?.version._status).toBe('published')
+      }
+    })
+  })
 })

--- a/tests/unit/pages-app-config-cache.spec.ts
+++ b/tests/unit/pages-app-config-cache.spec.ts
@@ -1,0 +1,62 @@
+import type { PayloadRequest } from 'payload'
+
+import { describe, expect, it, vi } from 'vitest'
+
+import { loadAppConfigOnce } from '@/collections/Pages/appConfigCache'
+
+/**
+ * Minimal PayloadRequest stub — loadAppConfigOnce only touches `context` and
+ * `payload.findGlobal`. Returns the spy separately so assertions stay cleanly
+ * typed instead of reaching through the cast request.
+ */
+function makeReq(impl: () => Promise<Record<string, unknown>>) {
+  const findGlobal = vi.fn(impl)
+  const req = { context: {}, payload: { findGlobal } } as unknown as PayloadRequest
+  return { req, findGlobal }
+}
+
+describe('loadAppConfigOnce (#542 bulk-publish stampede guard)', () => {
+  it('issues a single findGlobal when many callers race before it resolves', async () => {
+    // A deferred load: every caller arrives while it is still pending — the
+    // exact bulk-publish concurrency (Payload runs each doc's afterRead via
+    // Promise.all) that stampedes a resolved-value cache. Controlling when it
+    // resolves makes the race deterministic instead of timing-dependent.
+    let resolve!: (v: Record<string, unknown>) => void
+    const pending = new Promise<Record<string, unknown>>((r) => {
+      resolve = r
+    })
+    const { req, findGlobal } = makeReq(() => pending)
+
+    const inflight = Array.from({ length: 8 }, () => loadAppConfigOnce(req))
+    resolve({ morningMeditation: 1 })
+    const results = await Promise.all(inflight)
+
+    // A value cache would call findGlobal 8× here — all 8 clear the "not cached"
+    // check before the first settles. The promise cache collapses it to one.
+    expect(findGlobal).toHaveBeenCalledTimes(1)
+    expect(findGlobal).toHaveBeenCalledWith(
+      expect.objectContaining({ slug: 'wm-app-config', depth: 0 }),
+    )
+    results.forEach((r) => expect(r).toEqual({ morningMeditation: 1 }))
+  })
+
+  it('reuses the cached load for later callers in the same request', async () => {
+    const { req, findGlobal } = makeReq(async () => ({ foo: 'bar' }))
+
+    const first = await loadAppConfigOnce(req)
+    const second = await loadAppConfigOnce(req)
+
+    expect(second).toBe(first)
+    expect(findGlobal).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not share the cache across requests', async () => {
+    const a = makeReq(async () => ({ n: 'a' }))
+    const b = makeReq(async () => ({ n: 'b' }))
+
+    expect(await loadAppConfigOnce(a.req)).toEqual({ n: 'a' })
+    expect(await loadAppConfigOnce(b.req)).toEqual({ n: 'b' })
+    expect(a.findGlobal).toHaveBeenCalledTimes(1)
+    expect(b.findGlobal).toHaveBeenCalledTimes(1)
+  })
+})

--- a/tests/unit/pages-app-config-cache.spec.ts
+++ b/tests/unit/pages-app-config-cache.spec.ts
@@ -50,6 +50,20 @@ describe('loadAppConfigOnce (#542 bulk-publish stampede guard)', () => {
     expect(findGlobal).toHaveBeenCalledTimes(1)
   })
 
+  it('evicts the cache on failure so a later read in the request retries', async () => {
+    let calls = 0
+    const { req, findGlobal } = makeReq(() => {
+      calls += 1
+      return calls === 1 ? Promise.reject(new Error('boom')) : Promise.resolve({ ok: true })
+    })
+
+    await expect(loadAppConfigOnce(req)).rejects.toThrow('boom')
+    // A cached rejection would poison the rest of the request; eviction lets the
+    // next read reload instead.
+    await expect(loadAppConfigOnce(req)).resolves.toEqual({ ok: true })
+    expect(findGlobal).toHaveBeenCalledTimes(2)
+  })
+
   it('does not share the cache across requests', async () => {
     const a = makeReq(async () => ({ n: 'a' }))
     const b = makeReq(async () => ({ n: 'b' }))


### PR DESCRIPTION
## Summary

- Bulk-publishing pages reloaded the `wm-app-config` global once **per doc** (10× for a 10-page publish, per the #534 prod capture) — a cache stampede: the `appUrl` afterRead runs concurrently across docs (Payload's bulk update awaits them with `Promise.all`), and the resolved-value `req.context` cache was only populated *after* the await, so every doc raced past the "cached?" check. Now memoize the in-flight **promise**, collapsing it to one load per request.
- Sized the Postgres pool to the measured prod budget: `DATABASE_POOL_MAX` default **10 → 20** (verified `max_connections=100` → 97 usable, 1 app replica) — ~doubles bulk-publish burst headroom, which is the dominant cost (uniform ~900 ms/query = connection-acquisition wait, not SQL time).
- No change to version-history behavior.

## Changes

- `src/collections/Pages/appConfigCache.ts` (new) — `loadAppConfigOnce(req)`: promise-memoized single-flight load of `wm-app-config` on `req.context`.
- `src/collections/Pages/Pages.ts` — `appUrl` `exposeWhen` now calls the helper instead of inlining a value-cache.
- `src/lib/env/server.ts` — `DATABASE_POOL_MAX` default 10 → 20.
- `.claude/docs/architecture.md` — measured prod connection budget + sizing formula for future tuning.

## Test Results

- Unit: 647 passed (incl. 4 new). The stampede guard is deterministic — verified to fail `expected 1, got 8` on the old value-cache, passes on the promise-cache; plus a cache-eviction-on-failure guard.
- Integration (`pages.int.spec.ts`): 19 passed — a bulk publish publishes each doc, computes `webPath`, gates `appUrl` off, and leaves one published latest version per doc.
- Lint: ✓   Typecheck: ✓
- Build: runs on the Railway preview (GitHub Actions does not build).

## Notes for reviewer

- **Why a new helper vs. reusing `getWmAppConfig`** (in the WeMeditateAppStatus global): that helper value-caches keyed by `locale:depth`, so reusing it would reintroduce the stampede this PR fixes; and importing a global's internals into a collection violates the cross-owner-import rule (`.claude/rules/project-structure.md`). Folding both behind one shared `src/lib/` single-flight loader (converting `getWmAppConfig` to promise-memoization too) is a reasonable **follow-up**, deferred to keep this PR scoped to the #542 write path.
- **Pool sizing is prod-specific** (documented in architecture.md). **Revisit before adding a 2nd app replica** — `2 × 20` steady plus deploy-overlap approaches the 97-usable budget.
- The stampede is **load-dependent** (needs prod's ~900 ms connection-pool wait), so it does not reproduce on a fast local DB — hence the guard is a deterministic unit test controlling promise resolution, not a black-box call count (a count would pass on the buggy code locally too).

## Manual verification

1. In the admin, select ~10 pages and **Publish**; confirm it completes quickly and each page is published with correct in-app/web links.
2. The `< 3 s` server-wall target is best confirmed via the #534 prod slow-query capture after deploy (raise `SENTRY_TRACES_SAMPLE_RATE`, forced `sentry-trace`, then revert).

Closes #542

🤖 Generated with [Claude Code](https://claude.com/claude-code)
