### PR TITLE
chore(types): typecheck the test suite, starting with the unit lane

### DIFF
--- a/.claude/docs/workflow-parity.md
+++ b/.claude/docs/workflow-parity.md
@@ -76,7 +76,7 @@ with a **mktemp body file** → return the URL.
 | Concern | SahajCloud | SahajAtlasWeb | WeMeditateWeb |
 | --- | --- | --- | --- |
 | Schema/contract step | Payload migrations: attempt-then-fallback (`timeout 30 pnpm db:migrations:create <name> --skip-empty < /dev/null`; hand off on exit 124) per `.claude/rules/migrations.md` | `pnpm types:cms` + `pnpm types:openapi` contract refresh | `pnpm types:cms` (consumes SahajCloud types; no migrations) |
-| Lean gate contents | lint + `test:unit` (+ targeted int specs) | lint + typecheck + `test:run` | lint + `tsc --noEmit` + `test:run` |
+| Lean gate contents | lint + typecheck + `typecheck:tests` + `test:unit` (+ targeted int specs) | lint + typecheck + `test:run` | lint + `tsc --noEmit` + `test:run` |
 | Security-review trigger paths | access plugins, Clients/Managers, endpoints, storage, webhooks, payload.config | api config, Widget entry, lexical/HTML sinks, deps, env, vite config | `server/`, `pages/preview/`, wrangler/vite/sentry configs, `scripts/`, env files |
 | Worktree env setup | `CI=true pnpm install`; `.env` is git-tracked (already present); dev server needs a distinct `PORT` (shared instance + shared local Postgres via `push: true`) | `pnpm install`; copy `.env.local` from main checkout if needed | `pnpm install`; copy `.env` / `.dev.vars` from main checkout if needed |
 | Deploy target | Railway (+ per-PR preview) | Cloudflare Pages | Cloudflare Workers + Pages (Ladle) |

--- a/.claude/rules/testing-reqs.md
+++ b/.claude/rules/testing-reqs.md
@@ -23,10 +23,12 @@ Every test command belongs to one of three tiers. Each tier has a job — Claude
 | Tier           | Command                                     | Target runtime | Fires when                                                                                        |
 | -------------- | ------------------------------------------- | -------------- | ------------------------------------------------------------------------------------------------- |
 | **1 — Hook**   | `pnpm test:unit`                            | < 5 s          | Claude PostToolUse Edit/Write on `src/**` and `tests/unit/**` (see `.claude/hooks/unit-test.mjs`) |
-| **2 — Pre-PR** | `pnpm lint && pnpm typecheck && pnpm test:unit`               | < 45 s         | The pr-prep lean gate — `.claude/skills/pr-prep/check.sh`                                         |
-| **3 — CI**     | `pnpm lint && pnpm typecheck && pnpm test && pnpm test:smoke` | ≤ 20 min       | GitHub Actions on every PR (`.github/workflows/ci.yml`)                                           |
+| **2 — Pre-PR** | `pnpm lint && pnpm typecheck && pnpm typecheck:tests && pnpm test:unit`               | < 45 s         | The pr-prep lean gate — `.claude/skills/pr-prep/check.sh`                                         |
+| **3 — CI**     | `pnpm lint && pnpm typecheck && pnpm typecheck:tests && pnpm test && pnpm test:smoke` | ≤ 20 min       | GitHub Actions on every PR (`.github/workflows/ci.yml`)                                           |
 
 > **Why `pnpm typecheck` is its own gate step:** `eslint` and Vitest do **not** type-check (`tsc`), so a type error passes lint + the whole test suite and surfaces only at the Railway build — i.e. after merge. Tier 2 and CI both run `tsc --noEmit` (~15-20 s) to catch it before merge.
+>
+> **Why `pnpm typecheck:tests` is separate:** the root `tsconfig.json` lists `tests` in `exclude`, and it's the config the Next.js build consumes — so `pnpm typecheck` covers `src/` only. Without a second pass nothing checks the specs at all (esbuild erases their types without checking them), and a stale fixture surfaces as a *runtime* integration failure, or never. `tsconfig.test.json` closes that gap; it currently scopes to the **unit lane** (`tests/unit/**` + `tests/utils/**`), and widening it to `tests/int/**` is tracked in #606 Phase 2. Keeping the two commands apart means a failure names the lane it came from.
 
 Tier-specific guidance:
 
@@ -47,10 +49,12 @@ Run the full `pnpm test:int` locally, or `check.sh --full` for CI parity, **only
 ## Test Commands
 
 ```bash
-pnpm test:unit   # Tier 1 — unit lane only (fast, no Payload bootstrap)
-pnpm test        # Tier 3 first half — unit + integration (what CI runs locally)
-pnpm test:int    # Integration tests (Vitest) — targeted spec preferred
-pnpm test:smoke  # Tier 3 second half — Playwright against CF PR preview (CI-only)
+pnpm test:unit        # Tier 1 — unit lane only (fast, no Payload bootstrap)
+pnpm test             # Tier 3 first half — unit + integration (what CI runs locally)
+pnpm test:int         # Integration tests (Vitest) — targeted spec preferred
+pnpm test:smoke       # Tier 3 second half — Playwright against CF PR preview (CI-only)
+pnpm typecheck        # tsc over src/ (root tsconfig — excludes tests)
+pnpm typecheck:tests  # tsc over the test suite (tsconfig.test.json — unit lane)
 ```
 
 ## Correct Usage

--- a/.claude/skills/pr-prep/check.sh
+++ b/.claude/skills/pr-prep/check.sh
@@ -39,7 +39,7 @@ fi
 echo "✓ Lint passed"
 echo
 
-echo "=== Typecheck ==="
+echo "=== Typecheck (src) ==="
 if ! pnpm typecheck; then
   echo
   echo "❌ Typecheck failed. Fix type errors before continuing."
@@ -48,6 +48,19 @@ if ! pnpm typecheck; then
   exit 1
 fi
 echo "✓ Typecheck passed"
+echo
+
+# Separate from the src pass: the root tsconfig excludes `tests`, so specs are
+# otherwise never typechecked — Vitest transpiles via esbuild, which erases types
+# without checking them (#606). Scoped to the unit lane; `tests/int/**` is Phase 2.
+echo "=== Typecheck (tests) ==="
+if ! pnpm typecheck:tests; then
+  echo
+  echo "❌ Test-suite typecheck failed. Fix type errors before continuing."
+  echo "  Scope is tsconfig.test.json (tests/unit + tests/utils)."
+  exit 1
+fi
+echo "✓ Test-suite typecheck passed"
 echo
 
 if [[ "$MODE" == "--full" ]]; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,7 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - run: pnpm lint
       - run: pnpm typecheck # tsc --noEmit — lint and Vitest don't typecheck; only this + the Railway build do
+      - run: pnpm typecheck:tests # the root tsconfig excludes `tests`, so specs need their own pass (#606)
       - run: pnpm test # test:unit + test:int (integration runs against Postgres)
 
       # ── Smoke specs against the Railway PR preview ──────────────────────────

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,7 +49,8 @@ Manual fallback: `pnpm dev` (start), `pnpm devsafe` (clean dev — removes `.nex
 ### Code Quality, Types, Testing
 
 - `pnpm lint` — ESLint
-- `pnpm typecheck` — TypeScript type checking
+- `pnpm typecheck` — TypeScript type checking over `src/` (the root `tsconfig.json` excludes `tests`)
+- `pnpm typecheck:tests` — the same over the test suite, via `tsconfig.test.json` (unit lane for now; `tests/int/**` is #606 Phase 2)
 - `pnpm generate:types` — TypeScript types from Payload schema (after schema changes)
 - `pnpm generate:importmap` — admin-panel import map
 - `pnpm test:unit` — fast unit lane (~1–2 s, no Payload bootstrap)
@@ -141,8 +142,8 @@ The test suite runs in three tiers (see `.claude/rules/testing-reqs.md` for the 
 | Tier           | Command                                     | Fires when                                               |
 | -------------- | ------------------------------------------- | -------------------------------------------------------- |
 | **1 — Hook**   | `pnpm test:unit`                            | Claude PostToolUse on `src/**` / `tests/unit/**` (< 5 s) |
-| **2 — Pre-PR** | `pnpm lint && pnpm typecheck && pnpm test:unit`               | Local pr-prep lean gate (< 45 s)                         |
-| **3 — CI**     | `pnpm lint && pnpm typecheck && pnpm test && pnpm test:smoke` | GitHub Actions on every PR (≤ 20 min)                    |
+| **2 — Pre-PR** | `pnpm lint && pnpm typecheck && pnpm typecheck:tests && pnpm test:unit`               | Local pr-prep lean gate (< 45 s)                         |
+| **3 — CI**     | `pnpm lint && pnpm typecheck && pnpm typecheck:tests && pnpm test && pnpm test:smoke` | GitHub Actions on every PR (≤ 20 min)                    |
 
 Before marking a PR ready, run the **Tier 2** lean gate plus the targeted integration spec(s) for what you changed. Use the `/pr-prep` skill (`.claude/skills/pr-prep/`) — its `--full` flag reproduces the Tier 3 checks locally when you need to debug a red run, and it documents handling pre-existing failures. Don't block on a local full-suite/build run — that's CI's job.
 

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "start": "HOSTNAME=0.0.0.0 NODE_OPTIONS=--max-http-header-size=65536 node .next/standalone/server.js",
     "lint": "eslint . --max-warnings 0",
     "typecheck": "tsc --noEmit",
+    "typecheck:tests": "tsc --noEmit -p tsconfig.test.json",
     "audit": "pnpm audit --audit-level=high",
     "postinstall": "node scripts/postinstall.cjs",
     "test": "pnpm run test:unit && pnpm run test:int",

--- a/tests/unit/document-managers.unit.spec.ts
+++ b/tests/unit/document-managers.unit.spec.ts
@@ -1,4 +1,4 @@
-import type { FlattenedField, Payload, PayloadRequest } from 'payload'
+import type { CollectionSlug, FlattenedField, Payload, PayloadRequest } from 'payload'
 
 import { describe, expect, it } from 'vitest'
 
@@ -10,7 +10,7 @@ import {
 } from '@/plugins/access/documentManagers'
 
 /** Build a mock payload exposing only the `flattenedFields` the introspection reads. */
-function payloadWithFields(collection: string, fields: Partial<FlattenedField>[]): Payload {
+function payloadWithFields(collection: CollectionSlug, fields: Partial<FlattenedField>[]): Payload {
   return {
     collections: { [collection]: { config: { flattenedFields: fields } } },
   } as unknown as Payload
@@ -28,7 +28,7 @@ const managerSingle: Partial<FlattenedField> = {
   relationTo: 'managers',
   hasMany: false,
 }
-const selfParent = (collection: string): Partial<FlattenedField> => ({
+const selfParent = (collection: CollectionSlug): Partial<FlattenedField> => ({
   type: 'relationship',
   name: 'parent',
   relationTo: collection,
@@ -90,10 +90,10 @@ describe('getDocManagerFields', () => {
 
   it('matches a polymorphic relationTo array that includes managers', () => {
     const fields = getDocManagerFields(
-      payloadWithFields('things', [
+      payloadWithFields('events', [
         { type: 'relationship', name: 'manager', relationTo: ['managers', 'clients'] },
       ]),
-      'things',
+      'events',
     )
     expect(fields.managerField).toBe('manager')
   })
@@ -126,7 +126,7 @@ describe('parent-walk fallback (no breadcrumbs) terminates on cycles', () => {
       },
     } as unknown as PayloadRequest
 
-    const ids = await resolveManagedDocIds(req, 'things', 99, parentFields)
+    const ids = await resolveManagedDocIds(req, 'regions', 99, parentFields)
     expect(ids.sort()).toEqual([1, 2])
   })
 
@@ -142,7 +142,7 @@ describe('parent-walk fallback (no breadcrumbs) terminates on cycles', () => {
       },
     } as unknown as PayloadRequest
 
-    await expect(userManagesDocument(req, 'things', 99, 3, parentFields)).resolves.toBe(false)
+    await expect(userManagesDocument(req, 'regions', 99, 3, parentFields)).resolves.toBe(false)
   })
 
   it('userManagesDocument finds the user on an ancestor via the parent walk', async () => {
@@ -157,6 +157,6 @@ describe('parent-walk fallback (no breadcrumbs) terminates on cycles', () => {
       },
     } as unknown as PayloadRequest
 
-    await expect(userManagesDocument(req, 'things', 99, 5, parentFields)).resolves.toBe(true)
+    await expect(userManagesDocument(req, 'regions', 99, 5, parentFields)).resolves.toBe(true)
   })
 })

--- a/tests/unit/filterAvailableLocales.spec.ts
+++ b/tests/unit/filterAvailableLocales.spec.ts
@@ -62,7 +62,7 @@ describe('filterAvailableLocales', () => {
     it('returns all locales for API clients (not filtered)', () => {
       const clientUser = testData.dummyUser('clients', {
         id: 1,
-        roles: ['wemeditate-web'],
+        roles: ['wemeditate-web-client'],
       })
       const req = createMockRequest(clientUser)
       const result = filterAvailableLocales({ locales: allLocales, req })
@@ -77,7 +77,7 @@ describe('filterAvailableLocales', () => {
       const inactiveUser = testData.dummyUser('managers', {
         id: 1,
         type: 'inactive',
-        roles: { en: ['translator'], cs: ['meditations-editor'] },
+        roles: { en: ['web-translator'], cs: ['meditations-editor'] },
       })
       const req = createMockRequest(inactiveUser)
       const result = filterAvailableLocales({ locales: allLocales, req })
@@ -92,7 +92,7 @@ describe('filterAvailableLocales', () => {
       const managerUser = testData.dummyUser('managers', {
         id: 1,
         type: 'manager',
-        roles: { cs: ['meditations-editor'], de: ['translator'] },
+        roles: { cs: ['meditations-editor'], de: ['web-translator'] },
       })
       const req = createMockRequest(managerUser)
       const result = filterAvailableLocales({ locales: allLocales, req })
@@ -133,10 +133,10 @@ describe('filterAvailableLocales', () => {
         id: 1,
         type: 'manager',
         roles: {
-          en: ['translator'],
+          en: ['web-translator'],
           cs: ['meditations-editor'],
           de: ['path-editor'],
-          fa: ['translator'],
+          fa: ['web-translator'],
         },
       })
       const req = createMockRequest(managerUser)
@@ -153,7 +153,7 @@ describe('filterAvailableLocales', () => {
         type: 'manager',
       })
       // Explicitly set roles to undefined to simulate missing field
-      ;(managerUser as Record<string, unknown>).roles = undefined
+      ;(managerUser as unknown as Record<string, unknown>).roles = undefined
 
       const req = createMockRequest(managerUser)
       const result = filterAvailableLocales({ locales: allLocales, req })
@@ -168,7 +168,10 @@ describe('filterAvailableLocales', () => {
         type: 'manager',
       })
       // Set roles to flat array to simulate legacy format
-      ;(managerUser as Record<string, unknown>).roles = ['translator', 'meditations-editor']
+      ;(managerUser as unknown as Record<string, unknown>).roles = [
+        'web-translator',
+        'meditations-editor',
+      ]
 
       const req = createMockRequest(managerUser)
       const result = filterAvailableLocales({ locales: allLocales, req })
@@ -184,7 +187,7 @@ describe('filterAvailableLocales', () => {
       const managerUser = testData.dummyUser('managers', {
         id: 1,
         type: 'manager',
-        roles: { fa: ['translator'], de: ['meditations-editor'], en: ['path-editor'] },
+        roles: { fa: ['web-translator'], de: ['meditations-editor'], en: ['path-editor'] },
       })
       const req = createMockRequest(managerUser)
       const result = filterAvailableLocales({ locales: allLocales, req })

--- a/tests/unit/lectures-for-audience-helpers.spec.ts
+++ b/tests/unit/lectures-for-audience-helpers.spec.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from 'vitest'
 
 import { mergeSubtitles } from '@/lib/lectures/lectureShape'
+import type { Lecture } from '@/payload-types'
+
+
+/** The `overrides` argument's own type, so locale codes are checked. */
+type SubtitleOverrides = NonNullable<Lecture['subtitles']>
 
 describe('mergeSubtitles', () => {
   it('returns the base map unchanged when there are no overrides', () => {
@@ -12,7 +17,7 @@ describe('mergeSubtitles', () => {
 
   it('layers each non-empty override on top of the base map', () => {
     const base = { en: 'base-en', es: 'base-es', de: 'base-de' }
-    const overrides = [
+    const overrides: SubtitleOverrides = [
       { locale: 'es', url: 'override-es' },
       { locale: 'fr', url: 'override-fr' },
     ]
@@ -26,10 +31,10 @@ describe('mergeSubtitles', () => {
 
   it('ignores override rows with empty or missing url', () => {
     const base = { en: 'base-en' }
-    const overrides = [
+    const overrides: SubtitleOverrides = [
       { locale: 'en', url: '' },
       { locale: 'es', url: 'override-es' },
-    ] as Array<{ locale: string; url: string }>
+    ]
     expect(mergeSubtitles(base, overrides)).toEqual({
       en: 'base-en', // empty url did NOT override
       es: 'override-es',

--- a/tests/unit/openapi-endpoint-auth.spec.ts
+++ b/tests/unit/openapi-endpoint-auth.spec.ts
@@ -15,6 +15,7 @@ function buildProtectedHandler(handler = vi.fn(() => new Response('ok'))): Endpo
   const config = openapiEndpointAuth({
     path: '/openapi-raw.json',
   })({
+    // A minimal config — the plugin only reads `endpoints`.
     endpoints: [
       {
         method: 'get',
@@ -22,7 +23,7 @@ function buildProtectedHandler(handler = vi.fn(() => new Response('ok'))): Endpo
         handler,
       },
     ],
-  } as Config)
+  } as unknown as Config)
 
   return config.endpoints![0].handler
 }

--- a/tests/unit/registration-details.spec.ts
+++ b/tests/unit/registration-details.spec.ts
@@ -28,7 +28,10 @@ function schedule(overrides: Partial<Schedule> = {}): Schedule {
   } as Schedule
 }
 
-function event(overrides: Partial<Event> = {}): Event {
+// `title` is widened to allow `null`: the collection requires it, so that state
+// is unreachable in practice, but the shaper defends against it with an
+// id-based fallback and the case below asserts that defence.
+function event(overrides: Partial<Omit<Event, 'title'>> & { title?: string | null } = {}): Event {
   return {
     id: 1,
     title: 'Meditation Class',

--- a/tests/unit/server-env.spec.ts
+++ b/tests/unit/server-env.spec.ts
@@ -1,5 +1,10 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
+// `NODE_ENV` is required on `ProcessEnv` (Next augments it) and is always set
+// during a test run, so it's carried through even when clearing the vars under
+// test — none of which it is.
+const baseEnv = { NODE_ENV: 'test' } as const
+
 const requiredEnv = {
   PAYLOAD_SECRET: 'test-secret-key-with-32-chars-minimum',
   DATABASE_URL: 'postgresql://postgres:postgres@localhost:5432/payload_test',
@@ -18,20 +23,20 @@ describe('serverEnv', () => {
   })
 
   it('does not validate server variables when the module is imported', async () => {
-    process.env = {}
+    process.env = { ...baseEnv }
 
     await expect(import('../../src/lib/env/server')).resolves.toBeDefined()
   })
 
   it('validates when a server variable is accessed', async () => {
-    process.env = { ...requiredEnv }
+    process.env = { ...baseEnv, ...requiredEnv }
     const { serverEnv } = await import('../../src/lib/env/server')
 
     expect(serverEnv.PAYLOAD_SECRET).toBe(requiredEnv.PAYLOAD_SECRET)
   })
 
   it('throws a client-specific error if server variables are accessed in a browser bundle', async () => {
-    process.env = {}
+    process.env = { ...baseEnv }
     vi.stubGlobal('window', {})
     const { serverEnv } = await import('../../src/lib/env/server')
 

--- a/tests/unit/storageIsolationGuard.spec.ts
+++ b/tests/unit/storageIsolationGuard.spec.ts
@@ -149,7 +149,8 @@ describe('Cloudflare Stream delete guard', () => {
       return jsonResponse({ success: true, errors: [] })
     })
 
-  const deleteCalls = (spy: ReturnType<typeof vi.spyOn>) =>
+  // Typed off the helper above, so `calls` keeps `fetch`'s argument tuple.
+  const deleteCalls = (spy: ReturnType<typeof mockFetchWithMeta>) =>
     spy.mock.calls.filter(([, init]) => (init?.method ?? 'GET').toUpperCase() === 'DELETE')
 
   const handleDelete = (uid: string) =>

--- a/tests/unit/thumbnail-url.spec.ts
+++ b/tests/unit/thumbnail-url.spec.ts
@@ -1,9 +1,12 @@
 import { describe, expect, it } from 'vitest'
 
 import { resolveThumbnailUrl } from '@/lib/utilities/thumbnailUrl'
+import type { Image } from '@/payload-types'
+
 
 describe('resolveThumbnailUrl', () => {
-  const img = (url: string) => ({ id: 1, url }) as { id: number; url: string }
+  // A populated thumbnail relationship; the resolver only reads `url`.
+  const img = (url: string) => ({ id: 1, url }) as Image
 
   it('picks the override first', () => {
     expect(

--- a/tests/unit/url-field.spec.ts
+++ b/tests/unit/url-field.spec.ts
@@ -1,11 +1,15 @@
+import type { TextFieldSingleValidation } from 'payload'
+
 import { describe, expect, it } from 'vitest'
 
 import { urlField } from '@/fields/urlField'
 
-// The factory's validator only reads `value`; the second arg is unused.
+// The factory's validator only reads `value`; the second arg is unused. It
+// returns `TextField`, whose `validate` widens to the hasMany union — but the
+// factory pins `hasMany: false`, so narrow to the single-value form it casts to.
 const validatorFor = (options?: { protocols?: string[] }) => {
-  const { validate } = urlField({ name: 'link', ...options })
-  return (value: unknown) => validate!(value as string, undefined!)
+  const validate = urlField({ name: 'link', ...options }).validate as TextFieldSingleValidation
+  return (value: unknown) => validate(value as string, undefined!)
 }
 
 describe('urlField validation', () => {

--- a/tests/utils/testData.ts
+++ b/tests/utils/testData.ts
@@ -56,23 +56,18 @@ type DummyUserOverrides = Partial<Omit<Manager, 'roles'> | Omit<Client, 'roles'>
 }
 
 /**
- * Checks a test factory's `create` payload, then hands it to `payload.create` at
- * the type that operation wants.
+ * Checks a factory's `create` payload, then hands it over at the type
+ * `payload.create` wants.
  *
- * Payload derives `create`'s `data` type from the generated *output* doc type, so
- * every field carrying a `defaultValue` or a value-filling hook is typed as
- * **required** even though Payload supplies it when omitted — `slug` (via
- * `slugField`), `appCards.default.aspectRatio`, `userChoices.type`, and more.
- * Factories additionally spread `Partial<Doc>` overrides into `data`, which
- * re-widens genuinely-required keys to `T | undefined`.
+ * Payload derives that `data` type from the generated *output* doc, so fields it
+ * fills in itself are still demanded on input (`slug`, `userChoices.type`, …), and
+ * the `Partial<Doc>` overrides these factories spread in re-widen required keys to
+ * `T | undefined`. Hence the partial: Payload supplies the rest, and its own
+ * validation — which the int lane exercises — enforces what's truly required.
  *
- * So the payload is modelled as partial: Payload fills the remainder, and its own
- * validation — exercised by the int lane — is what enforces truly-required fields.
- * What `tsc` still checks here, and the reason this seam exists, is that every
- * field a test *does* pass is a real field of that collection with a valid type.
- * That's the rot #606 is about: a renamed field or a stale enum literal (say
- * `level: 'center'` after #605) now fails instantly instead of after a 7-minute
- * CI round.
+ * What `tsc` still catches is the point: every field a test *does* pass must be a
+ * real field of that collection, with a valid type. That's the #606 rot — a stale
+ * enum literal like `level: 'center'` now fails here, not 7 minutes into CI.
  */
 function createData<TSlug extends CollectionSlug>(
   data: Partial<RequiredDataFromCollectionSlug<TSlug>>,

--- a/tests/utils/testData.ts
+++ b/tests/utils/testData.ts
@@ -1,4 +1,4 @@
-import type { Payload, TypedUser } from 'payload'
+import type { CollectionSlug, Payload, RequiredDataFromCollectionSlug, TypedUser } from 'payload'
 
 import fs from 'fs'
 import path from 'path'
@@ -24,11 +24,44 @@ import type {
   Video,
   Author,
   Lecture,
-  ManagerRole,
-  ClientRole,
   Event,
   Region,
 } from '@/payload-types'
+
+/**
+ * Manager- and client-specific role subsets.
+ *
+ * `@/payload-types` exports only the combined `RoleSlug` — all seven roles, which
+ * the access plugin injects into the generated JSON schema — so these are derived
+ * from each collection's own `roles` field and track it automatically.
+ */
+type ManagerRole = NonNullable<Manager['roles']>[number]
+type ClientRole = NonNullable<Client['roles']>[number]
+
+/**
+ * Checks a test factory's `create` payload, then hands it to `payload.create` at
+ * the type that operation wants.
+ *
+ * Payload derives `create`'s `data` type from the generated *output* doc type, so
+ * every field carrying a `defaultValue` or a value-filling hook is typed as
+ * **required** even though Payload supplies it when omitted — `slug` (via
+ * `slugField`), `appCards.default.aspectRatio`, `userChoices.type`, and more.
+ * Factories additionally spread `Partial<Doc>` overrides into `data`, which
+ * re-widens genuinely-required keys to `T | undefined`.
+ *
+ * So the payload is modelled as partial: Payload fills the remainder, and its own
+ * validation — exercised by the int lane — is what enforces truly-required fields.
+ * What `tsc` still checks here, and the reason this seam exists, is that every
+ * field a test *does* pass is a real field of that collection with a valid type.
+ * That's the rot #606 is about: a renamed field or a stale enum literal (say
+ * `level: 'center'` after #605) now fails instantly instead of after a 7-minute
+ * CI round.
+ */
+function createData<TSlug extends CollectionSlug>(
+  data: Partial<RequiredDataFromCollectionSlug<TSlug>>,
+): RequiredDataFromCollectionSlug<TSlug> {
+  return data as RequiredDataFromCollectionSlug<TSlug>
+}
 
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = path.dirname(__filename)
@@ -83,7 +116,7 @@ export const testData = {
 
     return (await payload.create({
       collection: 'app-cards',
-      data: {
+      data: createData<'app-cards'>({
         label: `Test Card ${uniqueId}`,
         type: 'standard',
         ...restOverrides,
@@ -92,9 +125,15 @@ export const testData = {
           header: 'Test Header',
           textColor: 'black',
           image: imageId,
+          // `default` is a nested group, so `createData`'s top-level `Partial`
+          // doesn't reach inside it — and both of these are `required: true` with
+          // a `defaultValue` in AppCards. Pass the collection's own declared
+          // defaults, which is what Payload would have filled in anyway.
+          aspectRatio: 'square',
+          alignment: 'center',
           ...defaultOverrides,
         },
-      },
+      }),
     })) as AppCard
   },
 
@@ -239,11 +278,11 @@ export const testData = {
 
     return (await payload.create({
       collection: 'user-choices',
-      data: {
+      data: createData<'user-choices'>({
         title: defaultTitle,
         color: '#FF5733',
         ...overrides,
-      },
+      }),
       file: {
         // Use Buffer directly - SVG detection requires Buffer.toString(encoding, start, end)
         data: fileBuffer,
@@ -334,10 +373,10 @@ export const testData = {
 
     return (await payload.create({
       collection: 'song-tags',
-      data: {
+      data: createData<'song-tags'>({
         title: defaultTitle,
         ...overrides,
-      },
+      }),
       file: {
         // Use Buffer directly - SVG detection requires Buffer.toString(encoding, start, end)
         data: fileBuffer,
@@ -632,10 +671,9 @@ export const testData = {
       },
     })
 
-    return {
-      collection: 'managers',
-      ...manager,
-    } as Manager & { collection: 'managers' }
+    // `collection` last: the access-control mocks in `.claude/rules/tests.md`
+    // require the discriminator, so it must not be spreadable-away.
+    return { ...manager, collection: 'managers' as const }
   },
 
   /**
@@ -657,10 +695,7 @@ export const testData = {
       },
     })
 
-    return {
-      collection: 'clients',
-      ...client,
-    } as Client & { collection: 'clients' }
+    return { ...client, collection: 'clients' as const }
   },
 
   /**
@@ -673,7 +708,7 @@ export const testData = {
 
     return (await payload.create({
       collection: 'pages',
-      data: {
+      data: createData<'pages'>({
         title: overrides.title || defaultTitle,
         tags: [],
         content: {
@@ -703,7 +738,7 @@ export const testData = {
           },
         },
         ...overrides,
-      },
+      }),
     })) as Page
   },
 
@@ -777,10 +812,10 @@ export const testData = {
   async createAuthor(payload: Payload, overrides: Partial<Author> = {}): Promise<Author> {
     return (await payload.create({
       collection: 'authors',
-      data: {
+      data: createData<'authors'>({
         name: 'Test Author',
         ...overrides,
-      },
+      }),
     })) as Author
   },
 
@@ -922,7 +957,7 @@ export const testData = {
 
     return (await payload.create({
       collection: 'regions',
-      data: {
+      data: createData<'regions'>({
         name,
         level: 'city',
         mapboxId,
@@ -931,7 +966,7 @@ export const testData = {
         longitude: 0,
         radius: 1000,
         ...overrides,
-      },
+      }),
     })) as Region
   },
 

--- a/tests/utils/testData.ts
+++ b/tests/utils/testData.ts
@@ -4,6 +4,7 @@ import fs from 'fs'
 import path from 'path'
 import { fileURLToPath } from 'url'
 
+import type { LocaleCode } from '@/lib/locales'
 import type {
   AppCard,
   Narrator,
@@ -26,17 +27,33 @@ import type {
   Lecture,
   Event,
   Region,
+  RoleSlug,
 } from '@/payload-types'
 
 /**
- * Manager- and client-specific role subsets.
+ * The manager-specific role subset.
  *
  * `@/payload-types` exports only the combined `RoleSlug` — all seven roles, which
- * the access plugin injects into the generated JSON schema — so these are derived
- * from each collection's own `roles` field and track it automatically.
+ * the access plugin injects into the generated JSON schema — so this is derived
+ * from the collection's own `roles` field and tracks it automatically.
  */
 type ManagerRole = NonNullable<Manager['roles']>[number]
-type ClientRole = NonNullable<Client['roles']>[number]
+
+/**
+ * Overrides for `dummyUser` — a hand-built mock auth user, not a real document.
+ *
+ * `roles` is declared apart from the generated doc types because manager roles
+ * are **localized**: at runtime they arrive as a per-locale record, which is the
+ * shape `filterAvailableLocales` reads, while Payload generates the field as a
+ * flat array. Intersecting `{ roles?: … }` onto the doc type wouldn't override
+ * that array, it would intersect with it — so `roles` is `Omit`ted from the doc
+ * fields first. Locale keys are optional: a manager only has entries for locales
+ * they hold a role in, and both readers already treat an absent key as "no roles"
+ * (`extractRoles` does `roles[locale] || []`).
+ */
+type DummyUserOverrides = Partial<Omit<Manager, 'roles'> | Omit<Client, 'roles'>> & {
+  roles?: RoleSlug[] | Partial<Record<LocaleCode, RoleSlug[]>>
+}
 
 /**
  * Checks a test factory's `create` payload, then hands it to `payload.create` at
@@ -910,9 +927,9 @@ export const testData = {
    *   permissions: { pages: ['read', 'translate'], projects: ['wemeditate-web'] }
    * })
    */
-  dummyUser(collection: 'managers' | 'clients', overrides: Partial<Manager | Client> = {}) {
+  dummyUser(collection: 'managers' | 'clients', overrides: DummyUserOverrides = {}) {
     // Handle roles field based on collection type
-    let defaultRoles: ManagerRole[] | ClientRole[] | { en: string[] }
+    let defaultRoles: NonNullable<DummyUserOverrides['roles']>
     if (collection === 'managers') {
       // Managers have localized roles
       defaultRoles = overrides.roles || { en: [] }

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,16 @@
+{
+  // Typecheck gate for the test suite. The root `tsconfig.json` excludes
+  // `tests`, and it's the config the Next.js build consumes — so the test lane
+  // gets its own config here instead, keeping this work off the shipping build.
+  //
+  // Scoped to the unit lane for now (#606 Phase 1). `tests/int/**` still has
+  // ~154 errors; widening `include` to `tests/**` is Phase 2. `src/**` needs no
+  // entry — it's pulled in transitively via the `@/` imports these files make,
+  // and the root config already typechecks it directly.
+  //
+  // Note: `tests/tsconfig.json` is a separate editor-only config covering all of
+  // `tests/**`. No script runs it; Phase 2 should collapse the two.
+  "extends": "./tsconfig.json",
+  "include": ["tests/unit/**/*.ts", "tests/utils/**/*.ts"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary

- No file under `tests/` was ever typechecked — `tsconfig.json` excludes `tests`, ESLint doesn't typecheck, and Vitest's esbuild erases types without checking them. Adds a gate that does.
- Clears the 34 errors that gate surfaced, including two imports of types that don't exist and five stale role slugs.
- Scoped to the unit lane; widening to `tests/int/**` (~154 errors) is Phase 2, deliberately not in this PR.

## Changes

- `tsconfig.test.json` (new) — extends the root config, includes `tests/unit/**` + `tests/utils/**`. `tsconfig.json` is untouched, so this carries zero risk of changing what the Next.js build ships.
- `package.json` — adds `typecheck:tests`. `typecheck` stays src-only rather than composing both, so a failure names the lane it came from.
- `.claude/skills/pr-prep/check.sh`, `.github/workflows/ci.yml` — run it as its own Tier 2 / Tier 3 step.
- `tests/utils/testData.ts` — the three concentrated root causes in the shared factory (below).
- `tests/unit/**` (9 files) — each spec now types its fixtures against the real contract instead of a hand-written approximation.
- `.claude/rules/testing-reqs.md`, `AGENTS.md`, `.claude/docs/workflow-parity.md` — tier tables documented Tier 2/3 as `lint && typecheck && test`.

### What the exclusion was hiding

- **Imports of types that don't exist.** `ManagerRole` / `ClientRole` were imported from `@/payload-types`, which exports neither — the suite passed only because esbuild strips type imports without resolving them. `@/payload-types` exports just the combined `RoleSlug`, so the two subsets are now derived from each collection's own `roles` field and track it automatically.
- **Five stale role slugs.** `dummyUser` took `Partial<Manager | Client>`, checking `roles` against the generated flat array — which both admits invalid slugs and rejects the localized per-locale form the spec actually uses. Retyping it surfaced `'translator'` (×5, now `'web-translator'`) and `'wemeditate-web'` (now `'wemeditate-web-client'`; the `-client` suffix exists precisely to disambiguate roles from project slugs). Outcomes are unchanged — clients skip locale filtering entirely, and the manager cases only need a non-empty array per locale — so all 12 cases still pass, now for the right reason.
- **A spread that could clobber the `collection` discriminator.** `{ collection: 'managers', ...manager }` put the spread last, with an `as` cast hiding it, against a rule (`.claude/rules/tests.md`) that access-control mocks must carry it. **No runtime misbehaviour today** — Payload's returned doc has no `collection` key, so there was nothing to overwrite, and the 54 access specs pass either way — but it was one generated-type change away from breaking silently. Corrected; the cast is no longer needed.

## Test Results

- `pnpm typecheck:tests`: ✓ exits 0 (from 34 errors / 10 files)
- Unit: ✓ 849 passed (81 files)
- Integration (targeted): ✓ `role-based-access` 54, `app-cards-for-audience` 32, `collections-smoke` 19 — the specs covering the factory changes that aren't purely type-level
- Lint: ✓ no errors · `pnpm typecheck` (src): ✓ unchanged
- Tier 2 lean gate: ✓ 19–20 s, against its < 45 s target (the new step adds ~4 s)

**Mutation-checked, so the gate isn't passing vacuously.** Injecting `level: 'venue'` into a factory — the exact shape of the #605 escape — fails with `Type '"venue"' is not assignable to type '"region" | "center" | "country" | "city"'`. Review separately confirmed that `createData`'s `Partial` still rejects an unknown property (`nmae`) and that `dummyUser` still rejects an invalid role slug.

## Notes for reviewer

- **`createData` is the one deliberate loosening.** Payload derives `create`'s `data` type from the generated *output* doc, so any field it fills in itself (`slug` via `slugField`, `userChoices.type`, `appCards.default.aspectRatio`) is demanded on input, and the `Partial<Doc>` overrides these factories spread in re-widen required keys to `T | undefined`. Modelling the payload as partial trades "you forgot a required field" — which Payload validates at runtime, and the int lane exercises — for "every field you *do* pass is real and correctly typed", which is the rot #606 is about. Excess-property checking survives, verified above.
- `createAppCard` now passes `aspectRatio: 'square'` / `alignment: 'center'` explicitly: `default` is a nested group, so the top-level `Partial` doesn't reach inside it, and both are `required: true` with a `defaultValue`. Values match the collection's declared defaults, so runtime is identical.
- **Two src-level follow-ups I left out to keep this scoped to tests**, both worth doing in Phase 2: `TypedAuthUser['roles']`'s localized form is typed `Record<LocaleCode, RoleSlug[]>` but is genuinely partial (both readers already do `roles[locale] || []` / `?.length > 0`); and `urlField` declares its return as `TextField` while pinning `hasMany: false` and internally casting `validate` to `TextFieldSingleValidation`, so callers must repeat that cast. I started the first, then reverted it — a shipping-code type change didn't belong in a test-typing PR.
- The pre-existing `tests/tsconfig.json` is editor-only (no script or CI step references it) and covers all of `tests/**`. Left alone for a minimal diff; Phase 2 should collapse the two.
- `workflow-parity.md`'s lean-gate cell for this repo was already stale (it omitted `typecheck` entirely) — corrected here, so `/sync-workflow` should propagate it to SahajAtlasWeb and WeMeditateWeb.

Refs #606 — Phase 1 only; Phase 2 (`tests/int/**`) remains open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
