### PR TITLE
perf(app-cards): select-gate status reads + bound audience-id input

### DIFF
--- a/src/collections/AppCards/endpoints/forAudience.ts
+++ b/src/collections/AppCards/endpoints/forAudience.ts
@@ -136,6 +136,7 @@ export const appCardsForAudience: Endpoint = {
       req: asTrustedReq(req),
     })
 
+    const audienceIdSet = new Set(audienceIds)
     const eligible = (docs as AppCard[]).filter((card) => {
       if (!card.targetSections?.includes(targetSection)) return false
       // Conditions gate: ALL conditions on the card must be in the supplied audienceIds
@@ -143,7 +144,7 @@ export const appCardsForAudience: Endpoint = {
       const conditions = card.conditions as Array<number | { id: number }> | null | undefined
       if (conditions && conditions.length > 0) {
         const conditionIds = conditions.map((c) => (typeof c === 'number' ? c : c.id))
-        if (!conditionIds.every((id) => audienceIds.includes(id))) return false
+        if (!conditionIds.every((id) => audienceIdSet.has(id))) return false
       }
       return true
     })

--- a/src/globals/WeMeditateAppStatus/sections/appCards.ts
+++ b/src/globals/WeMeditateAppStatus/sections/appCards.ts
@@ -47,6 +47,7 @@ export const appCardsSection: SectionSpec<WeMeditateAppStatusConfig, Ctx> = {
         limit: 0,
         pagination: false,
         depth: 0,
+        select: { _status: true, default: true, label: true },
         req,
       })
       launchCriticalCards = docs as unknown as Record<string, unknown>[]
@@ -73,6 +74,7 @@ export const appCardsSection: SectionSpec<WeMeditateAppStatusConfig, Ctx> = {
       limit: 0,
       pagination: false,
       depth: 0,
+      select: { _status: true, default: true, label: true },
       req,
     })
     const enPublishedIds = new Set<number | string>(enPublishedOther.map((card) => card.id))
@@ -95,6 +97,7 @@ export const appCardsSection: SectionSpec<WeMeditateAppStatusConfig, Ctx> = {
         limit: 0,
         pagination: false,
         depth: 0,
+        select: { _status: true, default: true, label: true },
         req,
       })
       otherDocs = (otherCardDocs as unknown as Record<string, unknown>[])

--- a/src/lib/audiences/audiencesQueryParam.ts
+++ b/src/lib/audiences/audiencesQueryParam.ts
@@ -57,5 +57,15 @@ export const audiencesQueryParamSchema = z
       return z.NEVER
     }
 
-    return [...new Set(ids)].sort((a, b) => a - b)
+    const dedupedIds = [...new Set(ids)].sort((a, b) => a - b)
+
+    if (dedupedIds.length > 1000) {
+      ctx.addIssue({
+        code: 'custom',
+        message: 'audiences list must not exceed 1000 unique IDs',
+      })
+      return z.NEVER
+    }
+
+    return dedupedIds
   })

--- a/tests/int/app-cards-for-audience.int.spec.ts
+++ b/tests/int/app-cards-for-audience.int.spec.ts
@@ -656,4 +656,99 @@ describe('appCardsForAudience endpoint', () => {
       }
     })
   })
+
+  describe('Audience ID input validation (#568)', () => {
+    it('rejects audience-id lists exceeding 1000 with a 400 validation error', async () => {
+      // Build a list of 1001 unique IDs (all beyond any realistic audience set)
+      const overLimit = Array.from({ length: 1001 }, (_, i) => String(1000 + i)).join(',')
+
+      const { status, body } = await callEndpoint(
+        payload,
+        { audiences: overLimit, targetSection: 'hero', limit: 20 },
+        undefined,
+        { skipDefaultAudiences: true },
+      )
+
+      expect(status).toBe(400)
+      expect(body).toMatchObject({
+        errors: expect.arrayContaining([
+          expect.objectContaining({
+            message: expect.stringContaining('1000'),
+          }),
+        ]),
+      })
+    })
+
+    it('accepts valid audience-id lists up to exactly 1000 IDs', async () => {
+      // Create an audience to ensure the endpoint can find something
+      const testAudience = await testData.createAudience(payload, {
+        label: 'Test Audience for Max',
+      })
+
+      await testData.createAppCard(payload, {
+        default: {
+          title: 'Test Card for Max',
+          image: (await testData.createMediaImage(payload, { alt: 'test' })).id,
+        },
+        targetSections: ['hero'],
+        audiences: [testAudience.id],
+        _status: 'published',
+      })
+
+      // Build a list of exactly 1000 unique IDs (only testAudience.id is real)
+      const atLimit = [
+        testAudience.id,
+        ...Array.from({ length: 999 }, (_, i) => String(2000 + i)),
+      ].join(',')
+
+      const { status } = await callEndpoint(
+        payload,
+        { audiences: atLimit, targetSection: 'hero', limit: 20 },
+        undefined,
+        { skipDefaultAudiences: true },
+      )
+
+      expect(status).toBe(200)
+    })
+
+    it('condition filtering works correctly with realistic audience ID counts', async () => {
+      const aud1 = await testData.createAudience(payload, {
+        label: 'Audience 1',
+      })
+      const condAud = await testData.createAudience(payload, {
+        label: 'Condition Audience',
+      })
+
+      const cardWithCondition = await testData.createAppCard(payload, {
+        default: {
+          title: 'Card with Condition',
+          image: (await testData.createMediaImage(payload, { alt: 'test' })).id,
+        },
+        targetSections: ['hero'],
+        audiences: [aud1.id],
+        conditions: [condAud.id], // AND-gate: caller must have this ID too
+        _status: 'published',
+      })
+
+      // Caller has aud1 but NOT condAud → card should NOT appear
+      const { body: resultWithoutCond } = await callEndpoint(
+        payload,
+        { targetSection: 'hero', limit: 20 },
+        undefined,
+        { defaultAudiences: [aud1.id].join(',') },
+      )
+      const cardsWithoutCond = (resultWithoutCond as { docs: AppCard[] }).docs
+      expect(cardsWithoutCond.map((c) => c.id)).not.toContain(cardWithCondition.id)
+
+      // Caller has both aud1 AND condAud → card SHOULD appear
+      const { body: resultWithCond } = await callEndpoint(
+        payload,
+        { targetSection: 'hero', limit: 20 },
+        undefined,
+        { defaultAudiences: [aud1.id, condAud.id].join(',') },
+      )
+      const cardsWithCond = (resultWithCond as { docs: AppCard[] }).docs
+      expect(cardsWithCond.map((c) => c.id)).toContain(cardWithCondition.id)
+    })
+  })
 })

--- a/tests/int/app-status-readiness.int.spec.ts
+++ b/tests/int/app-status-readiness.int.spec.ts
@@ -1,0 +1,110 @@
+import type { Payload } from 'payload'
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+
+import { appCardChecks } from '@/globals/WeMeditateAppStatus/sections/shared'
+import { labelOf } from '@/lib/status'
+
+import { testData } from '../utils/testData'
+import { createTestEnvironment } from '../utils/testHelpers'
+
+// The readiness section (src/globals/WeMeditateAppStatus/sections/appCards.ts)
+// fetches app-cards with exactly this narrowed select. These tests guard that
+// appCardChecks + labelOf still resolve correctly under it — a future check that
+// reads an unselected field would regress to a false "not ready" or a "#id" label.
+// app-cards carry their display name in the top-level `label` field (there is no
+// top-level title/name — those live inside the `default` view group), so labelOf
+// resolves to `label`.
+const READINESS_SELECT = { _status: true, default: true, label: true } as const
+
+type LabelDoc = { id: number | string; title?: unknown; name?: unknown; label?: unknown }
+
+describe('App Status Readiness Checks (#568)', () => {
+  let payload: Payload
+  let cleanup: () => Promise<void>
+
+  beforeAll(async () => {
+    const env = await createTestEnvironment()
+    payload = env.payload
+    cleanup = env.cleanup
+  })
+
+  afterAll(async () => {
+    await cleanup()
+  })
+
+  it('resolves labels and checks under the narrowed readiness select', async () => {
+    const publishedCard = await testData.createAppCard(payload, {
+      label: 'Published Card',
+      default: { title: 'Published Title', subtitle: 'Published Subtitle', buttonText: 'Click Me' },
+      _status: 'published',
+    })
+    const incompleteCard = await testData.createAppCard(payload, {
+      label: 'Incomplete Card',
+      default: { title: 'Only Title' }, // no subtitle / buttonText
+      _status: 'published',
+    })
+
+    const { docs } = await payload.find({
+      collection: 'app-cards',
+      where: { id: { in: [publishedCard.id, incompleteCard.id] } },
+      select: READINESS_SELECT,
+    })
+    expect(docs).toHaveLength(2)
+
+    const pub = docs.find((d) => d.id === publishedCard.id) as unknown as Record<string, unknown>
+    expect(labelOf(pub as LabelDoc)).toBe('Published Card')
+    expect(appCardChecks(pub)).toEqual([
+      { key: 'published', passed: true },
+      { key: 'title-set', passed: true },
+      { key: 'subtitle-set', passed: true },
+      { key: 'button-label-set', passed: true },
+    ])
+
+    const incomplete = docs.find((d) => d.id === incompleteCard.id) as unknown as Record<
+      string,
+      unknown
+    >
+    expect(labelOf(incomplete as LabelDoc)).toBe('Incomplete Card')
+    expect(appCardChecks(incomplete)).toEqual([
+      { key: 'published', passed: true },
+      { key: 'title-set', passed: true },
+      { key: 'subtitle-set', passed: false },
+      { key: 'button-label-set', passed: false },
+    ])
+  })
+
+  it('produces identical readiness output with the narrowed select and a full fetch', async () => {
+    const readyCard = await testData.createAppCard(payload, {
+      label: 'Ready Card',
+      default: { title: 'Ready Title', subtitle: 'Ready Subtitle', buttonText: 'Go!' },
+      _status: 'published',
+    })
+
+    const { docs: narrowedDocs } = await payload.find({
+      collection: 'app-cards',
+      where: { id: { equals: readyCard.id } },
+      select: READINESS_SELECT,
+    })
+    const { docs: fullDocs } = await payload.find({
+      collection: 'app-cards',
+      where: { id: { equals: readyCard.id } },
+    })
+    expect(narrowedDocs).toHaveLength(1)
+    expect(fullDocs).toHaveLength(1)
+
+    const narrowed = narrowedDocs[0] as unknown as Record<string, unknown>
+    const full = fullDocs[0] as unknown as Record<string, unknown>
+
+    // The narrowed select must not change what the readiness report computes.
+    expect(appCardChecks(narrowed)).toEqual(appCardChecks(full))
+    expect(labelOf(narrowed as LabelDoc)).toEqual(labelOf(full as LabelDoc))
+    expect(labelOf(narrowed as LabelDoc)).toBe('Ready Card')
+    expect(appCardChecks(narrowed)).toEqual([
+      { key: 'published', passed: true },
+      { key: 'title-set', passed: true },
+      { key: 'subtitle-set', passed: true },
+      { key: 'button-label-set', passed: true },
+    ])
+  })
+})


### PR DESCRIPTION
## Summary

Two low-cost read-path improvements on the `app-cards` surface, from the review in #568.

- **WeMeditateAppStatus readiness reads** now pass an explicit `select: { _status, default, label }` to the three `app-cards` finds, so Payload skips the per-doc `viewScheduleAfterRead` hook for the readiness report.
- **`/app-cards/for-audience`** builds the audience-id lookup as a `Set` (O(1) membership instead of `Array.includes` inside a loop), and the `audiences` query param is now capped at **1000 unique IDs** — abusive input is rejected with a 400 before it reaches the DB `in` clause.

No behaviour change for valid requests.

Closes #568

## Test plan

- `tests/int/app-status-readiness.int.spec.ts` (new) — asserts `labelOf` + `appCardChecks` resolve correctly under the narrowed select, and that readiness output is **identical** with the narrowed select vs a full fetch (guards against a future check reading an unselected field and regressing to a false "not ready" / `#id` label).
- `tests/int/app-cards-for-audience.int.spec.ts` — boundary tests (accepts exactly 1000 IDs; rejects 1001 with a 400) + a condition-filtering case exercising the new `Set` gate.
- Ran locally: both integration specs green (34 tests), `pnpm lint` + `pnpm typecheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
