### PR TITLE
chore(ci): add typecheck step to CI and the pr-prep lean gate

### DIFF
--- a/.claude/rules/testing-reqs.md
+++ b/.claude/rules/testing-reqs.md
@@ -23,8 +23,10 @@ Every test command belongs to one of three tiers. Each tier has a job — Claude
 | Tier           | Command                                     | Target runtime | Fires when                                                                                        |
 | -------------- | ------------------------------------------- | -------------- | ------------------------------------------------------------------------------------------------- |
 | **1 — Hook**   | `pnpm test:unit`                            | < 5 s          | Claude PostToolUse Edit/Write on `src/**` and `tests/unit/**` (see `.claude/hooks/unit-test.mjs`) |
-| **2 — Pre-PR** | `pnpm lint && pnpm test:unit`               | < 15 s         | The pr-prep lean gate — `.claude/skills/pr-prep/check.sh`                                         |
-| **3 — CI**     | `pnpm lint && pnpm test && pnpm test:smoke` | ≤ 20 min       | GitHub Actions on every PR (`.github/workflows/ci.yml`)                                           |
+| **2 — Pre-PR** | `pnpm lint && pnpm typecheck && pnpm test:unit`               | < 45 s         | The pr-prep lean gate — `.claude/skills/pr-prep/check.sh`                                         |
+| **3 — CI**     | `pnpm lint && pnpm typecheck && pnpm test && pnpm test:smoke` | ≤ 20 min       | GitHub Actions on every PR (`.github/workflows/ci.yml`)                                           |
+
+> **Why `pnpm typecheck` is its own gate step:** `eslint` and Vitest do **not** type-check (`tsc`), so a type error passes lint + the whole test suite and surfaces only at the Railway build — i.e. after merge. Tier 2 and CI both run `tsc --noEmit` (~15-20 s) to catch it before merge.
 
 Tier-specific guidance:
 

--- a/.claude/skills/pr-prep/check.sh
+++ b/.claude/skills/pr-prep/check.sh
@@ -6,20 +6,20 @@
 # minus smoke) under --full. See .claude/rules/testing-reqs.md for the full
 # three-tier contract.
 #
-# Default — Tier 2: lint + the fast unit suite. Run the targeted integration
-# spec(s) for what you changed separately, e.g.
+# Default — Tier 2: lint + typecheck + the fast unit suite. Run the targeted
+# integration spec(s) for what you changed separately, e.g.
 #   pnpm exec vitest run tests/int/<file>.int.spec.ts --config ./vitest.config.mts
 #
-# --full — Tier 3 locally: lint + full `pnpm test` + Cloudflare build. Skips
-# `pnpm test:smoke` because the smoke specs target a deployed Cloudflare PR
-# preview (built by Cloudflare Workers Builds, not by `pnpm build`). For full
-# Tier 3 coverage, push and let CI run smoke against the preview.
+# --full — Tier 3 locally: lint + typecheck + full `pnpm test` + the Railway
+# `pnpm build`. Skips `pnpm test:smoke` because the smoke specs target a
+# deployed Railway PR preview, not a local build. For full Tier 3 coverage,
+# push and let CI run smoke against the preview.
 #
 # CI (.github/workflows/ci.yml) is the source of truth for Tier 3 on every PR.
 #
 # Usage:
-#   .claude/skills/pr-prep/check.sh            # Tier 2: lint + test:unit
-#   .claude/skills/pr-prep/check.sh --full     # Tier 3 locally (no smoke): lint + full test + Cloudflare build
+#   .claude/skills/pr-prep/check.sh            # Tier 2: lint + typecheck + test:unit
+#   .claude/skills/pr-prep/check.sh --full     # Tier 3 locally (no smoke): lint + typecheck + full test + Railway build
 
 set -u
 
@@ -39,6 +39,17 @@ fi
 echo "✓ Lint passed"
 echo
 
+echo "=== Typecheck ==="
+if ! pnpm typecheck; then
+  echo
+  echo "❌ Typecheck failed. Fix type errors before continuing."
+  echo "  Note: type errors are caught ONLY here and by the Railway build —"
+  echo "  neither lint nor the Vitest suites (nor GitHub CI's test step) typecheck."
+  exit 1
+fi
+echo "✓ Typecheck passed"
+echo
+
 if [[ "$MODE" == "--full" ]]; then
   echo "=== Tier 3 (local): Full test suite ==="
   if ! pnpm test; then
@@ -49,22 +60,15 @@ if [[ "$MODE" == "--full" ]]; then
   echo "✓ Tests passed"
   echo
 
-  echo "=== Tier 3 (local): Cloudflare build ==="
-  if ! NODE_OPTIONS="--no-deprecation --max-old-space-size=8000" CLOUDFLARE_ENV= pnpm exec wrangler types; then
+  echo "=== Tier 3 (local): Railway build (pnpm build) ==="
+  if ! pnpm build; then
     echo
-    echo "❌ wrangler types failed."
+    echo "❌ Build failed. This is the Next.js build Railway runs on deploy."
     exit 1
   fi
-  if ! NODE_OPTIONS="--no-deprecation --max-old-space-size=8000" CLOUDFLARE_ENV= \
-    WRANGLER_BUILD_CONDITIONS="" WRANGLER_BUILD_PLATFORM="node" \
-    pnpm exec opennextjs-cloudflare build; then
-    echo
-    echo "❌ Cloudflare build failed."
-    exit 1
-  fi
-  echo "✓ Cloudflare build passed"
+  echo "✓ Build passed"
   echo
-  echo "ℹ Tier 3 smoke specs (pnpm test:smoke) target a deployed Cloudflare PR"
+  echo "ℹ Tier 3 smoke specs (pnpm test:smoke) target a deployed Railway PR"
   echo "  preview and run in CI only. Push to trigger them on the PR."
   echo
 else

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,7 @@ jobs:
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - run: pnpm lint
+      - run: pnpm typecheck # tsc --noEmit — lint and Vitest don't typecheck; only this + the Railway build do
       - run: pnpm test # test:unit + test:int (integration runs against Postgres)
 
       # ── Smoke specs against the Railway PR preview ──────────────────────────

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -137,8 +137,8 @@ The test suite runs in three tiers (see `.claude/rules/testing-reqs.md` for the 
 | Tier           | Command                                     | Fires when                                               |
 | -------------- | ------------------------------------------- | -------------------------------------------------------- |
 | **1 — Hook**   | `pnpm test:unit`                            | Claude PostToolUse on `src/**` / `tests/unit/**` (< 5 s) |
-| **2 — Pre-PR** | `pnpm lint && pnpm test:unit`               | Local pr-prep lean gate (< 15 s)                         |
-| **3 — CI**     | `pnpm lint && pnpm test && pnpm test:smoke` | GitHub Actions on every PR (≤ 20 min)                    |
+| **2 — Pre-PR** | `pnpm lint && pnpm typecheck && pnpm test:unit`               | Local pr-prep lean gate (< 45 s)                         |
+| **3 — CI**     | `pnpm lint && pnpm typecheck && pnpm test && pnpm test:smoke` | GitHub Actions on every PR (≤ 20 min)                    |
 
 Before marking a PR ready, run the **Tier 2** lean gate plus the targeted integration spec(s) for what you changed. Use the `/pr-prep` skill (`.claude/skills/pr-prep/`) — its `--full` flag reproduces the Tier 3 checks locally when you need to debug a red run, and it documents handling pre-existing failures. Don't block on a local full-suite/build run — that's CI's job.
 


### PR DESCRIPTION
## Summary

- Adds a `pnpm typecheck` (`tsc --noEmit`) step to CI and the pr-prep lean gate. `eslint` and Vitest don't type-check, so a type error currently slips past lint + the full test suite and only surfaces at the Railway build (post-merge) — this catches it before merge.
- Switches the pr-prep `--full` local build from the retired Cloudflare/wrangler path to the Railway `pnpm build`, matching how the app is actually built on deploy.

## Changes

- `.github/workflows/ci.yml` — new `pnpm typecheck` step between `pnpm lint` and `pnpm test`.
- `.claude/skills/pr-prep/check.sh` — runs typecheck in both the Tier-2 default and `--full` paths; `--full` now runs `pnpm build` (Railway) instead of `wrangler types` + `opennextjs-cloudflare build`.
- `.claude/rules/testing-reqs.md`, `AGENTS.md` — Tier-2/Tier-3 tables updated to include typecheck; Tier-2 budget bumped 15s → 45s, with a note on why typecheck is its own step.

## Test Results

- Docs + CI-config + a shell script only; no application code. CI on this PR exercises the new typecheck step itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
