### PR TITLE
refactor(registrations): validate + type questions via jsonSchema

### DIFF
--- a/src/collections/Registrations/Registrations.ts
+++ b/src/collections/Registrations/Registrations.ts
@@ -2,7 +2,7 @@ import type { CollectionConfig } from 'payload'
 
 import { legacyMigrationFields } from '@/fields'
 import { DEFAULT_LOCALE, getLocaleOptions } from '@/lib/locales'
-import { validateRegistrationQuestions } from '@/lib/registrations/questions'
+import { registrationQuestionsJsonSchema } from '@/lib/registrations/questions'
 
 /**
  * Registrations — a registrant (User) signing up for an Event. Migrated from
@@ -71,10 +71,15 @@ export const Registrations: CollectionConfig = {
     {
       name: 'questions',
       type: 'json',
-      // Enforce the shape: keys ⊆ EVENT_REGISTRATION_QUESTIONS, string answers.
-      // A bad payload throws a ValidationError (400) — the register endpoint's
-      // catch surfaces it verbatim rather than a 500.
-      validate: (value: unknown) => validateRegistrationQuestions(value),
+      // Typed + validated by a JSON Schema derived from EVENT_REGISTRATION_QUESTIONS:
+      // Payload generates the `questions` TS type AND validates on write (an unknown
+      // key or non-string answer throws a ValidationError → 400 at the register
+      // endpoint, surfaced verbatim rather than a 500).
+      jsonSchema: {
+        uri: 'https://sahajcloud.dev/schemas/registration-questions.json',
+        fileMatch: ['https://sahajcloud.dev/schemas/registration-questions.json'],
+        schema: registrationQuestionsJsonSchema,
+      },
       admin: {
         description:
           "Raw registrant answers, keyed by the event's enabled registration questions (EVENT_REGISTRATION_QUESTIONS — priorExperience, referralSource, healthInfo, accessibility, guests).",

--- a/src/lib/registrations/questions.ts
+++ b/src/lib/registrations/questions.ts
@@ -1,7 +1,7 @@
 /**
  * The registration-questions contract, shared across owners: the Events
- * collection enables questions, the Registrations collection validates the
- * stored answers, the register endpoint shapes them, and the manager
+ * collection enables questions, the Registrations collection validates + types
+ * the stored answers, the register endpoint shapes them, and the manager
  * notification email forwards them.
  *
  * It lives in `src/lib/` rather than a collection folder precisely because it is
@@ -9,6 +9,8 @@
  * cross-collection import from `Registrations/` (see
  * `.claude/rules/project-structure.md`).
  */
+
+import type { JSONSchema4 } from 'json-schema'
 
 /**
  * Optional questions an event can ask registrants. Rendered as a group of
@@ -24,48 +26,38 @@ export const EVENT_REGISTRATION_QUESTIONS = [
   { name: 'guests', label: 'Will you be bringing any guests?' },
 ] as const
 
-/** A configured registration-question key (`priorExperience`, `referralSource`, …). */
-export type EventRegistrationQuestionName = (typeof EVENT_REGISTRATION_QUESTIONS)[number]['name']
-
-/**
- * The stored shape of a registration's `questions` field: each configured
- * question key maps to the registrant's (string) answer. Every key is optional —
- * an event enables only some questions, and a registrant may skip any.
- */
-export type RegistrationQuestions = Partial<Record<EventRegistrationQuestionName, string>>
-
 /** A registrant's answer to one registration question, labelled for display. */
 export interface RegistrationAnswer {
   label: string
   value: string
 }
 
+/**
+ * JSON Schema for the stored `questions` answers: an object keyed by the
+ * configured question names, each answer a string, no other keys allowed.
+ * Derived from `EVENT_REGISTRATION_QUESTIONS` so it can't drift.
+ *
+ * Wired onto `Registrations.questions` via the field's `jsonSchema`, which
+ * Payload uses to BOTH validate on write (an unknown key or non-string answer
+ * throws a `ValidationError` → the register endpoint returns 400) AND generate
+ * the field's TypeScript type in `payload-types.ts`. (This compiles an Ajv
+ * `new Function()` validator — fine on Railway/Node; the old comments warning it
+ * breaks under Cloudflare Workers predate the migration off Workers.)
+ */
+export const registrationQuestionsJsonSchema: JSONSchema4 = {
+  type: 'object',
+  additionalProperties: false,
+  properties: Object.fromEntries(
+    EVENT_REGISTRATION_QUESTIONS.map((question) => [
+      question.name,
+      { type: 'string', description: question.label },
+    ]),
+  ),
+}
+
 const CONFIGURED_QUESTION_NAMES = new Set<string>(
   EVENT_REGISTRATION_QUESTIONS.map((question) => question.name),
 )
-
-/**
- * Enforce the `questions` structure on write: an object whose keys are all
- * configured question names and whose values are strings. Returns `true` or an
- * error message. Pure JS (no `jsonSchema` — Payload would compile that to an Ajv
- * `new Function()` validator, which throws under Cloudflare's codegen ban; see
- * `src/fields/translationsField.ts`).
- */
-export function validateRegistrationQuestions(value: unknown): true | string {
-  if (value == null) return true
-  if (typeof value !== 'object' || Array.isArray(value)) {
-    return 'Registration answers must be an object of question answers.'
-  }
-  for (const [key, answer] of Object.entries(value)) {
-    if (!CONFIGURED_QUESTION_NAMES.has(key)) {
-      return `Unknown registration question: "${key}".`
-    }
-    if (typeof answer !== 'string') {
-      return `The answer for "${key}" must be text.`
-    }
-  }
-  return true
-}
 
 /** Render one raw answer value as a display string, or `''` to skip it. */
 function formatAnswer(raw: unknown): string {

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -1856,18 +1856,28 @@ export interface Registration {
         | 'nl'
       )
     | null;
-  /**
-   * Raw registrant answers, keyed by the event's enabled registration questions (EVENT_REGISTRATION_QUESTIONS — priorExperience, referralSource, healthInfo, accessibility, guests).
-   */
-  questions?:
-    | {
-        [k: string]: unknown;
-      }
-    | unknown[]
-    | string
-    | number
-    | boolean
-    | null;
+  questions?: {
+    /**
+     * Have you practised Sahaja Yoga meditation before?
+     */
+    priorExperience?: string;
+    /**
+     * How did you hear about this event?
+     */
+    referralSource?: string;
+    /**
+     * Is there anything about your health we should know?
+     */
+    healthInfo?: string;
+    /**
+     * Do you have any accessibility requirements?
+     */
+    accessibility?: string;
+    /**
+     * Will you be bringing any guests?
+     */
+    guests?: string;
+  };
   uuid: string;
   mailingListSubscribedAt?: string | null;
   legacyId?: number | null;

--- a/tests/unit/registration-answers.spec.ts
+++ b/tests/unit/registration-answers.spec.ts
@@ -1,33 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import {
-  buildRegistrationAnswers,
-  validateRegistrationQuestions,
-} from '@/lib/registrations/questions'
-
-describe('validateRegistrationQuestions', () => {
-  it('accepts an object of known keys with string answers', () => {
-    expect(validateRegistrationQuestions({ referralSource: 'A friend', guests: 'Yes' })).toBe(true)
-  })
-
-  it('accepts null / undefined (the field is optional)', () => {
-    expect(validateRegistrationQuestions(null)).toBe(true)
-    expect(validateRegistrationQuestions(undefined)).toBe(true)
-  })
-
-  it('rejects a non-object', () => {
-    expect(validateRegistrationQuestions('nope')).toMatch(/must be an object/)
-    expect(validateRegistrationQuestions(['a'])).toMatch(/must be an object/)
-  })
-
-  it('rejects an unknown question key', () => {
-    expect(validateRegistrationQuestions({ mystery: 'x' })).toMatch(/Unknown registration question/)
-  })
-
-  it('rejects a non-string answer', () => {
-    expect(validateRegistrationQuestions({ guests: 3 })).toMatch(/must be text/)
-  })
-})
+import { buildRegistrationAnswers } from '@/lib/registrations/questions'
 
 describe('buildRegistrationAnswers', () => {
   it('maps a known question key to its configured label', () => {


### PR DESCRIPTION
## Summary

Follow-up to #594 (merged). Now that the app runs on **Railway (Node.js)**, not Cloudflare Workers, Payload's `json`-field `jsonSchema` is viable again — it compiles an Ajv `new Function()` validator, which only threw under the (now-decommissioned) Workers V8 codegen ban.

Replaces the hand-written `RegistrationQuestions` type + pure-JS `validateRegistrationQuestions` on `Registrations.questions` with a `jsonSchema` derived from `EVENT_REGISTRATION_QUESTIONS`:

- Payload now **auto-generates** the `questions` TS type in `payload-types.ts` (with the question labels as JSDoc) — the typed field originally asked for in #588.
- It **validates on write** (Ajv, `additionalProperties: false`): an unknown key or non-string answer → `ValidationError` → `400` at `POST /api/events/:id/register`.

## Context

The codebase deliberately avoided `jsonSchema` because Ajv's `new Function()` codegen throws under Cloudflare Workers' V8 isolate. That runtime is gone (Railway migration complete — see `RAILWAY_RUNBOOK.md`), so the constraint no longer applies. Comments in `src/fields/translationsField.ts` and `src/lib/utilities/subtitles.ts` still cite it and are now stale — left untouched here (out of scope; flagged for a future cleanup).

## Test results

- Integration: `event-registration.int.spec.ts` **31 passed** — including the unknown-key → **400** enforcement (now via Ajv) and valid / no-questions → 201.
- Unit: `buildRegistrationAnswers` tests retained; the `validateRegistrationQuestions` tests were removed with the function. Full unit lane green.
- Lint ✓ · Typecheck ✓.

Refs #588, #594.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
