### PR TITLE
perf(meditations): skip redundant count(*) in frames enrichment (pagination:false)

### DIFF
--- a/src/collections/Meditations/Meditations.ts
+++ b/src/collections/Meditations/Meditations.ts
@@ -417,6 +417,10 @@ export const Meditations: CollectionConfig = {
                                 collection: 'frames',
                                 where: { id: { in: frameIds } },
                                 limit: frameIds.length,
+                                // Fetch by explicit id list — disable pagination to skip
+                                // Payload's redundant `count(*)` (the total is never used).
+                                // See #534 Sentry analysis (frames select/count pairs).
+                                pagination: false,
                               })
 
                               // Create map of relevant frame data

--- a/tests/int/meditationFrames.int.spec.ts
+++ b/tests/int/meditationFrames.int.spec.ts
@@ -316,14 +316,39 @@ describe('Meditation Frames Field', () => {
         id: testMeditation.id,
       })) as Meditation
 
-      const enrichedFrames = fetched.frames as Array<
-        KeyframeDefinition & { imageSet?: string }
-      >
+      const enrichedFrames = fetched.frames as Array<KeyframeDefinition & { imageSet?: string }>
 
       expect(enrichedFrames).toHaveLength(2)
       // Enrichment populates fields from the underlying Frame doc
       expect(enrichedFrames[0].imageSet).toBe('male')
       expect(enrichedFrames[1].imageSet).toBe('male')
+    })
+
+    it('fetches frames with pagination:false to skip the redundant count(*) (#534)', async () => {
+      const frames: KeyframeDefinition[] = [
+        { id: frameId(testFrame1), timestamp: 0 },
+        { id: frameId(testFrame2), timestamp: 30 },
+      ]
+      await payload.update({
+        collection: 'meditations',
+        id: testMeditation.id,
+        data: { frames },
+      })
+
+      const findSpy = vi.spyOn(payload, 'find')
+      try {
+        await payload.findByID({ collection: 'meditations', id: testMeditation.id })
+        const framesCalls = findSpy.mock.calls.filter((c) => c[0]?.collection === 'frames')
+        expect(framesCalls.length).toBeGreaterThan(0)
+        // Every frames-enrichment read must disable pagination so Payload skips the
+        // `select count(*)` it would otherwise run alongside the id-list fetch — the
+        // total is never used. See #534 Sentry analysis (frames select/count pairs).
+        for (const call of framesCalls) {
+          expect(call[0].pagination).toBe(false)
+        }
+      } finally {
+        findSpy.mockRestore()
+      }
     })
   })
 


### PR DESCRIPTION
## Summary

The Meditations `frames` `afterRead` enrichment fetched frame docs with `payload.find` but **without `pagination: false`**, so Payload ran a redundant `select count(*)` alongside every id-list fetch. Surfaced by the #534 production Sentry analysis, where these appeared as matched `select frames …` + `select count(*) from frames …` pairs (~2M ms of wasted counts over 7 days; one live `related-lectures` trace held 5 redundant frame counts).

Adding `pagination: false` halves every frames-enrichment read. **Behavior-preserving** — the same docs are returned; the total count was never used.

## Testing

- Added a `payload.find` spy assertion in `meditationFrames.int.spec.ts`: every frames-enrichment read passes `pagination: false`.
- `pnpm lint` + `pnpm typecheck` clean; `meditationFrames.int.spec.ts` 20/20; `pnpm test:unit` 659/659.

Refs #534

🤖 Generated with [Claude Code](https://claude.com/claude-code)
