### PR TITLE
perf(meditations,lectures): eliminate virtual-field N+1 on related-* + for-audience reads

### DIFF
--- a/.claude/rules/endpoints.md
+++ b/.claude/rules/endpoints.md
@@ -128,6 +128,50 @@ See `.claude/rules/openapi.md` for the full shim contract.
   over an explicit field allowlist, like `GET /api/meditations/{id}/songs` — not
   a raw passthrough.
 
+## Bound internal candidate-pool reads (the virtual-field N+1)
+
+The response shape is only half the story. **Any internal `depth ≥ 1` read that
+fetches a pool of rows to shape must carry a bounded `select`.** A read without
+one runs *every* field's `afterRead` on *every* row — and the expensive ones
+(virtual/computed fields, native `join` fields) each fire a per-row sub-query.
+That turns one shaped endpoint into an N+1 that scales linearly with the pool
+size. This was #541: `related-meditations` / `related-lectures` / `for-audience`
+paid ~16 extra queries per candidate (meditations `tagAssignments`, lectures
+`clips`) until each internal read was given a `select`.
+
+The client REST surface is already protected — `validateClientQueryParamsHook`
+rejects any API-client read without a `select` (see `.claude/rules/api-clients.md`).
+The gap is **server-side reads that forward `asTrustedReq(req)`**, which bypass
+that gate. Those are exactly the reads you must bound by hand.
+
+Rules of thumb:
+
+- **Co-locate the select with the shape helper.** Export a `FOO_CARD_SELECT`
+  next to the function that reads those fields (`MEDITATION_CARD_SELECT` in
+  `meditationShape.ts`, `LECTURE_FEED_SELECT` in `lectureShape.ts`), so the two
+  stay in sync when the shape changes. The endpoint spreads it and adds any
+  extra fields its own ranking/sort needs (`createdAt`, `subtleSystemNodes`, …).
+- **Co-select a virtual field's dependency.** An include-mode `select` strips
+  unselected siblings *before* any `afterRead` runs, so a computed field reads
+  `null` unless you also select what its hook reads: `durationMinutes` needs
+  `duration`; `title` needs `subtleSystemNodeWeights`; `url` needs `filename`
+  (`Meditations/endpoints/songs.ts`). Miss one and the card is silently dropped,
+  not just slow.
+- **`select` can't narrow a *relationship's* fields** — for a relationship field
+  it's boolean-only (`fullLecture: true`, not `fullLecture: { … }`). To skip an
+  expensive field on a **populated** relationship (e.g. a clip's nested
+  `fullLecture` parent), exclude it on the *target* collection with
+  `defaultPopulate: { expensiveField: false }` — `Lectures.defaultPopulate:
+  { clips: false }`, mirroring `Meditations.defaultPopulate:
+  { tagAssignments: false }`. `defaultPopulate` only affects relationship
+  hydration; direct reads and the admin edit view are unaffected.
+- **Regression-test it flat, not fast.** Spy on `payload.find` and assert the
+  per-row sub-query count stays at zero as the pool doubles (see the #541 cases
+  in `tests/int/lecture-related-meditations.int.spec.ts`); for native joins,
+  assert the field is absent from the populated docs
+  (`tests/int/lectures-for-audience.int.spec.ts`). A timing assertion is flaky;
+  a count assertion pins the behaviour.
+
 ## When to use a Payload endpoint vs a Next.js route
 
 | Use case                                                                                                                                                                                                  | Where                                                               |

--- a/src/collections/Lectures/Lectures.ts
+++ b/src/collections/Lectures/Lectures.ts
@@ -17,6 +17,17 @@ export const Lectures: CollectionConfig = {
     plural: 'Lectures',
   },
   endpoints: [lecturesForAudience, lectureRelatedMeditations],
+  // Skip the `clips` join when a lecture is hydrated through a relationship
+  // (depth ≥ 1) — e.g. a clip's `fullLecture` parent in the for-audience /
+  // related-lectures feeds. The join fires a per-row subquery, so populating it
+  // across a candidate pool is an N+1 no relationship consumer needs (the app
+  // never reads a nested lecture's `clips`). Mirrors
+  // `Meditations.defaultPopulate: { tagAssignments: false }`. Direct reads and
+  // the admin edit view (which loads a lecture head-on, not via a relationship)
+  // still get `clips`. See #541.
+  defaultPopulate: {
+    clips: false,
+  },
   admin: {
     group: 'Content',
     useAsTitle: 'title',

--- a/src/collections/Lectures/endpoints/forAudience.ts
+++ b/src/collections/Lectures/endpoints/forAudience.ts
@@ -5,6 +5,7 @@ import { z } from 'zod'
 import { audiencesQueryParamSchema } from '@/lib/audiences/audiencesQueryParam'
 import { parseQuery, requireActiveClient } from '@/lib/endpoints'
 import { selectAudienceFeed } from '@/lib/lectures/audienceFeed'
+import { LECTURE_FEED_SELECT } from '@/lib/lectures/lectureShape'
 import type { Lecture } from '@/payload-types'
 import { asTrustedReq } from '@/plugins/usage/hooks'
 
@@ -55,6 +56,9 @@ export const lecturesForAudience: Endpoint = {
       // — clips have `metadata: null` and source it from their parent.
       depth: 2,
       pagination: false,
+      // Bounded to the feed-shape fields so the `clips` join afterRead never
+      // fires across the pool (#541).
+      select: LECTURE_FEED_SELECT,
       req: asTrustedReq(req),
     })
 

--- a/src/collections/Lectures/endpoints/relatedMeditations.ts
+++ b/src/collections/Lectures/endpoints/relatedMeditations.ts
@@ -3,12 +3,24 @@ import type { Endpoint, Where } from 'payload'
 import { z } from 'zod'
 
 import { commaSeparatedIntIds, parseQuery, requireActiveClient } from '@/lib/endpoints'
-import { shapeMeditation, type MeditationCardData } from '@/lib/meditations/meditationShape'
+import {
+  MEDITATION_CARD_SELECT,
+  shapeMeditation,
+  type MeditationCardData,
+} from '@/lib/meditations/meditationShape'
 import { scoreMeditationByNodes } from '@/lib/meditations/nodeWeights'
-import type { Lecture, Meditation, SubtleSystemNode } from '@/payload-types'
+import type { Lecture, Meditation, MeditationsSelect, SubtleSystemNode } from '@/payload-types'
 import { asTrustedReq } from '@/plugins/usage/hooks'
 
 const CACHE_HEADERS = { 'Cache-Control': 'public, max-age=600, s-maxage=600' } as const
+
+/**
+ * Bounded select for the candidate-pool reads: the card fields
+ * {@link MEDITATION_CARD_SELECT} plus `createdAt` for the recency fallback sort.
+ * Skips the meditations `tagAssignments`/`frames` per-row afterReads so the pool
+ * read stays flat instead of N+1 across every candidate (#541).
+ */
+const CANDIDATE_SELECT: MeditationsSelect<true> = { ...MEDITATION_CARD_SELECT, createdAt: true }
 
 /** Which selection strategy produced the `docs` in a related-meditations response. */
 export type RelatedMeditationsSource = 'relevance' | 'fallback'
@@ -148,6 +160,7 @@ export const lectureRelatedMeditations: Endpoint = {
         pagination: false,
         limit: 0,
         locale,
+        select: CANDIDATE_SELECT,
         req: asTrustedReq(req),
       })
       candidatePool = candidateDocs as Meditation[]
@@ -202,6 +215,7 @@ export const lectureRelatedMeditations: Endpoint = {
           limit: 0,
           sort: '-createdAt',
           locale,
+          select: CANDIDATE_SELECT,
           req: asTrustedReq(req),
         })
         recentDocs = docs as Meditation[]

--- a/src/collections/Meditations/endpoints/lectures.ts
+++ b/src/collections/Meditations/endpoints/lectures.ts
@@ -5,12 +5,36 @@ import { z } from 'zod'
 import { audiencesQueryParamSchema } from '@/lib/audiences/audiencesQueryParam'
 import { commaSeparatedIntIds, parseQuery, requireActiveClient } from '@/lib/endpoints'
 import { selectAudienceFeed } from '@/lib/lectures/audienceFeed'
-import { shapeLecture, type LecturePlayerData } from '@/lib/lectures/lectureShape'
+import {
+  LECTURE_FEED_SELECT,
+  shapeLecture,
+  type LecturePlayerData,
+} from '@/lib/lectures/lectureShape'
 import { recomputeWeightsForMeditation } from '@/lib/meditations/nodeWeights'
-import type { Lecture, Meditation, SubtleSystemNode, UserChoice } from '@/payload-types'
+import type {
+  Lecture,
+  LecturesSelect,
+  Meditation,
+  SubtleSystemNode,
+  UserChoice,
+} from '@/payload-types'
 import { asTrustedReq } from '@/plugins/usage/hooks'
 
 const CACHE_HEADERS = { 'Cache-Control': 'public, max-age=600, s-maxage=600' } as const
+
+/**
+ * Bounded select for the lecture candidate pool: the feed-shape fields
+ * ({@link LECTURE_FEED_SELECT}) plus the two relationships this endpoint's
+ * ranking loop reads — `subtleSystemNodes` (topical weight) and `userChoices`
+ * (the userChoice grouping). An include-mode select keeps the lectures `clips`
+ * join afterRead from firing across the whole candidate pool, so the read stays
+ * flat instead of N+1 (#541).
+ */
+const CANDIDATE_SELECT: LecturesSelect<true> = {
+  ...LECTURE_FEED_SELECT,
+  subtleSystemNodes: true,
+  userChoices: true,
+}
 
 /** Which selection strategy produced the `docs` in a related-lectures response. */
 export type RelatedLecturesSource = 'relevance' | 'audience-fallback'
@@ -175,6 +199,7 @@ export const meditationLectures: Endpoint = {
       // — clips have `metadata: null` and source it from their parent.
       depth: 2,
       pagination: false,
+      select: CANDIDATE_SELECT,
       locale: req.locale ?? 'en',
       req: asTrustedReq(req),
     })
@@ -263,6 +288,7 @@ export const meditationLectures: Endpoint = {
         limit: 0,
         depth: 2,
         pagination: false,
+        select: CANDIDATE_SELECT,
         locale: req.locale ?? 'en',
         req: asTrustedReq(req),
       })

--- a/src/lib/lectures/lectureShape.ts
+++ b/src/lib/lectures/lectureShape.ts
@@ -2,7 +2,41 @@ import type { PayloadLogger } from 'payload'
 
 import type { LectureMetadata } from '@/lib/lectures/nirmalaVidya'
 import { resolveThumbnailUrl } from '@/lib/utilities/thumbnailUrl'
-import type { Lecture } from '@/payload-types'
+import type { Lecture, LecturesSelect } from '@/payload-types'
+
+/**
+ * Bounded include-mode `select` covering exactly the fields the feed/player
+ * shaping path reads — {@link shapeLecture} plus `selectAudienceFeed`'s
+ * `priority` partition. Pass it to any internal `depth ≥ 2` lectures read that
+ * only builds `LecturePlayerData` (`/api/lectures/for-audience`, and the base of
+ * `/api/meditations/:id/related-lectures`).
+ *
+ * The point is to keep the top-level lectures `clips` join field (a per-row
+ * subquery) from firing across the whole candidate pool — an include-mode select
+ * strips it before its afterRead runs, so the pool read stays flat instead of
+ * N+1 (#541).
+ *
+ * `fullLecture` is selected wholesale (`true`) so a clip's parent populates at
+ * depth: the clip sources its playback `metadata` and `fullLectureId`-gate
+ * `audiences` from it. `select` can't narrow a *relationship's* fields (that's a
+ * populate concern, not a select one), so the parent's own `clips` join is
+ * bounded separately by `Lectures.defaultPopulate: { clips: false }` — the
+ * nested-population analog of this top-level skip. The related-lectures ranking
+ * loop additionally reads `subtleSystemNodes` / `userChoices`; it spreads those
+ * onto this base rather than bloating the shared feed select (for-audience
+ * doesn't rank, so it doesn't need them).
+ */
+export const LECTURE_FEED_SELECT = {
+  type: true,
+  title: true,
+  metadata: true,
+  startTime: true,
+  stopTime: true,
+  thumbnail: true,
+  subtitles: true,
+  priority: true,
+  fullLecture: true,
+} satisfies LecturesSelect<true>
 
 /**
  * Flat, playback-ready shape for a lecture returned from /api/lectures/for-audience

--- a/src/lib/meditations/meditationShape.ts
+++ b/src/lib/meditations/meditationShape.ts
@@ -1,7 +1,35 @@
 import type { PayloadLogger } from 'payload'
 
 import { resolveThumbnailUrl } from '@/lib/utilities/thumbnailUrl'
-import type { Meditation, Narrator } from '@/payload-types'
+import type { Meditation, MeditationsSelect, Narrator } from '@/payload-types'
+
+/**
+ * Bounded include-mode `select` covering exactly the fields {@link shapeMeditation}
+ * reads. Pass it to any internal `depth ≥ 1` meditations read whose only purpose
+ * is to build cards (e.g. the candidate-pool reads in
+ * `/api/lectures/:id/related-meditations`). An include-mode select strips every
+ * unselected field *before* its `afterRead` runs, so the expensive per-row
+ * virtual-field hooks — `tagAssignments` (≈4 user-choices queries/row) and
+ * `frames` enrichment — never fire. Without it those hooks turn a card read into
+ * an N+1 that scales with the candidate pool (see #541).
+ *
+ * The two co-selected dependencies are load-bearing, not decorative — each
+ * virtual field's `afterRead` reads a sibling that would otherwise be stripped
+ * first (same pattern as `url`→`filename` in `Meditations/endpoints/songs.ts`):
+ *   - `duration` feeds the `durationMinutes` afterRead.
+ *   - `subtleSystemNodeWeights` feeds the `title` afterRead (and the endpoint's
+ *     own `scoreMeditationByNodes`).
+ * Drop either and the virtual reads to `null`, so `shapeMeditation` discards the
+ * card — a silent correctness regression, not just a slow one.
+ */
+export const MEDITATION_CARD_SELECT = {
+  title: true,
+  duration: true,
+  durationMinutes: true,
+  thumbnail: true,
+  narrator: true,
+  subtleSystemNodeWeights: true,
+} satisfies MeditationsSelect<true>
 
 /**
  * Flat, card-ready shape for a meditation returned from the related-content

--- a/tests/int/lecture-related-meditations.int.spec.ts
+++ b/tests/int/lecture-related-meditations.int.spec.ts
@@ -292,4 +292,61 @@ describe('lectureRelatedMeditations endpoint', () => {
       expect(status).toBe(403)
     })
   })
+
+  describe('bounded-select keeps the candidate-pool read flat (#541)', () => {
+    // The meditations `tagAssignments` virtual-join subfields each run a
+    // `payload.find('user-choices')` per row, and the `frames` afterRead runs a
+    // `payload.find('frames')` per row. Before #541 the endpoint fetched the
+    // candidate pool with no `select`, so those per-row hooks fired across the
+    // whole daily pool — an N+1 that grew with the number of candidates. The
+    // bounded `CANDIDATE_SELECT` omits both fields, so their afterReads are
+    // stripped before they run. Asserting the count stays at *zero* as the pool
+    // grows proves it's flat, not merely "smaller".
+    const findCollections = (spy: ReturnType<typeof vi.spyOn>): string[] =>
+      spy.mock.calls.map((c) => (c[0] as { collection: string }).collection)
+
+    it('fires no per-row user-choices / frames sub-queries, and stays flat as the pool grows', async () => {
+      const findSpy = vi.spyOn(payload, 'find')
+      try {
+        // Measurement 1 — the three daily meditations from the outer setup.
+        await callEndpoint(payload, anchorLecture.id, { limit: 25 })
+        expect(findCollections(findSpy).filter((c) => c === 'user-choices')).toHaveLength(0)
+        expect(findCollections(findSpy).filter((c) => c === 'frames')).toHaveLength(0)
+
+        // Grow the daily pool: three more daily meditations, each with frames and
+        // a category (user-choice) referencing it — so the skipped hooks would
+        // have real per-row work to do if they still fired.
+        for (let i = 0; i < 3; i++) {
+          const med = await testData.createMeditation(payload, undefined, {
+            title: `Extra Daily ${i}`,
+          })
+          await setFrames(payload, med.id, [{ id: frameA.id, timestamp: 0 }])
+          await testData.createUserChoice(payload, {
+            morningMeditation: med.id,
+          } as Parameters<typeof testData.createUserChoice>[1])
+        }
+
+        // Measurement 2 — over the now-doubled pool. Clear first so only the
+        // endpoint's own reads (not the setup writes above) are counted.
+        findSpy.mockClear()
+        const { body } = await callEndpoint(payload, anchorLecture.id, { limit: 25 })
+        expect(findCollections(findSpy).filter((c) => c === 'user-choices')).toHaveLength(0)
+        expect(findCollections(findSpy).filter((c) => c === 'frames')).toHaveLength(0)
+
+        // The pool genuinely grew, and every card still shapes correctly under
+        // the narrowed select (title / durationMinutes / thumbnail all present —
+        // a missing dependency would have dropped the card instead).
+        const res = body as ResponseBody
+        expect(res.docs.length).toBeGreaterThanOrEqual(4)
+        for (const card of res.docs) {
+          expect(typeof card.title).toBe('string')
+          expect(card.title.length).toBeGreaterThan(0)
+          expect(typeof card.durationMinutes).toBe('number')
+          expect(card.thumbnailUrl.length).toBeGreaterThan(0)
+        }
+      } finally {
+        findSpy.mockRestore()
+      }
+    })
+  })
 })

--- a/tests/int/lecture-related-meditations.int.spec.ts
+++ b/tests/int/lecture-related-meditations.int.spec.ts
@@ -302,16 +302,14 @@ describe('lectureRelatedMeditations endpoint', () => {
     // bounded `CANDIDATE_SELECT` omits both fields, so their afterReads are
     // stripped before they run. Asserting the count stays at *zero* as the pool
     // grows proves it's flat, not merely "smaller".
-    const findCollections = (spy: ReturnType<typeof vi.spyOn>): string[] =>
-      spy.mock.calls.map((c) => (c[0] as { collection: string }).collection)
-
     it('fires no per-row user-choices / frames sub-queries, and stays flat as the pool grows', async () => {
       const findSpy = vi.spyOn(payload, 'find')
       try {
         // Measurement 1 — the three daily meditations from the outer setup.
         await callEndpoint(payload, anchorLecture.id, { limit: 25 })
-        expect(findCollections(findSpy).filter((c) => c === 'user-choices')).toHaveLength(0)
-        expect(findCollections(findSpy).filter((c) => c === 'frames')).toHaveLength(0)
+        const before = findSpy.mock.calls.map((c) => c[0].collection)
+        expect(before.filter((c) => c === 'user-choices')).toHaveLength(0)
+        expect(before.filter((c) => c === 'frames')).toHaveLength(0)
 
         // Grow the daily pool: three more daily meditations, each with frames and
         // a category (user-choice) referencing it — so the skipped hooks would
@@ -330,8 +328,9 @@ describe('lectureRelatedMeditations endpoint', () => {
         // endpoint's own reads (not the setup writes above) are counted.
         findSpy.mockClear()
         const { body } = await callEndpoint(payload, anchorLecture.id, { limit: 25 })
-        expect(findCollections(findSpy).filter((c) => c === 'user-choices')).toHaveLength(0)
-        expect(findCollections(findSpy).filter((c) => c === 'frames')).toHaveLength(0)
+        const after = findSpy.mock.calls.map((c) => c[0].collection)
+        expect(after.filter((c) => c === 'user-choices')).toHaveLength(0)
+        expect(after.filter((c) => c === 'frames')).toHaveLength(0)
 
         // The pool genuinely grew, and every card still shapes correctly under
         // the narrowed select (title / durationMinutes / thumbnail all present —

--- a/tests/int/lectures-for-audience.int.spec.ts
+++ b/tests/int/lectures-for-audience.int.spec.ts
@@ -3,7 +3,7 @@ import type { Payload, PayloadRequest } from 'payload'
 import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest'
 
 import { lecturesForAudience } from '@/collections/Lectures/endpoints/forAudience'
-import type { LecturePlayerData } from '@/lib/lectures/lectureShape'
+import { LECTURE_FEED_SELECT, type LecturePlayerData } from '@/lib/lectures/lectureShape'
 import type { Audience, Client, Image, Lecture } from '@/payload-types'
 
 import { testData } from '../utils/testData'
@@ -954,6 +954,46 @@ describe('lecturesForAudience endpoint', () => {
       } finally {
         findSpy.mockRestore()
       }
+    })
+  })
+
+  describe('bounded-select skips the clips join (#541)', () => {
+    // for-audience (and related-lectures) fetch the candidate pool at depth 2
+    // with LECTURE_FEED_SELECT. The lectures `clips` field is a native join — a
+    // per-row subquery. The bounded select omits it on the top-level rows, and
+    // `Lectures.defaultPopulate: { clips: false }` omits it on a clip's nested
+    // `fullLecture` parent. Together they keep the pool read flat rather than an
+    // N+1 that grows with the number of (clip) candidates.
+    it('omits the clips join on candidate lectures and their nested parents', async () => {
+      const parent = await testData.createLecture(payload)
+      const clip = await testData.createLectureExcerpt(payload, { fullLecture: parent.id })
+      const where = { id: { in: [parent.id, clip.id] } }
+
+      // Baseline: a direct read resolves the parent's `clips` join (it has one
+      // clip), proving the field genuinely populates when nothing skips it.
+      const baseline = await payload.find({ collection: 'lectures', where, depth: 2, locale: 'en' })
+      const baseParent = baseline.docs.find((d) => d.id === parent.id) as Lecture
+      const baseClips = (baseParent.clips as { docs?: unknown[] } | undefined)?.docs ?? []
+      expect(baseClips.length).toBeGreaterThanOrEqual(1)
+
+      // With the feed select: the join is skipped on the top-level rows...
+      const bounded = await payload.find({
+        collection: 'lectures',
+        where,
+        depth: 2,
+        locale: 'en',
+        select: LECTURE_FEED_SELECT,
+      })
+      const boundedParent = bounded.docs.find((d) => d.id === parent.id) as Lecture
+      expect(boundedParent.clips).toBeUndefined()
+
+      // ...and on the clip's nested `fullLecture` parent (via defaultPopulate),
+      // while the fields shapeLecture reads off that parent still survive.
+      const boundedClip = bounded.docs.find((d) => d.id === clip.id) as Lecture
+      const nestedParent = boundedClip.fullLecture as Lecture
+      expect(nestedParent && typeof nestedParent === 'object').toBe(true)
+      expect(nestedParent.clips).toBeUndefined()
+      expect(nestedParent.metadata).toBeTruthy()
     })
   })
 })


### PR DESCRIPTION
## Summary

- Eliminates the virtual-field N+1 on the related-content endpoints: they fetched their candidate pool at `depth ≥ 1` with no `select`, so every row ran the expensive per-row `afterRead` hooks — meditations `tagAssignments` (~4 user-choices queries/row) and the native lectures `clips` join — an N+1 that scaled with pool size (`related-meditations` was measured at 432 DB queries / 2.97 s for 25 rows in #541).
- Adds a bounded include-mode `select` to each internal candidate-pool read, co-located with the shape helper it feeds, so those hooks are stripped before they run. Applies to `related-meditations`, `related-lectures`, and the sibling `for-audience` (same N+1, shared helper).
- Response shapes are unchanged — this is purely how many rows/fields the internal reads hydrate.

## Changes

- `src/lib/meditations/meditationShape.ts` — export `MEDITATION_CARD_SELECT` (the fields `shapeMeditation` reads, incl. the co-selected `duration`→`durationMinutes` and `subtleSystemNodeWeights`→`title` dependencies).
- `src/lib/lectures/lectureShape.ts` — export `LECTURE_FEED_SELECT` (fields `shapeLecture` + `selectAudienceFeed` read; `fullLecture` selected wholesale so a clip's parent still populates).
- `src/collections/Lectures/endpoints/relatedMeditations.ts`, `Meditations/endpoints/lectures.ts`, `Lectures/endpoints/forAudience.ts` — apply the bounded selects to their `payload.find` candidate-pool reads.
- `src/collections/Lectures/Lectures.ts` — `defaultPopulate: { clips: false }` bounds the `clips` join on a clip's nested `fullLecture` parent (`select` can't narrow a relationship's fields). Mirrors `Meditations.defaultPopulate: { tagAssignments: false }`.
- `.claude/rules/endpoints.md` — new section documenting how to avoid this class of N+1 on future endpoints.

## Test Results

- Unit: 643 passed
- Integration (affected specs): 89 passed across the three endpoint suites
  (`lecture-related-meditations`, `meditation-lectures`, `lectures-for-audience`)
- Lint: ✓ No errors · Typecheck: ✓ No errors
- Full suite + Playwright smoke run in CI / Railway preview

Regression guards (both verified to fail without the fix):
- `related-meditations`: spy on `payload.find`, assert **zero** user-choices/frames sub-queries as the pool doubles (was 4/row — 12 finds for 3 rows before the fix).
- `for-audience`: assert the `clips` join is absent from candidate lectures (select) and from a clip's nested `fullLecture` parent (defaultPopulate), with a direct-read baseline proving it otherwise populates.

## Notes for reviewer

- **No migration** — `defaultPopulate` is a read-time projection, not a schema change.
- `related-lectures` shares the exact `LECTURE_FEED_SELECT` + `defaultPopulate` mechanism as `for-audience`; the clips-skip is regression-tested once (in the for-audience spec) rather than duplicated. Its own existing suite (89 passing across the 3 affected specs) covers shaping under the bounded select.
- Deferred the issue's optional fix #2 (batching the user-choices lookups inside the `tagAssignments` factory) — unnecessary for the acceptance criteria since #1 skips those hooks entirely, and organic client REST reads are already `select`-gated by `validateClientQueryParamsHook`. Worth a follow-up only if an ungated direct meditation read at depth ≥ 1 shows up in prod traces.

Closes #541

🤖 Generated with [Claude Code](https://claude.com/claude-code)
