### PR TITLE
chore(types): typecheck the integration lane (#606 Phase 2)

### DIFF
--- a/.claude/rules/testing-reqs.md
+++ b/.claude/rules/testing-reqs.md
@@ -28,7 +28,9 @@ Every test command belongs to one of three tiers. Each tier has a job — Claude
 
 > **Why `pnpm typecheck` is its own gate step:** `eslint` and Vitest do **not** type-check (`tsc`), so a type error passes lint + the whole test suite and surfaces only at the Railway build — i.e. after merge. Tier 2 and CI both run `tsc --noEmit` (~15-20 s) to catch it before merge.
 >
-> **Why `pnpm typecheck:tests` is separate:** the root `tsconfig.json` lists `tests` in `exclude`, and it's the config the Next.js build consumes — so `pnpm typecheck` covers `src/` only. Without a second pass nothing checks the specs at all (esbuild erases their types without checking them), and a stale fixture surfaces as a *runtime* integration failure, or never. `tsconfig.test.json` closes that gap; it currently scopes to the **unit lane** (`tests/unit/**` + `tests/utils/**`), and widening it to `tests/int/**` is tracked in #606 Phase 2. Keeping the two commands apart means a failure names the lane it came from.
+> **Why `pnpm typecheck:tests` is separate:** the root `tsconfig.json` lists `tests` in `exclude`, and it's the config the Next.js build consumes — so `pnpm typecheck` covers `src/` only. Without a second pass nothing checks the specs at all (esbuild erases their types without checking them), and a stale fixture surfaces as a *runtime* integration failure, or never. `tsconfig.test.json` closes that gap over the whole suite (`tests/**`, ~6 s). Keeping the two commands apart means a failure names the lane it came from.
+>
+> The gate only earns its keep if fixtures are typed against the real schema — see **"Typed fixtures"** in `.claude/rules/tests.md`.
 
 Tier-specific guidance:
 
@@ -54,7 +56,7 @@ pnpm test             # Tier 3 first half — unit + integration (what CI runs l
 pnpm test:int         # Integration tests (Vitest) — targeted spec preferred
 pnpm test:smoke       # Tier 3 second half — Playwright against CF PR preview (CI-only)
 pnpm typecheck        # tsc over src/ (root tsconfig — excludes tests)
-pnpm typecheck:tests  # tsc over the test suite (tsconfig.test.json — unit lane)
+pnpm typecheck:tests  # tsc over the whole test suite (tsconfig.test.json)
 ```
 
 ## Correct Usage

--- a/.claude/rules/tests.md
+++ b/.claude/rules/tests.md
@@ -169,6 +169,51 @@ The bound is deliberate: the lane is **DB-bound** (every suite runs a full-schem
 exhausting connections — see `tests/PERF.md`. `maxConcurrency: 1` only serialises
 tests **within** a file; it does **not** serialise files.
 
+## Typed fixtures
+
+`pnpm typecheck:tests` (`tsconfig.test.json`) type-checks all of `tests/**` in
+~6 s — Vitest doesn't, since esbuild erases types without checking them. Fixtures
+have to be typed against the real schema for that to catch anything, so
+`tests/utils/testData.ts` exports two helpers. Prefer them over
+`Record<string, unknown>`, a bare object literal, or `as any`:
+
+| Use | For |
+| --- | --- |
+| `createData<'slug'>({ … })` | Anything you hand to `payload.create` as `data` |
+| `FixtureOverrides<Doc>` | The param type of a spec's own fixture helper |
+
+```typescript
+import { createData, testData, type FixtureOverrides } from '../utils/testData'
+
+const createRegion = (data: FixtureOverrides<Region>) =>
+  payload.create({
+    collection: 'regions',
+    data: createData<'regions'>({ level: 'country', name: 'Region', ...data }),
+  })
+
+createRegion({ level: 'center' }) // TS2322 — 'center' was renamed to 'venue' (#605)
+```
+
+Why each is needed:
+
+- **`createData`** — Payload derives the create `data` type from the *output*
+  doc, so fields it fills itself (`slug`, …) are still demanded on input. Omit
+  one and `tsc` falls through to the draft-create overload and reports
+  `Property 'draft' is missing`, which points nowhere near the real problem.
+- **`FixtureOverrides<T>`** — every field optional at *every* depth. `Partial<T>`
+  relaxes only the top level, so passing a group obliges you to fill in its
+  `defaultValue`-backed subfields (`default: { title, image }` on an app card
+  wanted `aspectRatio`/`textColor`/`alignment` too). Unknown and mistyped
+  properties still error at any depth, which is the part worth keeping.
+
+Two more shared helpers worth knowing: `runTaskHandler(task, { payload, … })`
+(`tests/utils/taskRunner.ts`) invokes a job task without the queue and returns
+its generated output type — don't hand-roll `Parameters<typeof Task.handler>[0]`,
+which can't compile because `handler` is `string | TaskHandler`. And
+`idOnlySelect()` (`tests/utils/testHelpers.ts`) is the minimal `select` an
+API-client read can pass; `select: {}` is **not** equivalent — the client gate
+rejects an empty select with a 400.
+
 ## Test file organization
 
 | File                              | Purpose                                                                                                                                                                                                                                                                    |

--- a/.claude/skills/pr-prep/check.sh
+++ b/.claude/skills/pr-prep/check.sh
@@ -52,12 +52,13 @@ echo
 
 # Separate from the src pass: the root tsconfig excludes `tests`, so specs are
 # otherwise never typechecked — Vitest transpiles via esbuild, which erases types
-# without checking them (#606). Scoped to the unit lane; `tests/int/**` is Phase 2.
+# without checking them (#606). Covers all of `tests/**`.
 echo "=== Typecheck (tests) ==="
 if ! pnpm typecheck:tests; then
   echo
   echo "❌ Test-suite typecheck failed. Fix type errors before continuing."
-  echo "  Scope is tsconfig.test.json (tests/unit + tests/utils)."
+  echo "  Scope is tsconfig.test.json (all of tests/**)."
+  echo "  Type fixtures with createData / FixtureOverrides — see .claude/rules/tests.md."
   exit 1
 fi
 echo "✓ Test-suite typecheck passed"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,7 +50,7 @@ Manual fallback: `pnpm dev` (start), `pnpm devsafe` (clean dev — removes `.nex
 
 - `pnpm lint` — ESLint
 - `pnpm typecheck` — TypeScript type checking over `src/` (the root `tsconfig.json` excludes `tests`)
-- `pnpm typecheck:tests` — the same over the test suite, via `tsconfig.test.json` (unit lane for now; `tests/int/**` is #606 Phase 2)
+- `pnpm typecheck:tests` — the same over the whole test suite, via `tsconfig.test.json`
 - `pnpm generate:types` — TypeScript types from Payload schema (after schema changes)
 - `pnpm generate:importmap` — admin-panel import map
 - `pnpm test:unit` — fast unit lane (~1–2 s, no Payload bootstrap)

--- a/tests/int/api.int.spec.ts
+++ b/tests/int/api.int.spec.ts
@@ -339,7 +339,7 @@ describe('API', () => {
       // defeated the afterRead dedup tracker and double-counted; post-fix,
       // beforeOperation counts the top-level read once and skips the
       // currentDepth-bearing populate sub-read.
-      const meditation = await testData.createMeditation(payload, {
+      const meditation = await testData.createMeditation(payload, undefined, {
         title: 'Test Meditation for Usage Tracking',
       })
 
@@ -371,8 +371,9 @@ describe('API', () => {
           id: true,
           morningMeditation: true,
         },
+        // `populate` is keyed by the *target collection*, not the field name.
         populate: {
-          morningMeditation: {
+          meditations: {
             title: true,
           },
         },

--- a/tests/int/app-cards-for-audience.int.spec.ts
+++ b/tests/int/app-cards-for-audience.int.spec.ts
@@ -650,7 +650,7 @@ describe('appCardsForAudience endpoint', () => {
         const pageFindCalls = findSpy.mock.calls.filter(
           ([args]) => (args as { collection?: string }).collection === 'pages',
         )
-        expect(pageFindCalls).toHaveLength(1, 'pages should be fetched in a single batched query')
+        expect(pageFindCalls).toHaveLength(1)
       } finally {
         findSpy.mockRestore()
       }

--- a/tests/int/atlas-collections.int.spec.ts
+++ b/tests/int/atlas-collections.int.spec.ts
@@ -2,6 +2,7 @@ import type { Payload } from 'payload'
 
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 
+import { createData } from '../utils/testData'
 import { createTestEnvironment } from '../utils/testHelpers'
 
 /**
@@ -32,12 +33,12 @@ describe('Atlas collections', () => {
       const region = await payload.create({
         collection: 'regions',
         overrideAccess: true,
-        data: {
+        data: createData<'regions'>({
           name: 'Москва',
           level: 'city',
           mapboxId: 'slug-cyrillic-city',
           managers: [managerId],
-        },
+        }),
       })
       expect(region.slug).toBe('moskva')
     })
@@ -47,46 +48,46 @@ describe('Atlas collections', () => {
     it('limits parents to one level up, except City (Country or Region)', async () => {
       const country = await payload.create({
         collection: 'regions',
-        data: {
+        data: createData<'regions'>({
           name: 'PR Country',
           level: 'country',
           mapboxId: 'pr.country',
           managers: [managerId],
-        },
+        }),
       })
       const city = await payload.create({
         collection: 'regions',
-        data: {
+        data: createData<'regions'>({
           name: 'PR City',
           level: 'city',
           mapboxId: 'pr.city',
           parent: country.id, // City may nest directly under a Country (Region optional)
           managers: [managerId],
-        },
+        }),
       })
 
       // A Venue may only nest under a City — not directly under a Country.
       await expect(
         payload.create({
           collection: 'regions',
-          data: {
+          data: createData<'regions'>({
             name: 'Bad Venue',
             level: 'venue',
             mapboxId: 'pr.venue.bad',
             parent: country.id,
             managers: [managerId],
-          },
+          }),
         }),
       ).rejects.toThrow()
       const venueNode = await payload.create({
         collection: 'regions',
-        data: {
+        data: createData<'regions'>({
           name: 'Good Venue',
           level: 'venue',
           mapboxId: 'pr.venue.good',
           parent: city.id,
           managers: [managerId],
-        },
+        }),
       })
       expect(venueNode.id).toBeTruthy()
 
@@ -94,13 +95,13 @@ describe('Atlas collections', () => {
       await expect(
         payload.create({
           collection: 'regions',
-          data: {
+          data: createData<'regions'>({
             name: 'Bad Region',
             level: 'region',
             mapboxId: 'pr.region',
             parent: city.id,
             managers: [managerId],
-          },
+          }),
         }),
       ).rejects.toThrow()
     })
@@ -113,12 +114,12 @@ describe('Atlas collections', () => {
         // draft: the now-required title/schedule are validated only on publish;
         // the title beforeChange hook still runs and auto-fills from the street.
         draft: true,
-        data: {
+        data: createData<'events'>({
           eventType: 'offline',
           registrationMode: 'sahaj-atlas',
           manager: managerId,
           address: { street: 'Hall A, Wing 2' },
-        },
+        }),
       })
 
       expect(event.title).toBe('Meditation at Hall A')
@@ -128,13 +129,13 @@ describe('Atlas collections', () => {
       const event = await payload.create({
         collection: 'events',
         draft: true,
-        data: {
+        data: createData<'events'>({
           title: 'Diwali Special',
           eventType: 'offline',
           registrationMode: 'sahaj-atlas',
           manager: managerId,
           address: { street: 'Hall A' },
-        },
+        }),
       })
 
       expect(event.title).toBe('Diwali Special')
@@ -144,11 +145,11 @@ describe('Atlas collections', () => {
       const event = await payload.create({
         collection: 'events',
         draft: true,
-        data: {
+        data: createData<'events'>({
           eventType: 'online',
           registrationMode: 'sahaj-atlas',
           manager: managerId,
-        },
+        }),
       })
 
       expect(event.title ?? null).toBeNull()
@@ -166,13 +167,13 @@ describe('Atlas collections', () => {
         .create({
           collection: 'events',
           draft: true,
-          data: {
+          data: createData<'events'>({
             eventType: 'offline',
             registrationMode: 'sahaj-atlas',
             manager: managerId,
             address: { street },
             ...(schedule ? { schedule } : {}),
-          },
+          }),
         })
         .then((e) => e.title)
 
@@ -213,14 +214,14 @@ describe('Atlas collections', () => {
       const created = await payload.create({
         collection: 'events',
         draft: true,
-        data: {
+        data: createData<'events'>({
           title: 'Hand-written generic name',
           eventType: 'offline',
           registrationMode: 'sahaj-atlas',
           manager: managerId,
           address: { street: 'Hall A' },
           schedule: { firstDate: '2024-09-06T17:30:00.000Z', firstDate_tz: 'Europe/Berlin' },
-        },
+        }),
       })
       expect(created.title).toBe('Hand-written generic name')
 
@@ -228,7 +229,7 @@ describe('Atlas collections', () => {
         collection: 'events',
         id: created.id,
         draft: true,
-        data: { title: '' },
+        data: createData<'events'>({ title: '' }),
       })
       expect(cleared.title).toBe('Evening Meditation at Hall A')
     })

--- a/tests/int/atlas-collections.int.spec.ts
+++ b/tests/int/atlas-collections.int.spec.ts
@@ -250,7 +250,7 @@ describe('Atlas collections', () => {
         const url = await livePreview.url({
           data: { id: 42 },
           locale: { code: 'cs' },
-        } as Parameters<typeof livePreview.url>[0])
+        } as unknown as Parameters<typeof livePreview.url>[0])
         expect(url).toBe(
           `${process.env.SAHAJATLAS_URL}/preview?collection=${slug}&id=42&secret=${process.env.SAHAJCLOUD_PREVIEW_SECRET}&locale=cs`,
         )

--- a/tests/int/atlas-sidebar.int.spec.ts
+++ b/tests/int/atlas-sidebar.int.spec.ts
@@ -4,7 +4,7 @@ import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 
 import { buildAtlasSidebarData } from '@/lib/atlasSidebar/getAtlasSidebarData'
 
-import { testData } from '../utils/testData'
+import { createData, testData } from '../utils/testData'
 import { createTestEnvironment } from '../utils/testHelpers'
 
 /**
@@ -32,12 +32,12 @@ describe('Atlas sidebar data builder', () => {
     const createRegion = (data: Record<string, unknown>) =>
       payload.create({
         collection: 'regions',
-        data: {
+        data: createData<'regions'>({
           level: 'country',
           name: 'Region',
           mapboxId: `place.${Math.random().toString(36).slice(2)}`,
           ...data,
-        },
+        }),
         depth: 0,
       })
 

--- a/tests/int/audiences.int.spec.ts
+++ b/tests/int/audiences.int.spec.ts
@@ -63,7 +63,7 @@ describe('Audiences Collection', () => {
       await expect(
         payload.create({
           collection: 'audiences',
-          data: {} as Record<string, unknown>,
+          data: createData<'audiences'>({}),
         }),
       ).rejects.toThrow()
     })
@@ -214,7 +214,7 @@ describe('Audiences Collection', () => {
     it('includes app cards in the appCards join', async () => {
       const audience = await testData.createAudience(payload, { label: 'AppCard Join Test' })
       const card = await testData.createAppCard(payload, {
-        title: 'Card With Audience',
+        default: { title: 'Card With Audience' },
         audiences: [audience.id],
       })
 

--- a/tests/int/audiences.int.spec.ts
+++ b/tests/int/audiences.int.spec.ts
@@ -2,7 +2,7 @@ import type { Payload } from 'payload'
 
 import { describe, it, beforeAll, afterAll, expect, vi } from 'vitest'
 
-import { testData } from '../utils/testData'
+import { createData, testData } from '../utils/testData'
 import { createTestEnvironment } from '../utils/testHelpers'
 
 // Mock the Nirmala Vidya API client — prevents real network calls when creating lectures
@@ -82,7 +82,7 @@ describe('Audiences Collection', () => {
       const updated = await payload.update({
         collection: 'audiences',
         id: audience.id,
-        data: { label: 'Updated' },
+        data: createData<'audiences'>({ label: 'Updated' }),
       })
       expect(updated.label).toBe('Updated')
     })
@@ -112,10 +112,10 @@ describe('Audiences Collection', () => {
       await expect(
         payload.create({
           collection: 'audiences',
-          data: {
+          data: createData<'audiences'>({
             label: 'Invalid Range',
             pathProgress: { min: 10, max: 5 },
-          },
+          }),
         }),
       ).rejects.toThrow()
     })

--- a/tests/int/client-origin-enforcement.int.spec.ts
+++ b/tests/int/client-origin-enforcement.int.spec.ts
@@ -5,7 +5,7 @@ import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 import { eventsGeoJson } from '@/collections/Events/endpoints/geojson'
 import { registerForEvent } from '@/collections/Events/endpoints/registerForEvent'
 
-import { testData } from '../utils/testData'
+import { createData, testData } from '../utils/testData'
 import { createTestEnvironment } from '../utils/testHelpers'
 
 /**
@@ -22,9 +22,9 @@ import { createTestEnvironment } from '../utils/testHelpers'
 const SCHEDULE = {
   firstDate: '2025-01-06T10:00:00.000Z',
   firstDate_tz: 'Europe/London',
-  recurrenceType: 'DAILY' as const,
+  recurrenceType: 'DAILY',
   interval: 1,
-}
+} as const
 
 describe('client Origin/Referer enforcement', () => {
   let payload: Payload
@@ -95,7 +95,7 @@ describe('client Origin/Referer enforcement', () => {
     const event = await payload.create({
       collection: 'events',
       overrideAccess: true,
-      data: {
+      data: createData<'events'>({
         title: 'Origin Event',
         languages: ['en'],
         eventType: 'online',
@@ -105,7 +105,7 @@ describe('client Origin/Referer enforcement', () => {
         region: region.id,
         schedule: SCHEDULE,
         _status: 'published',
-      },
+      }),
     })
     eventId = event.id
   })

--- a/tests/int/cloudflare-stream-webhook.int.spec.ts
+++ b/tests/int/cloudflare-stream-webhook.int.spec.ts
@@ -6,10 +6,16 @@
  * booting a Payload instance — the handler is designed to accept an injected
  * logger and fetch so tests stay fast.
  */
+import type { Mock } from 'vitest'
+
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+import type { WebhookLogger } from '@/plugins/storage/cloudflareStreamWebhook'
+
 // Dynamic-import these after env is prepared so any module-level validation
-// (none today, but cheap insurance) sees the expected env values.
+// (none today, but cheap insurance) sees the expected env values. The
+// `WebhookLogger` import above is type-only, so it's erased and doesn't
+// evaluate the module early.
 let parseSignatureHeader: typeof import('@/plugins/storage/cloudflareStreamWebhook').parseSignatureHeader
 let verifySignature: typeof import('@/plugins/storage/cloudflareStreamWebhook').verifySignature
 let handleStreamWebhook: typeof import('@/plugins/storage/cloudflareStreamWebhook').handleStreamWebhook
@@ -17,11 +23,17 @@ let handleStreamWebhook: typeof import('@/plugins/storage/cloudflareStreamWebhoo
 const FAKE_NOW_SECONDS = 1_750_000_000
 const SECRET = 'test-webhook-signing-secret-with-32-plus-chars'
 
-interface CapturedLogger {
-  info: ReturnType<typeof vi.fn>
-  warn: ReturnType<typeof vi.fn>
-  error: ReturnType<typeof vi.fn>
-}
+/**
+ * The injected logger, mocked method-for-method off the real interface.
+ *
+ * Each method was `ReturnType<typeof vi.fn>`, which resolves the generic to its
+ * *constraint* (`Mock<Procedure | Constructable>`) rather than its default — so
+ * the mock wasn't callable as `(obj: object) => void` and every
+ * `handleStreamWebhook({ logger })` call failed to typecheck (11 of #606
+ * Phase 2's errors). Mapping over `WebhookLogger` also means a new method on
+ * the interface breaks `makeLogger` here instead of going unmocked.
+ */
+type CapturedLogger = { [K in keyof WebhookLogger]: Mock<WebhookLogger[K]> }
 
 function makeLogger(): CapturedLogger {
   return {

--- a/tests/int/event-registration.int.spec.ts
+++ b/tests/int/event-registration.int.spec.ts
@@ -4,7 +4,7 @@ import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest
 
 import { registerForEvent } from '@/collections/Events/endpoints/registerForEvent'
 
-import { testData } from '../utils/testData'
+import { createData, testData } from '../utils/testData'
 import { createTestEnvironment } from '../utils/testHelpers'
 
 type TestUser = {
@@ -23,9 +23,9 @@ type RegisterBody = {
 const SCHEDULE = {
   firstDate: '2025-01-06T10:00:00.000Z',
   firstDate_tz: 'Europe/London',
-  recurrenceType: 'DAILY' as const,
+  recurrenceType: 'DAILY',
   interval: 1,
-}
+} as const
 
 async function userCountByEmail(payload: Payload, email: string): Promise<number> {
   const { totalDocs } = await payload.find({
@@ -89,7 +89,7 @@ describe('registerForEvent endpoint', () => {
     const event = await payload.create({
       collection: 'events',
       overrideAccess: true,
-      data: {
+      data: createData<'events'>({
         title: 'Registrable Event',
         languages: ['en'],
         eventType: 'online',
@@ -99,7 +99,7 @@ describe('registerForEvent endpoint', () => {
         region: region.id,
         schedule: SCHEDULE,
         _status: 'published',
-      },
+      }),
     })
     eventId = event.id
   })
@@ -182,7 +182,7 @@ describe('registerForEvent endpoint', () => {
     const finished = await payload.create({
       collection: 'events',
       overrideAccess: true,
-      data: {
+      data: createData<'events'>({
         title: 'Finished Session',
         eventType: 'online',
         onlineUrl: 'https://example.com/over',
@@ -195,7 +195,7 @@ describe('registerForEvent endpoint', () => {
         // One-off, years past.
         schedule: { firstDate: '2021-03-01T10:00:00.000Z', firstDate_tz: 'Europe/London' },
         _status: 'published',
-      },
+      }),
     })
 
     const { status, body } = await callRegister(finished.id, {
@@ -481,7 +481,7 @@ describe('registerForEvent endpoint', () => {
       await payload.update({
         collection: 'events',
         id: eventId,
-        data: { title: 'Registrable Event\r\nBcc: attacker@evil.example' },
+        data: createData<'events'>({ title: 'Registrable Event\r\nBcc: attacker@evil.example' }),
         overrideAccess: true,
       })
       const send = captureSend()
@@ -495,7 +495,7 @@ describe('registerForEvent endpoint', () => {
       await payload.update({
         collection: 'events',
         id: eventId,
-        data: { title: 'Registrable Event' },
+        data: createData<'events'>({ title: 'Registrable Event' }),
         overrideAccess: true,
       })
     })
@@ -567,7 +567,7 @@ describe('registerForEvent endpoint', () => {
       const event = await payload.create({
         collection: 'events',
         overrideAccess: true,
-        data: {
+        data: createData<'events'>({
           title: 'Notify Event',
           languages: ['en'],
           eventType: 'online',
@@ -578,7 +578,7 @@ describe('registerForEvent endpoint', () => {
           schedule: SCHEDULE,
           _status: 'published',
           ...overrides,
-        },
+        }),
       })
       return event.id
     }

--- a/tests/int/event-verification.int.spec.ts
+++ b/tests/int/event-verification.int.spec.ts
@@ -9,6 +9,7 @@ import type { NotificationLogEntry } from '@/lib/eventVerification/log'
 import { signVerifyToken } from '@/lib/eventVerification/token'
 import type { Event, Manager } from '@/payload-types'
 
+import { runTaskHandler } from '../utils/taskRunner'
 import { testData } from '../utils/testData'
 import { createTestEnvironment } from '../utils/testHelpers'
 
@@ -20,32 +21,11 @@ import { createTestEnvironment } from '../utils/testHelpers'
  * tested separately.
  */
 
-type ExpireOutput = {
-  processed: number
-  finished: number
-  advanced: number
-  trashed: number
-  remindersSent: number
-  failed: number
-}
-
 const DAY_MS = 24 * 60 * 60 * 1000
 const daysAgo = (n: number) => new Date(Date.now() - n * DAY_MS).toISOString()
 const inDays = (n: number) => new Date(Date.now() + n * DAY_MS).toISOString()
 
-async function runJob(payload: Payload): Promise<ExpireOutput> {
-  const req = { payload, context: {}, headers: new Headers() } as Parameters<
-    typeof ExpireEvents.handler
-  >[0]['req']
-  const res = await ExpireEvents.handler({
-    req,
-    input: {},
-    job: {} as Parameters<typeof ExpireEvents.handler>[0]['job'],
-    tasks: {} as Parameters<typeof ExpireEvents.handler>[0]['tasks'],
-    inlineTask: (() => {}) as Parameters<typeof ExpireEvents.handler>[0]['inlineTask'],
-  })
-  return res.output as ExpireOutput
-}
+const runJob = (payload: Payload) => runTaskHandler(ExpireEvents, { payload })
 
 /** Back-date an event's nextCheckAt so the next run treats it as due. */
 async function makeDue(payload: Payload, id: number): Promise<void> {

--- a/tests/int/event-verification.int.spec.ts
+++ b/tests/int/event-verification.int.spec.ts
@@ -10,7 +10,7 @@ import { signVerifyToken } from '@/lib/eventVerification/token'
 import type { Event, Manager } from '@/payload-types'
 
 import { runTaskHandler } from '../utils/taskRunner'
-import { createData, testData } from '../utils/testData'
+import { createData, testData, type FixtureOverrides } from '../utils/testData'
 import { createTestEnvironment } from '../utils/testHelpers'
 
 /**
@@ -84,10 +84,15 @@ describe('Event verification lifecycle', () => {
     await cleanup()
   })
 
-  async function createEvent(overrides: Partial<Event> = {}): Promise<Event> {
+  /** `schedule: null` is a local sentinel meaning "omit the group" (inactive events). */
+  type EventFixture = Omit<FixtureOverrides<Event>, 'schedule'> & {
+    schedule?: FixtureOverrides<Event>['schedule'] | null
+  }
+
+  async function createEvent(overrides: EventFixture = {}): Promise<Event> {
     const hasScheduleOverride = 'schedule' in overrides
-    const { schedule: scheduleOverride, ...rest } = overrides as Record<string, unknown>
-    const data: Record<string, unknown> = {
+    const { schedule: scheduleOverride, ...rest } = overrides
+    const data: FixtureOverrides<Event> = {
       title: 'Lifecycle Event',
       languages: ['en'],
       eventType: 'online',
@@ -111,7 +116,11 @@ describe('Event verification lifecycle', () => {
       // A null override omits the schedule entirely (inactive events).
       data.schedule = scheduleOverride
     }
-    return payload.create({ collection: 'events', overrideAccess: true, data: data as Event })
+    return payload.create({
+      collection: 'events',
+      overrideAccess: true,
+      data: createData<'events'>(data),
+    })
   }
 
   it('opens a verified, published cycle on create (verify-on-save hook)', async () => {
@@ -515,7 +524,7 @@ describe('Event verification lifecycle', () => {
       schedule: null,
       contactPhone: '+44 20 7946 0000',
       contactName: 'Event Contact',
-    } as Partial<Event>)
+    })
     await makeDue(payload, event.id)
     const result = await runJob(payload)
 

--- a/tests/int/event-verification.int.spec.ts
+++ b/tests/int/event-verification.int.spec.ts
@@ -10,7 +10,7 @@ import { signVerifyToken } from '@/lib/eventVerification/token'
 import type { Event, Manager } from '@/payload-types'
 
 import { runTaskHandler } from '../utils/taskRunner'
-import { testData } from '../utils/testData'
+import { createData, testData } from '../utils/testData'
 import { createTestEnvironment } from '../utils/testHelpers'
 
 /**
@@ -71,12 +71,12 @@ describe('Event verification lifecycle', () => {
     defaultRegion = await payload.create({
       collection: 'regions',
       overrideAccess: true,
-      data: {
+      data: createData<'regions'>({
         name: 'Default City',
         level: 'city',
         mapboxId: 'default-city',
         managers: [eventManager.id],
-      },
+      }),
     })
   })
 
@@ -129,12 +129,12 @@ describe('Event verification lifecycle', () => {
     const region = await payload.create({
       collection: 'regions',
       overrideAccess: true,
-      data: {
+      data: createData<'regions'>({
         name: 'Country LC',
         level: 'country',
         mapboxId: 'lc-country',
         managers: [eventManager.id],
-      },
+      }),
     })
     const regionManager = await testData.createManager(payload, {
       name: 'Region Manager',
@@ -143,13 +143,13 @@ describe('Event verification lifecycle', () => {
     const city = await payload.create({
       collection: 'regions',
       overrideAccess: true,
-      data: {
+      data: createData<'regions'>({
         name: 'City LC',
         level: 'city',
         mapboxId: 'lc-city',
         parent: region.id,
         managers: [regionManager.id],
-      },
+      }),
     })
     const event = await createEvent({ region: city.id })
 
@@ -278,12 +278,12 @@ describe('Event verification lifecycle', () => {
     const country = await payload.create({
       collection: 'regions',
       overrideAccess: true,
-      data: {
+      data: createData<'regions'>({
         name: 'Country DD',
         level: 'country',
         mapboxId: 'dd-country',
         managers: [eventManager.id],
-      },
+      }),
     })
     const countryManager = await testData.createManager(payload, {
       name: 'Country Manager',
@@ -293,19 +293,19 @@ describe('Event verification lifecycle', () => {
       collection: 'regions',
       id: country.id,
       overrideAccess: true,
-      data: { managers: [countryManager.id] },
+      data: createData<'regions'>({ managers: [countryManager.id] }),
     })
     const city = await payload.create({
       collection: 'regions',
       overrideAccess: true,
-      data: {
+      data: createData<'regions'>({
         name: 'City DD',
         level: 'city',
         mapboxId: 'dd-city',
         parent: country.id,
         // The event manager is *also* this region's manager.
         managers: [eventManager.id],
-      },
+      }),
     })
     const event = await createEvent({ region: city.id })
 
@@ -349,12 +349,12 @@ describe('Event verification lifecycle', () => {
     const region = await payload.create({
       collection: 'regions',
       overrideAccess: true,
-      data: {
+      data: createData<'regions'>({
         name: 'Country RS',
         level: 'country',
         mapboxId: 'rs-country',
         managers: [eventManager.id],
-      },
+      }),
     })
     const regionManager = await testData.createManager(payload, {
       name: 'Resume Region Manager',
@@ -363,13 +363,13 @@ describe('Event verification lifecycle', () => {
     const city = await payload.create({
       collection: 'regions',
       overrideAccess: true,
-      data: {
+      data: createData<'regions'>({
         name: 'City RS',
         level: 'city',
         mapboxId: 'rs-city',
         parent: region.id,
         managers: [regionManager.id],
-      },
+      }),
     })
     const event = await createEvent({ region: city.id })
 

--- a/tests/int/events-geojson.int.spec.ts
+++ b/tests/int/events-geojson.int.spec.ts
@@ -4,8 +4,9 @@ import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 
 import { eventsGeoJson } from '@/collections/Events/endpoints/geojson'
 import type { EventFeature } from '@/collections/Events/endpoints/responseTypes'
+import type { Event } from '@/payload-types'
 
-import { createData, testData } from '../utils/testData'
+import { createData, testData, type FixtureOverrides } from '../utils/testData'
 import { createTestEnvironment } from '../utils/testHelpers'
 
 type TestUser = {
@@ -88,13 +89,15 @@ describe('eventsGeoJson endpoint', () => {
     })
     regionId = region.id
 
-    const common = {
+    // Annotated rather than `as const`: the latter froze `languages` to a
+    // readonly tuple, which no `string[]` field accepts.
+    const common: FixtureOverrides<Event> = {
       languages: ['en'],
       registrationMode: 'sahaj-atlas',
       manager: managerId,
       region: regionId,
       schedule: SCHEDULE,
-    } as const
+    }
 
     const offline = await payload.create({
       collection: 'events',

--- a/tests/int/events-geojson.int.spec.ts
+++ b/tests/int/events-geojson.int.spec.ts
@@ -5,7 +5,7 @@ import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 import { eventsGeoJson } from '@/collections/Events/endpoints/geojson'
 import type { EventFeature } from '@/collections/Events/endpoints/responseTypes'
 
-import { testData } from '../utils/testData'
+import { createData, testData } from '../utils/testData'
 import { createTestEnvironment } from '../utils/testHelpers'
 
 type TestUser = {
@@ -25,9 +25,9 @@ type GeoJsonBody = {
 const SCHEDULE = {
   firstDate: '2025-01-06T10:00:00.000Z',
   firstDate_tz: 'Europe/London',
-  recurrenceType: 'DAILY' as const,
+  recurrenceType: 'DAILY',
   interval: 1,
-}
+} as const
 
 describe('eventsGeoJson endpoint', () => {
   let payload: Payload
@@ -99,7 +99,7 @@ describe('eventsGeoJson endpoint', () => {
     const offline = await payload.create({
       collection: 'events',
       overrideAccess: true,
-      data: {
+      data: createData<'events'>({
         ...common,
         title: 'Offline Meetup',
         eventType: 'offline',
@@ -111,33 +111,33 @@ describe('eventsGeoJson endpoint', () => {
           longitude: -0.12,
         },
         _status: 'published',
-      },
+      }),
     })
     offlineEventId = offline.id
 
     const online = await payload.create({
       collection: 'events',
       overrideAccess: true,
-      data: {
+      data: createData<'events'>({
         ...common,
         title: 'Online Session',
         eventType: 'online',
         onlineUrl: 'https://example.com/meet',
         _status: 'published',
-      },
+      }),
     })
     onlineEventId = online.id
 
     const draft = await payload.create({
       collection: 'events',
       overrideAccess: true,
-      data: {
+      data: createData<'events'>({
         ...common,
         title: 'Draft Meetup',
         eventType: 'offline',
         address: { street: '2 Test St', city: 'London', country: 'GB', latitude: 52, longitude: 0 },
         _status: 'draft',
-      },
+      }),
     })
     draftEventId = draft.id
   })
@@ -261,7 +261,7 @@ describe('eventsGeoJson endpoint', () => {
       const event = await payload.create({
         collection: 'events',
         overrideAccess: true,
-        data: {
+        data: createData<'events'>({
           title: 'Country-rooted Meetup',
           eventType: 'offline',
           languages: ['en'],
@@ -277,7 +277,7 @@ describe('eventsGeoJson endpoint', () => {
             longitude: -0.1,
           },
           _status: 'published',
-        },
+        }),
       })
 
       const { body } = await callGeoJson({ select: { webPath: true }, depth: 1 })
@@ -299,7 +299,7 @@ describe('eventsGeoJson endpoint', () => {
       return payload.create({
         collection: 'events',
         overrideAccess: true,
-        data: {
+        data: createData<'events'>({
           title,
           eventType: 'online',
           onlineUrl: 'https://example.com/meet',
@@ -310,7 +310,7 @@ describe('eventsGeoJson endpoint', () => {
           schedule,
           _status: 'published',
           ...extra,
-        },
+        }),
       })
     }
 

--- a/tests/int/events.int.spec.ts
+++ b/tests/int/events.int.spec.ts
@@ -2,6 +2,8 @@ import type { Payload } from 'payload'
 
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 
+import type { Event } from '@/payload-types'
+
 import { testData } from '../utils/testData'
 import { createTestEnvironment } from '../utils/testHelpers'
 
@@ -140,7 +142,9 @@ describe('Events collection', () => {
         overrideAccess: false,
       })
       expect(doc.id).toBe(finishedId)
-      expect(doc._status).toBe('published')
+      // Absent from the declared select on purpose: getting it back is what
+      // proves ensureWebPathDeps injected it, so the type needs widening here.
+      expect((doc as typeof doc & Pick<Event, '_status'>)._status).toBe('published')
       // Publish-gated, so a non-null path proves nothing unpublished it.
       expect(doc.webPath).toBeTruthy()
       expect(doc.webUrl).toBeTruthy()

--- a/tests/int/expire-events.int.spec.ts
+++ b/tests/int/expire-events.int.spec.ts
@@ -5,6 +5,7 @@ import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vites
 
 import { ExpireEvents } from '@/jobs/ExpireEvents/ExpireEvents'
 
+import { runTaskHandler } from '../utils/taskRunner'
 import { testData } from '../utils/testData'
 import { createTestEnvironment } from '../utils/testHelpers'
 
@@ -23,31 +24,7 @@ vi.mock('@sentry/nextjs', () => ({
   captureMessage: vi.fn(),
 }))
 
-type ExpireResult = {
-  processed: number
-  finished: number
-  advanced: number
-  trashed: number
-  remindersSent: number
-  failed: number
-}
-
-async function runTask(payload: Payload): Promise<ExpireResult> {
-  const req = {
-    payload,
-    context: {},
-    headers: new Headers(),
-  } as Parameters<typeof ExpireEvents.handler>[0]['req']
-
-  const result = await ExpireEvents.handler({
-    req,
-    input: {},
-    job: {} as Parameters<typeof ExpireEvents.handler>[0]['job'],
-    tasks: {} as Parameters<typeof ExpireEvents.handler>[0]['tasks'],
-    inlineTask: (() => {}) as Parameters<typeof ExpireEvents.handler>[0]['inlineTask'],
-  })
-  return result.output as ExpireResult
-}
+const runTask = (payload: Payload) => runTaskHandler(ExpireEvents, { payload })
 
 /** Make `payload.findByID` throw for one event id (mimics a broken record), pass through otherwise. */
 function failEventLoad(payload: Payload, failingId: number) {

--- a/tests/int/lectures-for-audience.int.spec.ts
+++ b/tests/int/lectures-for-audience.int.spec.ts
@@ -87,16 +87,13 @@ describe('lecturesForAudience endpoint', () => {
 
     audienceBeginner = await testData.createAudience(payload, {
       label: 'Beginner',
-      rules: { logic: 'AND', pathProgress: { min: 0, max: 5 } },
     })
     audienceIntermediate = await testData.createAudience(payload, {
       label: 'Intermediate',
-      rules: { logic: 'AND', pathProgress: { min: 5, max: 10 } },
     })
     // No lectures attached — used to exercise the empty-result path.
     audienceUnused = await testData.createAudience(payload, {
       label: 'Unused',
-      rules: { logic: 'AND', pathProgress: { min: 50, max: 100 } },
     })
 
     beginnerOnly = String(audienceBeginner.id)

--- a/tests/int/lectures.int.spec.ts
+++ b/tests/int/lectures.int.spec.ts
@@ -5,7 +5,7 @@ import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest'
 import type { LectureMetadata } from '@/lib/lectures/nirmalaVidya'
 import type { Image } from '@/payload-types'
 
-import { testData } from '../utils/testData'
+import { createData, testData } from '../utils/testData'
 import { createTestEnvironment } from '../utils/testHelpers'
 
 // Mock the Nirmala Vidya API client — prevents real network calls in tests.
@@ -47,14 +47,15 @@ describe('Lectures Collection', () => {
           { languageCode: 'en', url: 'https://example.com/subs/en.vtt' },
           { languageCode: 'cs', url: 'https://example.com/subs/cs.vtt' },
         ],
+        duration: null,
       })
 
       const lecture = await payload.create({
         collection: 'lectures',
-        data: {
+        data: createData<'lectures'>({
           nirmalVidyaVimeoUrl: 'https://vimeo.com/123456789',
-        },
-      } as any)
+        }),
+      })
 
       expect(lecture.title).toBe('Auto-populated Title')
 
@@ -76,15 +77,16 @@ describe('Lectures Collection', () => {
         thumbnailUrl: 'https://example.com/thumb.jpg',
         hlsUrl: 'https://example.com/stream.m3u8',
         subtitles: [],
+        duration: null,
       })
 
       const lecture = await payload.create({
         collection: 'lectures',
-        data: {
+        data: createData<'lectures'>({
           nirmalVidyaVimeoUrl: 'https://vimeo.com/111111111',
           title: 'User Provided Title',
-        },
-      } as any)
+        }),
+      })
 
       // User-provided title takes precedence over the API title in the editor-
       // visible field, but metadata.title still captures the canonical API value.
@@ -99,14 +101,15 @@ describe('Lectures Collection', () => {
         thumbnailUrl: 'https://example.com/thumb.jpg',
         hlsUrl: 'https://example.com/stream.m3u8',
         subtitles: [],
+        duration: null,
       })
 
       const lecture = await payload.create({
         collection: 'lectures',
-        data: {
+        data: createData<'lectures'>({
           nirmalVidyaVimeoUrl: 'https://vimeo.com/222222222',
-        },
-      } as any)
+        }),
+      })
 
       // `thumbnail` stays null — the endpoint falls back to metadata.thumbnailUrl.
       expect(lecture.thumbnail).toBeNull()
@@ -126,14 +129,15 @@ describe('Lectures Collection', () => {
           { languageCode: 'zh-hans', url: 'https://example.com/subs/zh-hans.vtt' },
           { languageCode: 'ja', url: 'https://example.com/subs/ja.vtt' },
         ],
+        duration: null,
       })
 
       const lecture = await payload.create({
         collection: 'lectures',
-        data: {
+        data: createData<'lectures'>({
           nirmalVidyaVimeoUrl: 'https://vimeo.com/777777777',
-        },
-      } as any)
+        }),
+      })
 
       const metadata = lecture.metadata as LectureMetadata
       // zh-hans and ja have no matching CMS locale → dropped
@@ -149,12 +153,13 @@ describe('Lectures Collection', () => {
         thumbnailUrl: null,
         hlsUrl: 'https://example.com/stream.m3u8',
         subtitles: [{ languageCode: 'pt', url: 'https://example.com/subs/pt.vtt' }],
+        duration: null,
       })
 
       const lecture = await payload.create({
         collection: 'lectures',
-        data: { nirmalVidyaVimeoUrl: 'https://vimeo.com/333333333' },
-      } as any)
+        data: createData<'lectures'>({ nirmalVidyaVimeoUrl: 'https://vimeo.com/333333333' }),
+      })
 
       expect((lecture.metadata as LectureMetadata).subtitles['pt-BR']).toBe(
         'https://example.com/subs/pt.vtt',
@@ -165,10 +170,10 @@ describe('Lectures Collection', () => {
       await expect(
         payload.create({
           collection: 'lectures',
-          data: {
+          data: createData<'lectures'>({
             nirmalVidyaVimeoUrl: 'https://youtube.com/watch?v=abc123',
-          },
-        } as any),
+          }),
+        }),
       ).rejects.toThrow()
     })
 
@@ -183,10 +188,10 @@ describe('Lectures Collection', () => {
       await expect(
         payload.create({
           collection: 'lectures',
-          data: {
+          data: createData<'lectures'>({
             nirmalVidyaVimeoUrl: 'https://vimeo.com/404',
-          },
-        } as any),
+          }),
+        }),
       ).rejects.toThrow()
     })
 
@@ -220,12 +225,13 @@ describe('Lectures Collection', () => {
           { languageCode: 'en', url: 'https://example.com/subs/en.vtt' },
           { languageCode: 'ru', url: 'https://example.com/subs/ru.vtt' },
         ],
+        duration: null,
       })
 
       const lecture = await payload.create({
         collection: 'lectures',
-        data: { nirmalVidyaVimeoUrl: 'https://vimeo.com/444444444' },
-      } as any)
+        data: createData<'lectures'>({ nirmalVidyaVimeoUrl: 'https://vimeo.com/444444444' }),
+      })
 
       const en = await payload.findByID({
         collection: 'lectures',
@@ -411,12 +417,13 @@ describe('Lectures Collection', () => {
         thumbnailUrl: null,
         hlsUrl: 'https://example.com/stream.m3u8',
         subtitles: [],
+        duration: null,
       })
       const uniqueId = `${Date.now()}${Math.floor(Math.random() * 1000)}`
       const lecture = await payload.create({
         collection: 'lectures',
 
-        data: { nirmalVidyaVimeoUrl: `https://vimeo.com/${uniqueId}` } as any,
+        data: createData<'lectures'>({ nirmalVidyaVimeoUrl: `https://vimeo.com/${uniqueId}` }),
       })
       expect(lecture.type).toBe('full')
     })
@@ -429,7 +436,7 @@ describe('Lectures Collection', () => {
         await payload.create({
           collection: 'lectures',
 
-          data: { type: 'full', nirmalVidyaVimeoUrl: dupUrl } as any,
+          data: createData<'lectures'>({ type: 'full', nirmalVidyaVimeoUrl: dupUrl }),
         })
         throw new Error('expected create to throw — duplicate URL should be rejected')
       } catch (err) {
@@ -448,7 +455,7 @@ describe('Lectures Collection', () => {
         payload.create({
           collection: 'lectures',
 
-          data: { type: 'clip' } as any,
+          data: createData<'lectures'>({ type: 'clip' }),
         }),
       ).rejects.toThrow()
     })
@@ -463,7 +470,7 @@ describe('Lectures Collection', () => {
       const clip = await payload.create({
         collection: 'lectures',
 
-        data: { type: 'clip', nirmalVidyaVimeoUrl: parentUrl } as any,
+        data: createData<'lectures'>({ type: 'clip', nirmalVidyaVimeoUrl: parentUrl }),
       })
 
       // Clip linked to existing parent — no NV API call (parent already exists).
@@ -486,13 +493,14 @@ describe('Lectures Collection', () => {
         thumbnailUrl: 'https://example.com/parent.jpg',
         hlsUrl: 'https://example.com/parent.m3u8',
         subtitles: [],
+        duration: null,
       })
 
       const newUrl = `https://vimeo.com/${Date.now()}999`
       const clip = await payload.create({
         collection: 'lectures',
 
-        data: { type: 'clip', nirmalVidyaVimeoUrl: newUrl } as any,
+        data: createData<'lectures'>({ type: 'clip', nirmalVidyaVimeoUrl: newUrl }),
       })
 
       const parentId =
@@ -518,7 +526,7 @@ describe('Lectures Collection', () => {
       const clip = await payload.create({
         collection: 'lectures',
 
-        data: { type: 'clip', fullLecture: parent.id } as any,
+        data: createData<'lectures'>({ type: 'clip', fullLecture: parent.id }),
       })
       const parentId =
         typeof clip.fullLecture === 'object' && clip.fullLecture !== null
@@ -537,7 +545,7 @@ describe('Lectures Collection', () => {
       await payload.create({
         collection: 'lectures',
 
-        data: { type: 'clip', fullLecture: parent.id } as any,
+        data: createData<'lectures'>({ type: 'clip', fullLecture: parent.id }),
       })
 
       expect(vi.mocked(fetchNirmalaVidyaVideo).mock.calls.length).toBe(callCountBefore)
@@ -546,8 +554,9 @@ describe('Lectures Collection', () => {
 
   describe('NirmalaVidyaResponseSchema', () => {
     it('coerces subtitles: null to an empty array', async () => {
-      const { NirmalaVidyaResponseSchema } =
-        await vi.importActual<typeof import('@/lib/lectures/nirmalaVidyaApi')>('@/lib/lectures/nirmalaVidyaApi')
+      const { NirmalaVidyaResponseSchema } = await vi.importActual<
+        typeof import('@/lib/lectures/nirmalaVidyaApi')
+      >('@/lib/lectures/nirmalaVidyaApi')
 
       const parsed = NirmalaVidyaResponseSchema.parse({
         name: 'Older Lecture',
@@ -560,8 +569,9 @@ describe('Lectures Collection', () => {
     })
 
     it('still accepts an omitted subtitles field', async () => {
-      const { NirmalaVidyaResponseSchema } =
-        await vi.importActual<typeof import('@/lib/lectures/nirmalaVidyaApi')>('@/lib/lectures/nirmalaVidyaApi')
+      const { NirmalaVidyaResponseSchema } = await vi.importActual<
+        typeof import('@/lib/lectures/nirmalaVidyaApi')
+      >('@/lib/lectures/nirmalaVidyaApi')
 
       const parsed = NirmalaVidyaResponseSchema.parse({
         name: 'Lecture',

--- a/tests/int/meditation-lectures.int.spec.ts
+++ b/tests/int/meditation-lectures.int.spec.ts
@@ -942,7 +942,7 @@ describe('meditationLectures endpoint', () => {
         expect(framesCalls.length).toBeLessThanOrEqual(2)
         // Verify results are still correct despite bounded selects
         expect(body).toBeDefined()
-        const res = body as ResponseBody
+        const res = body as { docs: LecturePlayerData[] }
         expect(res.docs.length).toBeGreaterThan(0)
       } finally {
         findSpy.mockRestore()

--- a/tests/int/meditation-lectures.int.spec.ts
+++ b/tests/int/meditation-lectures.int.spec.ts
@@ -143,13 +143,11 @@ describe('meditationLectures endpoint', () => {
 
     audience = await testData.createAudience(payload, {
       label: 'Everyone',
-      rules: { logic: 'AND', pathProgress: { min: 0, max: 100 } },
     })
     audienceFilter = String(audience.id)
 
     unusedAudience = await testData.createAudience(payload, {
       label: 'Unused',
-      rules: {},
     })
 
     userChoice = await testData.createUserChoice(payload, { title: 'Stress relief' })
@@ -749,7 +747,6 @@ describe('meditationLectures endpoint', () => {
 
       fbAudience = await testData.createAudience(payload, {
         label: 'Fallback audience',
-        rules: {},
       })
       // Lectures in the audience, tagged with nodes the meditation does NOT cover.
       fbLectureWithNode = await testData.createLecture(
@@ -825,7 +822,6 @@ describe('meditationLectures endpoint', () => {
     beforeAll(async () => {
       const separateAudience = await testData.createAudience(payload, {
         label: 'Separate (gating test)',
-        rules: {},
       })
       separateAudienceId = separateAudience.id
 

--- a/tests/int/meditations.int.spec.ts
+++ b/tests/int/meditations.int.spec.ts
@@ -2,7 +2,14 @@ import type { Payload } from 'payload'
 
 import { describe, it, beforeAll, afterAll, expect, vi } from 'vitest'
 
-import type { Meditation, Narrator, Image, SongTag, Album } from '@/payload-types'
+import type {
+  Meditation,
+  MeditationsSelect,
+  Narrator,
+  Image,
+  SongTag,
+  Album,
+} from '@/payload-types'
 
 import { testData } from '../utils/testData'
 import { createTestEnvironment } from '../utils/testHelpers'
@@ -257,7 +264,9 @@ describe('Meditations Collection', () => {
       })
       const allCount = await payload.count({
         collection: 'meditations',
-        locale: 'all',
+        // Payload's cross-locale read; the generated union lists configured
+        // locales only, so it doesn't include this.
+        locale: 'all' as Parameters<typeof payload.count>[0]['locale'],
       })
 
       expect(csCount.totalDocs).toBe(1)
@@ -368,7 +377,7 @@ describe('Meditations Collection', () => {
     // upload thumbnail fields appended by appendUploadSelectFields. Replicated
     // here because the select is assembled in @payloadcms/next's RSC List view,
     // which an integration test can't invoke directly.
-    const LIST_VIEW_SELECT = {
+    const LIST_VIEW_SELECT: MeditationsSelect<true> = {
       label: true,
       thumbnail: true,
       _status: true,

--- a/tests/int/pages.int.spec.ts
+++ b/tests/int/pages.int.spec.ts
@@ -7,7 +7,7 @@ import {
   createLexicalWithRelationshipNode,
   createLexicalWithUploadNode,
 } from '../utils/lexicalTestHelpers'
-import { testData } from '../utils/testData'
+import { testData, type LexicalContent } from '../utils/testData'
 import { createTestEnvironment, idOnlySelect } from '../utils/testHelpers'
 
 describe('Pages Collection', () => {
@@ -252,7 +252,7 @@ describe('Pages Collection', () => {
           indent: 0,
           version: 1,
         },
-      } as unknown as Parameters<typeof testData.createPage>[1]['content']
+      } as unknown as LexicalContent
 
       const page = await testData.createPage(payload, {
         title: 'Page with App Card Relationship',
@@ -320,7 +320,7 @@ describe('Pages Collection', () => {
           indent: 0,
           version: 1,
         },
-      } as unknown as Parameters<typeof testData.createPage>[1]['content']
+      } as unknown as LexicalContent
 
       const page = await testData.createPage(payload, {
         title: 'Published Page with Client App Card Relationship',

--- a/tests/int/pages.int.spec.ts
+++ b/tests/int/pages.int.spec.ts
@@ -8,7 +8,7 @@ import {
   createLexicalWithUploadNode,
 } from '../utils/lexicalTestHelpers'
 import { testData } from '../utils/testData'
-import { createTestEnvironment } from '../utils/testHelpers'
+import { createTestEnvironment, idOnlySelect } from '../utils/testHelpers'
 
 describe('Pages Collection', () => {
   let payload: Payload
@@ -358,7 +358,7 @@ describe('Pages Collection', () => {
 
       const directRead = await payload.find({
         collection: 'app-cards',
-        select: { id: true },
+        select: idOnlySelect(),
         depth: 0,
         user: client,
         overrideAccess: false,

--- a/tests/int/regions.int.spec.ts
+++ b/tests/int/regions.int.spec.ts
@@ -2,6 +2,7 @@ import type { Payload } from 'payload'
 
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 
+import { createData } from '../utils/testData'
 import { createTestEnvironment } from '../utils/testHelpers'
 
 /**
@@ -227,7 +228,7 @@ describe('Regions child-join recursive descendants', () => {
         collection: 'regions',
         id: countryZ,
         overrideAccess: true,
-        data: { slug: 'country-z-renamed' },
+        data: createData<'regions'>({ slug: 'country-z-renamed' }),
       })
       const after = await readRegion(cityZ)
       expect(after.webPath).not.toBe(before.webPath)

--- a/tests/int/regions.int.spec.ts
+++ b/tests/int/regions.int.spec.ts
@@ -2,7 +2,9 @@ import type { Payload } from 'payload'
 
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 
-import { createData } from '../utils/testData'
+import type { Region } from '@/payload-types'
+
+import { createData, type FixtureOverrides } from '../utils/testData'
 import { createTestEnvironment } from '../utils/testHelpers'
 
 /**
@@ -40,26 +42,22 @@ describe('Regions child-join recursive descendants', () => {
   type ChildJoinField = 'childrenRegions' | 'childrenCities' | 'childrenVenues'
 
   /** Descendant ids from a child join, shape-agnostic (depth 0 ids or populated docs). */
-  const joinIds = (doc: Record<string, unknown>, field: ChildJoinField): number[] => {
+  const joinIds = (doc: Region, field: ChildJoinField): number[] => {
     const join = doc[field] as { docs?: (number | { id: number })[] } | undefined
     return (join?.docs ?? []).map((entry) => (typeof entry === 'number' ? entry : entry.id))
   }
 
-  const createRegion = async (data: {
-    name: string
-    level: 'country' | 'region' | 'city' | 'venue'
-    mapboxId: string
-    parent?: number
-    slug?: string
-  }): Promise<number> => {
-    const region = await payload.create({ collection: 'regions', overrideAccess: true, data })
+  const createRegion = async (data: FixtureOverrides<Region>): Promise<number> => {
+    const region = await payload.create({
+      collection: 'regions',
+      overrideAccess: true,
+      data: createData<'regions'>(data),
+    })
     return region.id
   }
 
-  const readRegion = (id: number, locale?: 'en' | 'cs'): Promise<Record<string, unknown>> =>
-    payload.findByID({ collection: 'regions', id, depth: 0, locale }) as Promise<
-      Record<string, unknown>
-    >
+  const readRegion = (id: number, locale?: 'en' | 'cs'): Promise<Region> =>
+    payload.findByID({ collection: 'regions', id, depth: 0, locale })
 
   beforeAll(async () => {
     const env = await createTestEnvironment()

--- a/tests/int/registration-digests.int.spec.ts
+++ b/tests/int/registration-digests.int.spec.ts
@@ -5,6 +5,7 @@ import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest'
 
 import { SendRegistrationDigests } from '@/jobs/RegistrationNotifications/SendRegistrationDigests'
 
+import { runTaskHandler } from '../utils/taskRunner'
 import { testData } from '../utils/testData'
 import { createTestEnvironmentWithEmail } from '../utils/testHelpers'
 
@@ -15,29 +16,8 @@ const SCHEDULE = {
   interval: 1,
 }
 
-type DigestResult = {
-  eligibleManagers: number
-  digestsSent: number
-  registrationsIncluded: number
-  failed: number
-}
-
-async function runDigests(payload: Payload, now?: Date): Promise<DigestResult> {
-  const req = {
-    payload,
-    context: now ? { now } : {},
-    headers: new Headers(),
-  } as Parameters<typeof SendRegistrationDigests.handler>[0]['req']
-
-  const result = await SendRegistrationDigests.handler({
-    req,
-    input: {},
-    job: {} as Parameters<typeof SendRegistrationDigests.handler>[0]['job'],
-    tasks: {} as Parameters<typeof SendRegistrationDigests.handler>[0]['tasks'],
-    inlineTask: (() => {}) as Parameters<typeof SendRegistrationDigests.handler>[0]['inlineTask'],
-  })
-  return result.output as DigestResult
-}
+const runDigests = (payload: Payload, now?: Date) =>
+  runTaskHandler(SendRegistrationDigests, { payload, context: now ? { now } : {} })
 
 /** The smallest Monday (UTC) at or after `from` — always ≥ now, so today's registrations stay in-window. */
 function mondayOnOrAfter(from: Date): Date {

--- a/tests/int/registration-digests.int.spec.ts
+++ b/tests/int/registration-digests.int.spec.ts
@@ -6,15 +6,15 @@ import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest'
 import { SendRegistrationDigests } from '@/jobs/RegistrationNotifications/SendRegistrationDigests'
 
 import { runTaskHandler } from '../utils/taskRunner'
-import { testData } from '../utils/testData'
+import { createData, testData } from '../utils/testData'
 import { createTestEnvironmentWithEmail } from '../utils/testHelpers'
 
 const SCHEDULE = {
   firstDate: '2026-07-01T09:00:00.000Z',
   firstDate_tz: 'Europe/London',
-  recurrenceType: 'DAILY' as const,
+  recurrenceType: 'DAILY',
   interval: 1,
-}
+} as const
 
 const runDigests = (payload: Payload, now?: Date) =>
   runTaskHandler(SendRegistrationDigests, { payload, context: now ? { now } : {} })
@@ -65,7 +65,7 @@ describe('SendRegistrationDigests job', () => {
     const event = await payload.create({
       collection: 'events',
       overrideAccess: true,
-      data: {
+      data: createData<'events'>({
         title,
         languages: ['en'],
         eventType: 'online',
@@ -75,7 +75,7 @@ describe('SendRegistrationDigests job', () => {
         region: regionId,
         schedule: SCHEDULE,
         _status: 'published',
-      },
+      }),
     })
     return event.id
   }

--- a/tests/int/role-based-access.int.spec.ts
+++ b/tests/int/role-based-access.int.spec.ts
@@ -5,12 +5,15 @@ import path from 'path'
 
 import { describe, it, beforeAll, afterAll, expect, vi } from 'vitest'
 
-import { bypassPermissions, hasAnyPermission, hasPermission } from '@/plugins/access'
 import type { Event, Region } from '@/payload-types'
+import { bypassPermissions, hasAnyPermission, hasPermission } from '@/plugins/access'
 
-import type { FixtureOverrides } from '../utils/testData'
-
-import { createData, createTestLexicalContent, testData } from '../utils/testData'
+import {
+  createData,
+  createTestLexicalContent,
+  testData,
+  type FixtureOverrides,
+} from '../utils/testData'
 import { createTestEnvironment, idOnlySelect } from '../utils/testHelpers'
 
 /**

--- a/tests/int/role-based-access.int.spec.ts
+++ b/tests/int/role-based-access.int.spec.ts
@@ -5,25 +5,30 @@ import path from 'path'
 
 import { describe, it, beforeAll, afterAll, expect, vi } from 'vitest'
 
-import type { RegionLevel } from '@/lib/mapbox/geocoder'
 import { bypassPermissions, hasAnyPermission, hasPermission } from '@/plugins/access'
+import type { Event, Region } from '@/payload-types'
 
-import { createTestLexicalContent, testData } from '../utils/testData'
-import { createTestEnvironment } from '../utils/testHelpers'
+import type { FixtureOverrides } from '../utils/testData'
+
+import { createData, createTestLexicalContent, testData } from '../utils/testData'
+import { createTestEnvironment, idOnlySelect } from '../utils/testHelpers'
 
 /**
- * Region fixture data. `level` is narrowed to the canonical union instead of the
- * plain `Record<string, unknown>` these helpers used to take — an untyped fixture
- * is how `level: 'center'` survived the rename to `venue` and surfaced only as a
+ * Region fixture data — the whole doc, loosely: every field optional at every
+ * depth, but each one that *is* passed checked against the real collection.
+ * Replaces the `Record<string, unknown>` these helpers used to take, which is
+ * how `level: 'center'` survived the rename to `venue` and surfaced only as a
  * CI runtime failure.
  *
- * Note this does *not* make `pnpm typecheck` catch it: `tsconfig.json` excludes
- * `tests`, so tsc never reads this file (including `tests` today surfaces 189
- * pre-existing errors — its own ticket). The narrowing earns its place through
- * editor feedback while typing, and goes live if that exclusion is ever lifted.
- * The binding guard remains the int lane itself.
+ * As of #606 Phase 2 this is a live guard, not just editor feedback:
+ * `tsconfig.test.json` covers `tests/**`, so `pnpm typecheck:tests` reads this
+ * file and a stale enum literal fails in seconds rather than 7 minutes into the
+ * int lane.
  */
-type RegionFixture = Record<string, unknown> & { level?: RegionLevel }
+type RegionFixture = FixtureOverrides<Region>
+
+/** A manager fixture; `testData.createManager` already attaches `collection`. */
+type ManagerFixture = Awaited<ReturnType<typeof testData.createManager>>
 
 const SAMPLE_FILES_DIR = path.join(__dirname, '../files')
 
@@ -233,7 +238,7 @@ describe('Role-Based Access Control', () => {
   describe('Document-Level Manager Access', () => {
     // A manager (type: 'manager') with no roles — relies purely on being listed
     // on a document (or an ancestor) for access.
-    const managerUser = (m: { id: number }) => ({ ...m, collection: 'managers' as const })
+    const managerUser = (m: ManagerFixture) => ({ ...m, collection: 'managers' as const })
 
     describe('Pages — direct managers ("Page Editors")', () => {
       it('lets a listed manager with no roles read + update the page', async () => {
@@ -312,7 +317,10 @@ describe('Role-Based Access Control', () => {
         await expect(
           payload.create({
             collection: 'pages',
-            data: { title: 'Editor Created', content: createTestLexicalContent() },
+            data: createData<'pages'>({
+              title: 'Editor Created',
+              content: createTestLexicalContent(),
+            }),
             user: managerUser(editor),
             overrideAccess: false,
           }),
@@ -343,13 +351,13 @@ describe('Role-Based Access Control', () => {
       const createRegion = (data: RegionFixture) =>
         payload.create({
           collection: 'regions',
-          data: {
+          data: createData<'regions'>({
             level: 'country',
             name: 'Region',
             mapboxId: `place.${Math.random().toString(36).slice(2)}`,
             managers: [fillerManagerId],
             ...data,
-          },
+          }),
           depth: 0,
         })
 
@@ -431,7 +439,7 @@ describe('Role-Based Access Control', () => {
   })
 
   describe('Atlas manager — region-subtree write scoping', () => {
-    const managerUser = (m: { id: number }) => ({ ...m, collection: 'managers' as const })
+    const managerUser = (m: ManagerFixture) => ({ ...m, collection: 'managers' as const })
 
     let atlasManager: Awaited<ReturnType<typeof testData.createManager>>
     let fillerId: number
@@ -445,31 +453,31 @@ describe('Role-Based Access Control', () => {
     // Non-'manual' mapboxId keeps the conditionally-required coordinate fields out
     // of validation. Pass a `user` to exercise access (overrideAccess: false);
     // omit it to set up fixtures as admin.
-    const createRegion = (data: RegionFixture, user?: { id: number }) =>
+    const createRegion = (data: RegionFixture, user?: ManagerFixture) =>
       payload.create({
         collection: 'regions',
-        data: {
+        data: createData<'regions'>({
           level: 'country',
           name: 'Region',
           mapboxId: `place.${Math.random().toString(36).slice(2)}`,
           managers: [fillerId],
           ...data,
-        },
+        }),
         depth: 0,
         ...(user ? { user: managerUser(user), overrideAccess: false } : { overrideAccess: true }),
       })
 
-    const createEvent = (data: Record<string, unknown>, user?: { id: number }) =>
+    const createEvent = (data: FixtureOverrides<Event>, user?: ManagerFixture) =>
       payload.create({
         collection: 'events',
         // draft: the now-required title/schedule are validated only on publish.
         draft: true,
-        data: {
+        data: createData<'events'>({
           eventType: 'offline',
           registrationMode: 'sahaj-atlas',
           manager: fillerId,
           ...data,
-        },
+        }),
         depth: 0,
         ...(user ? { user: managerUser(user), overrideAccess: false } : { overrideAccess: true }),
       })
@@ -794,7 +802,7 @@ describe('Role-Based Access Control', () => {
         'videos',
         'forms',
         'form-submissions',
-      ]
+      ] as const
 
       webProjectCollections.forEach((collection) => {
         expect(
@@ -1075,10 +1083,10 @@ describe('Role-Based Access Control', () => {
       // Create a draft page (default status is draft)
       const draftPage = await payload.create({
         collection: 'pages',
-        data: {
+        data: createData<'pages'>({
           title: 'Draft Page for Client Test',
           content: createTestLexicalContent('Draft content'),
-        },
+        }),
         user: { ...admin, collection: 'managers' },
       })
 
@@ -1091,7 +1099,7 @@ describe('Role-Based Access Control', () => {
       // Note: overrideAccess: false is required to test access control with Local API
       const clientPages = await payload.find({
         collection: 'pages',
-        select: { id: true },
+        select: idOnlySelect(),
         depth: 0,
         user: client,
         overrideAccess: false,
@@ -1118,10 +1126,10 @@ describe('Role-Based Access Control', () => {
       // Create a draft page
       const draftPage = await payload.create({
         collection: 'pages',
-        data: {
+        data: createData<'pages'>({
           title: 'Draft Page for ID Test',
           content: createTestLexicalContent('Draft content'),
-        },
+        }),
         user: { ...admin, collection: 'managers' },
       })
 
@@ -1131,7 +1139,7 @@ describe('Role-Based Access Control', () => {
         payload.findByID({
           collection: 'pages',
           id: draftPage.id,
-          select: { id: true },
+          select: idOnlySelect(),
           depth: 0,
           user: client,
           overrideAccess: false,
@@ -1156,10 +1164,10 @@ describe('Role-Based Access Control', () => {
       // Create and publish a page
       const draftPage = await payload.create({
         collection: 'pages',
-        data: {
+        data: createData<'pages'>({
           title: 'Page to Publish',
           content: createTestLexicalContent('Published content'),
-        },
+        }),
         user: { ...admin, collection: 'managers' },
       })
 
@@ -1179,7 +1187,7 @@ describe('Role-Based Access Control', () => {
       // Note: overrideAccess: false is required to test access control with Local API
       const clientPages = await payload.find({
         collection: 'pages',
-        select: { id: true },
+        select: idOnlySelect(),
         depth: 0,
         user: client,
         overrideAccess: false,
@@ -1192,7 +1200,7 @@ describe('Role-Based Access Control', () => {
       const foundPage = await payload.findByID({
         collection: 'pages',
         id: publishedPage.id,
-        select: { id: true },
+        select: idOnlySelect(),
         depth: 0,
         user: client,
         overrideAccess: false,
@@ -1227,18 +1235,18 @@ describe('Role-Based Access Control', () => {
       // A published page is therefore unreadable by the draft client.
       await payload.create({
         collection: 'pages',
-        data: {
+        data: createData<'pages'>({
           title: 'Published Page Hidden From Draft Client',
           content: createTestLexicalContent('content'),
           _status: 'published',
-        },
+        }),
         user: { ...admin, collection: 'managers' },
       })
 
       await expect(
         payload.find({
           collection: 'pages',
-          select: { id: true },
+          select: idOnlySelect(),
           depth: 0,
           user: draftClient,
           overrideAccess: false,
@@ -1260,10 +1268,10 @@ describe('Role-Based Access Control', () => {
 
       const draftPage = await payload.create({
         collection: 'pages',
-        data: {
+        data: createData<'pages'>({
           title: 'Draft Page for Trusted Preview',
           content: createTestLexicalContent('Draft preview content'),
-        },
+        }),
         user: { ...admin, collection: 'managers' },
       })
 
@@ -1309,7 +1317,7 @@ describe('Role-Based Access Control', () => {
 
       const clientCards = await payload.find({
         collection: 'app-cards',
-        select: { id: true },
+        select: idOnlySelect(),
         depth: 0,
         user: client,
         overrideAccess: false,
@@ -1338,7 +1346,7 @@ describe('Role-Based Access Control', () => {
       await expect(
         payload.find({
           collection: 'app-cards',
-          select: { id: true },
+          select: idOnlySelect(),
           user: client,
           overrideAccess: false,
         }),
@@ -1363,7 +1371,7 @@ describe('Role-Based Access Control', () => {
 
         const result = await payload.find({
           collection: 'lectures',
-          select: { id: true },
+          select: idOnlySelect(),
           depth: 0,
           user: client,
           overrideAccess: false,
@@ -1392,10 +1400,10 @@ describe('Role-Based Access Control', () => {
       // Create a draft page
       const draftPage = await payload.create({
         collection: 'pages',
-        data: {
+        data: createData<'pages'>({
           title: 'Draft Page for Manager Test',
           content: createTestLexicalContent('Draft content'),
-        },
+        }),
         user: { ...admin, collection: 'managers' },
       })
 
@@ -1421,10 +1429,10 @@ describe('Role-Based Access Control', () => {
       // Create a draft page
       const draftPage = await payload.create({
         collection: 'pages',
-        data: {
+        data: createData<'pages'>({
           title: 'Draft Page for Admin Test',
           content: createTestLexicalContent('Draft content'),
-        },
+        }),
         user: { ...admin, collection: 'managers' },
       })
 
@@ -1466,7 +1474,7 @@ describe('Role-Based Access Control', () => {
       // Note: overrideAccess: false is required to test access control with Local API
       const clientMeditations = await payload.find({
         collection: 'meditations',
-        select: { id: true },
+        select: idOnlySelect(),
         depth: 0,
         user: client,
         overrideAccess: false,
@@ -1553,7 +1561,7 @@ describe('Role-Based Access Control', () => {
       // Note: overrideAccess: false is required to test access control with Local API
       const clientNarrators = await payload.find({
         collection: 'narrators',
-        select: { id: true },
+        select: idOnlySelect(),
         depth: 0,
         user: client,
         overrideAccess: false,

--- a/tests/int/session-reminders.int.spec.ts
+++ b/tests/int/session-reminders.int.spec.ts
@@ -6,7 +6,7 @@ import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest'
 import { SendSessionReminders } from '@/jobs/RegistrationNotifications/SendSessionReminders'
 
 import { runTaskHandler } from '../utils/taskRunner'
-import { testData } from '../utils/testData'
+import { createData, testData } from '../utils/testData'
 import { createTestEnvironmentWithEmail } from '../utils/testHelpers'
 
 // A daily class at 10:00 Europe/London (09:00 UTC in BST). With the run clock
@@ -15,9 +15,9 @@ import { createTestEnvironmentWithEmail } from '../utils/testHelpers'
 const SCHEDULE = {
   firstDate: '2026-07-01T09:00:00.000Z',
   firstDate_tz: 'Europe/London',
-  recurrenceType: 'DAILY' as const,
+  recurrenceType: 'DAILY',
   interval: 1,
-}
+} as const
 const NOW = new Date('2026-07-20T00:00:00.000Z')
 const OCCURRENCE = '2026-07-20T09:00:00.000Z'
 const OUT_OF_WINDOW = '2026-07-25T09:00:00.000Z'
@@ -57,7 +57,7 @@ describe('SendSessionReminders job', () => {
     const event = await payload.create({
       collection: 'events',
       overrideAccess: true,
-      data: {
+      data: createData<'events'>({
         title: `Reminder Event ${(seq += 1)}`,
         languages: ['en'],
         eventType: 'online',
@@ -68,7 +68,7 @@ describe('SendSessionReminders job', () => {
         schedule: SCHEDULE,
         _status: 'published',
         ...overrides,
-      },
+      }),
     })
     return event.id
   }

--- a/tests/int/session-reminders.int.spec.ts
+++ b/tests/int/session-reminders.int.spec.ts
@@ -5,6 +5,7 @@ import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest'
 
 import { SendSessionReminders } from '@/jobs/RegistrationNotifications/SendSessionReminders'
 
+import { runTaskHandler } from '../utils/taskRunner'
 import { testData } from '../utils/testData'
 import { createTestEnvironmentWithEmail } from '../utils/testHelpers'
 
@@ -21,29 +22,8 @@ const NOW = new Date('2026-07-20T00:00:00.000Z')
 const OCCURRENCE = '2026-07-20T09:00:00.000Z'
 const OUT_OF_WINDOW = '2026-07-25T09:00:00.000Z'
 
-type ReminderResult = {
-  processedEvents: number
-  remindersSent: number
-  skipped: number
-  failed: number
-}
-
-async function runReminders(payload: Payload, now: Date = NOW): Promise<ReminderResult> {
-  const req = {
-    payload,
-    context: { now },
-    headers: new Headers(),
-  } as Parameters<typeof SendSessionReminders.handler>[0]['req']
-
-  const result = await SendSessionReminders.handler({
-    req,
-    input: {},
-    job: {} as Parameters<typeof SendSessionReminders.handler>[0]['job'],
-    tasks: {} as Parameters<typeof SendSessionReminders.handler>[0]['tasks'],
-    inlineTask: (() => {}) as Parameters<typeof SendSessionReminders.handler>[0]['inlineTask'],
-  })
-  return result.output as ReminderResult
-}
+const runReminders = (payload: Payload, now: Date = NOW) =>
+  runTaskHandler(SendSessionReminders, { payload, context: { now } })
 
 describe('SendSessionReminders job', () => {
   let payload: Payload

--- a/tests/int/sync-lecture-metadata.int.spec.ts
+++ b/tests/int/sync-lecture-metadata.int.spec.ts
@@ -6,6 +6,7 @@ import { SyncLectureMetadata } from '@/jobs/SyncLectureMetadata/SyncLectureMetad
 import type { LectureMetadata } from '@/lib/lectures/nirmalaVidya'
 import type { Lecture } from '@/payload-types'
 
+import { runTaskHandler } from '../utils/taskRunner'
 import { testData } from '../utils/testData'
 import { createTestEnvironment } from '../utils/testHelpers'
 
@@ -23,29 +24,8 @@ vi.mock('@/lib/lectures/nirmalaVidyaApi', async (importOriginal) => {
   }
 })
 
-type SyncOutput = {
-  totalProcessed: number
-  synced: number
-  failed: number
-  skippedNoVimeoId: number
-}
-
-async function runTask(payload: Payload, input?: { lectureIds?: number[] }): Promise<SyncOutput> {
-  const req = {
-    payload,
-    context: {},
-    headers: new Headers(),
-  } as Parameters<typeof SyncLectureMetadata.handler>[0]['req']
-
-  const result = await SyncLectureMetadata.handler({
-    req,
-    input: input ?? {},
-    job: {} as Parameters<typeof SyncLectureMetadata.handler>[0]['job'],
-    tasks: {} as Parameters<typeof SyncLectureMetadata.handler>[0]['tasks'],
-    inlineTask: (() => {}) as Parameters<typeof SyncLectureMetadata.handler>[0]['inlineTask'],
-  })
-  return result.output as SyncOutput
-}
+const runTask = (payload: Payload, input?: { lectureIds?: number[] }) =>
+  runTaskHandler(SyncLectureMetadata, { payload, input: input ?? {} })
 
 describe('SyncLectureMetadata task', () => {
   let payload: Payload

--- a/tests/int/translations-field.int.spec.ts
+++ b/tests/int/translations-field.int.spec.ts
@@ -91,7 +91,7 @@ describe('buildTranslationTabs', () => {
       }
 
       const tabs = buildTranslationTabs(schema, 'test')
-      const group = tabs[0].fields[0] as {
+      const group = tabs[0].fields[0] as unknown as {
         type: 'group'
         name: string
         fields: [{ type: 'tabs'; tabs: Array<{ fields: Array<{ name: string }> }> }]

--- a/tests/int/videos.int.spec.ts
+++ b/tests/int/videos.int.spec.ts
@@ -9,6 +9,8 @@ import type { Payload } from 'payload'
 
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 
+import type { Video } from '@/payload-types'
+
 import { testData } from '../utils/testData'
 import { createTestEnvironment } from '../utils/testHelpers'
 
@@ -63,7 +65,9 @@ describe('Videos Collection — custom behavior', () => {
       await expect(
         testData.createVideo(payload, {
           title: 'Invalid Subs Video',
-          subtitles: [{ startTimeMs: 'oops', endTimeMs: 1000, content: 'x' }],
+          // Deliberately malformed — the case asserts the field validator
+          // rejects it, so it can't be typed as a valid row.
+          subtitles: [{ startTimeMs: 'oops', endTimeMs: 1000, content: 'x' }] as unknown as Video['subtitles'],
         }),
       ).rejects.toThrow(/subtitles|startTimeMs/i)
     })

--- a/tests/int/wemeditateAppStatus.int.spec.ts
+++ b/tests/int/wemeditateAppStatus.int.spec.ts
@@ -571,6 +571,8 @@ describe('WeMeditateAppStatus Global', () => {
     it('throws when a group evaluator emits a check key not declared in the section spec', async () => {
       const badSection: SectionSpec<WeMeditateAppStatusConfig, void> = {
         key: 'bogus',
+        label: 'Bogus',
+        description: 'Section whose evaluator emits an undeclared check key.',
         tutorialLink: null,
         checks: {
           // 'declared-check' is the only allowed key

--- a/tests/tsconfig.json
+++ b/tests/tsconfig.json
@@ -1,15 +1,8 @@
 {
-  "extends": "../tsconfig.json",
-  "compilerOptions": {
-    "types": ["vitest/globals"]
-  },
-  "include": [
-    "../next-env.d.ts",
-    "../worker-configuration.d.ts",
-    "../src/**/*.ts",
-    "../src/**/*.tsx",
-    "./**/*.ts",
-    "./**/*.tsx"
-  ],
-  "exclude": ["../node_modules"]
+  // Editor-only entry point. TS servers resolve the nearest `tsconfig.json`
+  // walking up from a file, so specs under `tests/` land here — this re-exports
+  // the real gate config (`pnpm typecheck:tests`) so the editor and CI agree.
+  // Relative paths resolve against the config that declares them, so the
+  // parent's `tests/**` still points at this directory.
+  "extends": "../tsconfig.test.json"
 }

--- a/tests/utils/taskRunner.ts
+++ b/tests/utils/taskRunner.ts
@@ -1,0 +1,68 @@
+import type {
+  Payload,
+  PayloadRequest,
+  TaskConfig,
+  TaskHandlerArgs,
+  TaskInput,
+  TaskOutput,
+  TaskType,
+} from 'payload'
+
+/**
+ * Invoke a job task's `handler` directly, bypassing the queue.
+ *
+ * Five int specs used to hand-roll this, and each one reached for
+ * `Parameters<typeof SomeTask.handler>[0]` to type the args. That never
+ * compiled: `TaskConfig['handler']` is `string | TaskHandler<TSlug>` — a task
+ * may point at a module path instead of a function — and `Parameters<T>`
+ * rejects the union (`TS2344`, 20 of #606 Phase 2's errors). The `typeof`
+ * guard below narrows the union properly, so `TaskHandlerArgs<TSlug>` is
+ * available for the stub fields and the whole thing typechecks without casts.
+ *
+ * The return type comes from the generated `TypedJobs` output schema, so the
+ * shapes each spec used to redeclare by hand (`ExpireResult`, `DigestResult`,
+ * `SyncOutput`, …) are now checked against the job's real contract instead of
+ * drifting from it.
+ */
+export async function runTaskHandler<TSlug extends TaskType>(
+  task: TaskConfig<TSlug>,
+  {
+    payload,
+    input,
+    context = {},
+  }: {
+    payload: Payload
+    /** Task input. Every task we run this way declares `input?: unknown`. */
+    input?: TaskInput<TSlug>
+    /** Seeds `req.context` — the window jobs read an injected `now` from it. */
+    context?: PayloadRequest['context']
+  },
+): Promise<TaskOutput<TSlug>> {
+  if (typeof task.handler !== 'function') {
+    throw new Error(
+      'runTaskHandler needs an inline handler; this task config points at a module path.',
+    )
+  }
+
+  // Handlers only ever touch `payload`, `context` and `headers`, so the rest of
+  // PayloadRequest is deliberately absent — hence the double assertion.
+  const req = { payload, context, headers: new Headers() } as unknown as PayloadRequest
+
+  const result = await task.handler({
+    req,
+    input: input as TaskHandlerArgs<TSlug>['input'],
+    // Queue plumbing. No task under test reads `job`/`tasks`; `inlineTask`
+    // throws rather than no-op'ing so a handler that grows a sub-task can't
+    // silently receive `undefined` where an output is expected.
+    job: {} as TaskHandlerArgs<TSlug>['job'],
+    tasks: {} as TaskHandlerArgs<TSlug>['tasks'],
+    inlineTask: (() => {
+      throw new Error('runTaskHandler does not support inline sub-tasks.')
+    }) as unknown as TaskHandlerArgs<TSlug>['inlineTask'],
+  })
+
+  if (result.state === 'failed') {
+    throw new Error(result.errorMessage ?? `Task handler reported state: 'failed'.`)
+  }
+  return result.output
+}

--- a/tests/utils/testData.ts
+++ b/tests/utils/testData.ts
@@ -68,8 +68,13 @@ type DummyUserOverrides = Partial<Omit<Manager, 'roles'> | Omit<Client, 'roles'>
  * What still errors is the part worth keeping: an unknown property, or a real
  * property at the wrong type, at any depth. Unions distribute, so a
  * relationship (`number | Image | null`) keeps accepting a bare id.
+ *
+ * Exported because specs build their own inline fixture helpers around
+ * `payload.create` — those want the same "loose but checked" contract rather
+ * than the `Record<string, unknown>` they used to reach for, which checks
+ * nothing (see #606: that's how `level: 'center'` outlived the rename).
  */
-type FixtureOverrides<T> = T extends (infer U)[]
+export type FixtureOverrides<T> = T extends (infer U)[]
   ? FixtureOverrides<U>[]
   : T extends Date
     ? T
@@ -90,8 +95,14 @@ type FixtureOverrides<T> = T extends (infer U)[]
  * What `tsc` still catches is the point: every field a test *does* pass must be a
  * real field of that collection, with a valid type. That's the #606 rot — a stale
  * enum literal like `level: 'center'` now fails here, not 7 minutes into CI.
+ *
+ * Exported for the same reason as `FixtureOverrides`: specs with their own
+ * inline `payload.create` helpers need this seam too. Without it TS can't match
+ * the non-draft `create` overload (the data type is derived from the *output*
+ * doc, so an omitted `slug` pushes it onto the draft one) and reports the
+ * baffling "Property 'draft' is missing".
  */
-function createData<TSlug extends CollectionSlug>(
+export function createData<TSlug extends CollectionSlug>(
   data: FixtureOverrides<RequiredDataFromCollectionSlug<TSlug>>,
 ): RequiredDataFromCollectionSlug<TSlug> {
   return data as RequiredDataFromCollectionSlug<TSlug>
@@ -102,11 +113,23 @@ const __dirname = path.dirname(__filename)
 const SAMPLE_FILES_DIR = path.join(__dirname, '../files')
 
 /**
+ * The shape Payload generates for a lexical `richText` field. Structurally
+ * identical across collections, so one collection's field anchors it.
+ */
+export type LexicalContent = NonNullable<Page['content']>
+
+/**
  * Creates minimal Lexical rich text content for testing
+ *
+ * The return type is annotated rather than inferred: without it `direction` and
+ * `format` widen to `string` and the result is rejected by every `richText`
+ * field it's assigned to (`'ltr'` vs `('ltr' | 'rtl') | null`) — 7 of #606
+ * Phase 2's errors. The annotation contextually types the literal instead.
+ *
  * @param text - The text content to include
  * @returns Lexical root structure compatible with PayloadCMS richText fields
  */
-export function createTestLexicalContent(text: string = 'Test content') {
+export function createTestLexicalContent(text: string = 'Test content'): LexicalContent {
   return {
     root: {
       type: 'root',

--- a/tests/utils/testData.ts
+++ b/tests/utils/testData.ts
@@ -69,6 +69,9 @@ type DummyUserOverrides = Partial<Omit<Manager, 'roles'> | Omit<Client, 'roles'>
  * property at the wrong type, at any depth. Unions distribute, so a
  * relationship (`number | Image | null`) keeps accepting a bare id.
  *
+ * No special case for `Date`: Payload generates every date field as an ISO
+ * `string`, so one can't reach the object branch here.
+ *
  * Exported because specs build their own inline fixture helpers around
  * `payload.create` — those want the same "loose but checked" contract rather
  * than the `Record<string, unknown>` they used to reach for, which checks
@@ -76,11 +79,9 @@ type DummyUserOverrides = Partial<Omit<Manager, 'roles'> | Omit<Client, 'roles'>
  */
 export type FixtureOverrides<T> = T extends (infer U)[]
   ? FixtureOverrides<U>[]
-  : T extends Date
-    ? T
-    : T extends object
-      ? { [K in keyof T]?: FixtureOverrides<T[K]> }
-      : T
+  : T extends object
+    ? { [K in keyof T]?: FixtureOverrides<T[K]> }
+    : T
 
 /**
  * Checks a factory's `create` payload, then hands it over at the type

--- a/tests/utils/testData.ts
+++ b/tests/utils/testData.ts
@@ -56,12 +56,34 @@ type DummyUserOverrides = Partial<Omit<Manager, 'roles'> | Omit<Client, 'roles'>
 }
 
 /**
+ * Fixture overrides: every field optional, at every depth.
+ *
+ * `Partial<Doc>` only relaxes the *top* level, so the moment a test passed a
+ * group or an array row it owed that subtree's required keys in full —
+ * `default: { title, image }` on an app card was rejected for omitting
+ * `aspectRatio`/`textColor`/`alignment`, which the collection fills from
+ * `defaultValue` anyway. That's ~40 of #606 Phase 2's errors, and demanding
+ * them is simply wrong for a fixture.
+ *
+ * What still errors is the part worth keeping: an unknown property, or a real
+ * property at the wrong type, at any depth. Unions distribute, so a
+ * relationship (`number | Image | null`) keeps accepting a bare id.
+ */
+type FixtureOverrides<T> = T extends (infer U)[]
+  ? FixtureOverrides<U>[]
+  : T extends Date
+    ? T
+    : T extends object
+      ? { [K in keyof T]?: FixtureOverrides<T[K]> }
+      : T
+
+/**
  * Checks a factory's `create` payload, then hands it over at the type
  * `payload.create` wants.
  *
  * Payload derives that `data` type from the generated *output* doc, so fields it
  * fills in itself are still demanded on input (`slug`, `userChoices.type`, …), and
- * the `Partial<Doc>` overrides these factories spread in re-widen required keys to
+ * the overrides these factories spread in re-widen required keys to
  * `T | undefined`. Hence the partial: Payload supplies the rest, and its own
  * validation — which the int lane exercises — enforces what's truly required.
  *
@@ -70,7 +92,7 @@ type DummyUserOverrides = Partial<Omit<Manager, 'roles'> | Omit<Client, 'roles'>
  * enum literal like `level: 'center'` now fails here, not 7 minutes into CI.
  */
 function createData<TSlug extends CollectionSlug>(
-  data: Partial<RequiredDataFromCollectionSlug<TSlug>>,
+  data: FixtureOverrides<RequiredDataFromCollectionSlug<TSlug>>,
 ): RequiredDataFromCollectionSlug<TSlug> {
   return data as RequiredDataFromCollectionSlug<TSlug>
 }
@@ -110,7 +132,10 @@ export const testData = {
   /**
    * Create an app card with image relationship
    */
-  async createAppCard(payload: Payload, overrides: Partial<AppCard> = {}): Promise<AppCard> {
+  async createAppCard(
+    payload: Payload,
+    overrides: FixtureOverrides<AppCard> = {},
+  ): Promise<AppCard> {
     const uniqueId = Math.random().toString(36).substring(7)
     const { default: defaultOverrides, ...restOverrides } = overrides
 
@@ -194,7 +219,7 @@ export const testData = {
   /**
    * Create an album with artwork image relationship
    */
-  async createAlbum(payload: Payload, overrides: Partial<Album> = {}): Promise<Album> {
+  async createAlbum(payload: Payload, overrides: FixtureOverrides<Album> = {}): Promise<Album> {
     // Generate unique title to avoid collisions
     const uniqueId = Math.random().toString(36).substring(7)
     const defaultTitle = overrides.title || `Test Album ${uniqueId}`
@@ -209,12 +234,12 @@ export const testData = {
 
     return (await payload.create({
       collection: 'albums',
-      data: {
+      data: createData<'albums'>({
         title: defaultTitle,
         artist: defaultArtist,
         artwork: artworkId,
         ...overrides,
-      },
+      }),
     })) as Album
   },
 
@@ -275,7 +300,7 @@ export const testData = {
    */
   async createUserChoice(
     payload: Payload,
-    overrides: Partial<UserChoice> = {},
+    overrides: FixtureOverrides<UserChoice> = {},
     sampleFile = 'icon-test.svg',
   ): Promise<UserChoice> {
     const filePath = path.join(SAMPLE_FILES_DIR, sampleFile)
@@ -315,7 +340,7 @@ export const testData = {
   async createSubtleSystemNode(
     payload: Payload,
     deps: { page?: number } = {},
-    overrides: Partial<SubtleSystemNode> = {},
+    overrides: FixtureOverrides<SubtleSystemNode> = {},
   ): Promise<SubtleSystemNode> {
     const NODE_SLUGS = [
       'mooladhara',
@@ -356,11 +381,11 @@ export const testData = {
 
     return (await payload.create({
       collection: 'subtle-system-nodes',
-      data: {
+      data: createData<'subtle-system-nodes'>({
         slug,
         page: pageId,
         ...overrides,
-      },
+      }),
     })) as SubtleSystemNode
   },
 
@@ -370,7 +395,7 @@ export const testData = {
    */
   async createSongTag(
     payload: Payload,
-    overrides: Partial<SongTag> = {},
+    overrides: FixtureOverrides<SongTag> = {},
     sampleFile = 'icon-test.svg',
   ): Promise<SongTag> {
     const filePath = path.join(SAMPLE_FILES_DIR, sampleFile)
@@ -404,16 +429,19 @@ export const testData = {
    * All fields are optional — omit a range to leave it unbounded; omit
    * country to match all countries.
    */
-  async createAudience(payload: Payload, overrides: Partial<Audience> = {}): Promise<Audience> {
+  async createAudience(
+    payload: Payload,
+    overrides: FixtureOverrides<Audience> = {},
+  ): Promise<Audience> {
     const uniqueId = Math.random().toString(36).substring(7)
     const defaultLabel = overrides.label || `Test Audience ${uniqueId}`
 
     return (await payload.create({
       collection: 'audiences',
-      data: {
+      data: createData<'audiences'>({
         label: defaultLabel,
         ...overrides,
-      },
+      }),
     })) as Audience
   },
 
@@ -426,7 +454,7 @@ export const testData = {
    */
   async createVideo(
     payload: Payload,
-    overrides: Partial<Video> = {},
+    overrides: FixtureOverrides<Video> = {},
     sampleFile = 'video-30s.mp4',
   ): Promise<Video> {
     const filePath = path.join(SAMPLE_FILES_DIR, sampleFile)
@@ -453,11 +481,11 @@ export const testData = {
 
     return (await payload.create({
       collection: 'videos',
-      data: {
+      data: createData<'videos'>({
         title: defaultTitle,
         tags: 'testimonial', // Default tag for required field (single select, not hasMany)
         ...overrides,
-      },
+      }),
       file: {
         data: fileData as unknown as Buffer,
         mimetype,
@@ -473,7 +501,7 @@ export const testData = {
   async createMeditation(
     payload: Payload,
     deps?: { narrator?: number; thumbnail?: number },
-    overrides: Partial<Meditation> = {},
+    overrides: FixtureOverrides<Meditation> = {},
     sampleFile = 'audio-42s.mp3',
   ): Promise<Meditation> {
     const filePath = path.join(SAMPLE_FILES_DIR, sampleFile)
@@ -513,14 +541,14 @@ export const testData = {
       // locale option provides request-level locale context for join subqueries
       // that reference localized fields on other collections (e.g., user-choices)
       locale: overrides.locale || 'en',
-      data: {
+      data: createData<'meditations'>({
         label: overrides.label || overrides.title || defaultLabel,
         thumbnail: thumbnail,
         narrator: narrator,
         locale: overrides.locale || 'en',
         type: overrides.type || 'daily', // Default to 'daily' type
         ...overrides,
-      },
+      }),
       file: {
         data: fileData as unknown as Buffer,
         mimetype:
@@ -541,7 +569,7 @@ export const testData = {
    */
   async createSong(
     payload: Payload,
-    overrides: Partial<Song> & { album?: number | Album } = {},
+    overrides: FixtureOverrides<Song> & { album?: number | Album } = {},
     sampleFile = 'audio-42s.mp3',
   ): Promise<Song> {
     const filePath = path.join(SAMPLE_FILES_DIR, sampleFile)
@@ -567,11 +595,11 @@ export const testData = {
 
     return (await payload.create({
       collection: 'songs',
-      data: {
+      data: createData<'songs'>({
         title: defaultTitle,
         album: albumId,
         ...restOverrides,
-      },
+      }),
       file: {
         data: fileData as unknown as Buffer,
         mimetype:
@@ -652,7 +680,7 @@ export const testData = {
    */
   async createManager(
     payload: Payload,
-    overrides: Partial<Omit<Manager, 'roles'>> & {
+    overrides: FixtureOverrides<Omit<Manager, 'roles'>> & {
       roles?: ManagerRole[] | { en?: string[]; cs?: string[] } | null
     } = {},
   ) {
@@ -673,14 +701,14 @@ export const testData = {
     const manager = await payload.create({
       collection: 'managers',
       locale: 'en', // Create with English locale - roles will be auto-localized
-      data: {
+      data: createData<'managers'>({
         name: 'Test Manager',
         email: `${testEmail}@example.com`,
         password: 'password123',
         type: 'manager', // Default to 'manager' type
         ...overrides,
         roles: rolesData, // Pass array directly, Payload handles localization
-      },
+      }),
     })
 
     // `collection` last: the access-control mocks in `.claude/rules/tests.md`
@@ -694,17 +722,21 @@ export const testData = {
    * @param managerId - Manager user ID (required)
    * @param overrides - Optional field overrides
    */
-  async createClient(payload: Payload, managerId: number, overrides: Partial<Client> = {}) {
+  async createClient(
+    payload: Payload,
+    managerId: number,
+    overrides: FixtureOverrides<Client> = {},
+  ) {
     const client = await payload.create({
       collection: 'clients',
-      data: {
+      data: createData<'clients'>({
         name: 'Test Client',
         managers: [managerId],
         primaryContact: managerId,
         enableAPIKey: true,
         _status: 'published', // Published = active (publish/unpublish is the auth gate)
         ...overrides,
-      },
+      }),
     })
 
     return { ...client, collection: 'clients' as const }
@@ -713,7 +745,7 @@ export const testData = {
   /**
    * Create a page
    */
-  async createPage(payload: Payload, overrides: Partial<Page> = {}): Promise<Page> {
+  async createPage(payload: Payload, overrides: FixtureOverrides<Page> = {}): Promise<Page> {
     // Generate unique title to avoid slug collisions
     const uniqueId = Math.random().toString(36).substring(7)
     const defaultTitle = `Test Page ${uniqueId}`
@@ -764,7 +796,7 @@ export const testData = {
    */
   async createLesson(
     payload: Payload,
-    overrides: Omit<Partial<Lesson>, 'meditation'> & {
+    overrides: Omit<FixtureOverrides<Lesson>, 'meditation'> & {
       meditation?: number | Lesson['meditation']
     } = {},
   ): Promise<Lesson> {
@@ -821,7 +853,7 @@ export const testData = {
   /**
    * Create an author
    */
-  async createAuthor(payload: Payload, overrides: Partial<Author> = {}): Promise<Author> {
+  async createAuthor(payload: Payload, overrides: FixtureOverrides<Author> = {}): Promise<Author> {
     return (await payload.create({
       collection: 'authors',
       data: createData<'authors'>({
@@ -845,7 +877,7 @@ export const testData = {
   async createLecture(
     payload: Payload,
     deps?: { thumbnail?: number },
-    overrides: Partial<Lecture> = {},
+    overrides: FixtureOverrides<Lecture> = {},
   ): Promise<Lecture> {
     // Thumbnail is an optional editor override — only set it when the caller asks.
     const thumbnail = deps?.thumbnail
@@ -855,13 +887,13 @@ export const testData = {
     const uniqueVimeoId = `${Date.now()}${Math.floor(Math.random() * 1000)}`
     return (await payload.create({
       collection: 'lectures',
-      data: {
+      data: createData<'lectures'>({
         type: 'full',
         title: 'Test Lecture',
         ...(thumbnail !== undefined ? { thumbnail } : {}),
         nirmalVidyaVimeoUrl: `https://vimeo.com/${uniqueVimeoId}`,
         ...overrides,
-      },
+      }),
     })) as Lecture
   },
 
@@ -879,7 +911,7 @@ export const testData = {
   async createLectureExcerpt(
     payload: Payload,
     deps?: { fullLecture?: number },
-    overrides: Partial<Lecture> = {},
+    overrides: FixtureOverrides<Lecture> = {},
   ): Promise<Lecture> {
     let fullLecture = deps?.fullLecture
     if (!fullLecture) {
@@ -888,19 +920,19 @@ export const testData = {
     }
     return (await payload.create({
       collection: 'lectures',
-      data: {
+      data: createData<'lectures'>({
         type: 'clip',
         title: 'Test Lecture Excerpt',
         startTime: 0,
         stopTime: 60,
         fullLecture,
         ...overrides,
-      },
+      }),
     })) as Lecture
   },
 
   // Alias for createManager to maintain backward compatibility with tests
-  async createUser(payload: Payload, overrides: Partial<Manager> = {}) {
+  async createUser(payload: Payload, overrides: FixtureOverrides<Manager> = {}) {
     return this.createManager(payload, overrides)
   },
 
@@ -962,7 +994,7 @@ export const testData = {
    * Regions require name, level, and mapboxId (unique)
    * For manual locations, also provide latitude, longitude, and radius
    */
-  async createRegion(payload: Payload, overrides: Partial<Region> = {}): Promise<Region> {
+  async createRegion(payload: Payload, overrides: FixtureOverrides<Region> = {}): Promise<Region> {
     const uniqueId = Math.random().toString(36).substring(7)
     const name = overrides.name || `Test City ${uniqueId}`
     const mapboxId = overrides.mapboxId || `manual-test-${Date.now()}-${uniqueId}`
@@ -994,7 +1026,7 @@ export const testData = {
    * Create an event with all required fields populated
    * Events require: title, languages, region, manager, schedule (with firstDate when not inactive)
    */
-  async createEvent(payload: Payload, overrides: Partial<Event> = {}): Promise<Event> {
+  async createEvent(payload: Payload, overrides: FixtureOverrides<Event> = {}): Promise<Event> {
     const uniqueId = Math.random().toString(36).substring(7)
 
     // Create required relationships if not provided

--- a/tests/utils/testHelpers.ts
+++ b/tests/utils/testHelpers.ts
@@ -281,3 +281,17 @@ export function createClientAuthenticatedRequest(
     } as unknown as PayloadRequest['user'],
   }
 }
+
+/**
+ * The narrowest `select` an API-client read can pass.
+ *
+ * `validateClientQuery` (src/plugins/usage/hooks.ts) rejects a missing *or
+ * empty* `select` with a 400, so a spec exercising client access still owes it
+ * one key. `id` is the cheapest: Payload returns it regardless of selection —
+ * which is also why `id` is absent from the generated `…Select` types, and why
+ * this needs an assertion. Returned as the caller's own select type so it slots
+ * into any collection's `find`.
+ */
+export function idOnlySelect<TSelect>(): TSelect {
+  return { id: true } as TSelect
+}

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -3,14 +3,14 @@
   // `tests`, and it's the config the Next.js build consumes — so the test lane
   // gets its own config here instead, keeping this work off the shipping build.
   //
-  // Scoped to the unit lane for now (#606 Phase 1). `tests/int/**` still has
-  // ~154 errors; widening `include` to `tests/**` is Phase 2. `src/**` needs no
-  // entry — it's pulled in transitively via the `@/` imports these files make,
-  // and the root config already typechecks it directly.
+  // Covers the whole suite as of #606 Phase 2 (Phase 1 shipped the unit lane
+  // only). `src/**` needs no entry — it's pulled in transitively via the `@/`
+  // imports these files make, and the root config already typechecks it directly.
   //
-  // Note: `tests/tsconfig.json` is a separate editor-only config covering all of
-  // `tests/**`. No script runs it; Phase 2 should collapse the two.
+  // `tests/tsconfig.json` is the editor's entry point — TS servers resolve the
+  // nearest `tsconfig.json` walking up from a file and won't find this one by
+  // name — and is a one-line re-export, so the options live here only.
   "extends": "./tsconfig.json",
-  "include": ["tests/unit/**/*.ts", "tests/utils/**/*.ts"],
+  "include": ["tests/**/*.ts", "tests/**/*.tsx"],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
## Summary

- **#606 Phase 2**: `tsconfig.test.json` now covers all of `tests/**`, not just the unit lane. Phase 1 (#607) closed the gap for `tests/unit/**` + `tests/utils/**`; this closes it for the 26 int specs, clearing all **158** remaining errors.
- A stale fixture is now a **~6 s** local failure instead of a 7-minute CI one. The exact case that motivated the ticket — `level: 'center'` surviving the `center` → `venue` rename in #605 — is caught by `tsc`, verified by mutation below.
- **Zero `src/` files change.** Tests, tsconfig and docs only.

## Changes

The ticket asked for the concentrated patterns to be fixed *at their source*. Four shared seams do most of the work:

- `tests/utils/taskRunner.ts` (new) — `runTaskHandler(task, { payload, input, context })`. Five specs hand-rolled the same queue-less job invocation and typed it `Parameters<typeof Task.handler>[0]`, which cannot compile: `TaskConfig['handler']` is `string | TaskHandler<TSlug>` and `Parameters<T>` rejects the union. A `typeof` guard narrows it properly. Return type comes from the generated `TypedJobs` output schema, retiring five hand-maintained copies of the job output shapes.
- `tests/utils/testData.ts` — `FixtureOverrides<T>` (exported): every field optional at *every* depth. `Partial<Doc>` relaxes only the top level, so passing a group obliged the test to fill in subfields the collection supplies from `defaultValue`. Unknown/mistyped properties still error at any depth. `createData<TSlug>()` is now exported too — without it an omitted auto-filled field (`slug`) pushes `tsc` onto the *draft* create overload, which reports the unrelated-looking `Property 'draft' is missing`.
- `tests/utils/testHelpers.ts` — `idOnlySelect()`. `select: { id: true }` (11 sites) can't typecheck because Payload omits `id` from the generated `…Select` types. Note `select: {}` is **not** equivalent — `validateClientQuery` rejects an empty select with a 400 (the first attempt at this failed 7 tests; caught by running them, not by reading types).
- `tests/tsconfig.json` collapsed to a one-line re-export of `tsconfig.test.json`, so the editor and the gate read one set of options.

## Rot the exclusion was hiding

Not just typing noise — these were live defects:

- `tests/int/api.int.spec.ts` — `createMeditation(payload, { title })` put the title in the factory's **`deps`** slot (2nd param) instead of `overrides` (3rd), so the meditation silently got a random label. Its `populate` was also keyed on the field name rather than the target collection, making it a no-op.
- `tests/int/lectures.int.spec.ts` — all eight `fetchNirmalaVidyaVideo` mocks omitted `duration`, which is required on `NirmalaVidyaVideoData` and read by `populateFromNirmalaVidya`; they were passing `undefined` where the contract says `number | null`. Fifteen `as any` casts also collapsed the *result* type to a union over every collection, so `lecture.title` / `.metadata` didn't exist on it.
- `lectures-for-audience` / `meditation-lectures` — seven audience fixtures passed `rules: { logic: 'AND', … }`. `Audience` has no `rules` field (it was flattened into top-level range groups), so Payload had been dropping it. Removed rather than translated: `/lectures/for-audience` matches on audience **id** overlap and never evaluates rules, so nothing read it.
- `tests/int/audiences.int.spec.ts` — `createAppCard(payload, { title })`; AppCard's title lives under the `default` group, so it was dropped.
- `tests/int/app-cards-for-audience.int.spec.ts` — `toHaveLength(1, 'message')`; the matcher takes one argument and the message was discarded.
- `tests/int/wemeditateAppStatus.int.spec.ts` — the invariant fixture omitted `label` and `description`, both required on `SectionSpec`.
- The five `SCHEDULE` fixtures pinned `recurrenceType` with `as const` but left `firstDate_tz` widening to `string`, so none satisfied `SupportedTimezones`.

## Mutation check (ticket AC)

Three mutations introduced against the finished branch, each caught, then reverted to 0 errors:

| Mutation | Result |
|---|---|
| `level: 'venue'` → `'center'` (the #605 escape) | `TS2322: Type '"center"' is not assignable to type '"region" \| "country" \| "city" \| "venue"'` |
| `default: { title: … }` → `titel` on a nested group | `TS2561: … 'titel' does not exist in type …` |
| `const bad: string = result.processed` on a job output | `TS2322: Type 'number' is not assignable to type 'string'` |

## Test Results

- **Integration: 885 passed (54 files)** — full `pnpm test:int`, green
- **Unit: 978 passed (85 files)**
- `pnpm typecheck` (src): ✓ · `pnpm typecheck:tests`: ✓ 0 errors over `tests/**` · `pnpm lint`: ✓
- Tier 2 lean gate, cold (no `.tsbuildinfo`): **27 s** — inside its 45 s budget. `typecheck:tests` alone is 16.7 s cold / 3.5 s warm, 320k type instantiations.
- E2E: N/A — no UI changes.

## Notes for reviewer

- The interesting question for a typecheck-only PR is whether any fix quietly weakened an assertion. The eight behaviour-adjacent changes (the `idOnlySelect` swap, the `rules` deletion, `duration: null`, the `as const` schedules, the `EventFixture` sentinel, the `createMeditation` arg fix, the throwing `inlineTask`, the `_status` cast) were each verified against source and by running their specs.
- Casts were kept only where a test is deliberately out of contract, each with a comment: videos' malformed subtitle row, meditations' `locale: 'all'` (a real Payload value absent from the generated union), and events' `_status` assertion (omitted from the select on purpose, to prove the plugin injects it).
- `FixtureOverrides` has no `Date` branch — Payload generates every date field as an ISO `string`, verified by grep.
- Dropping `types: ["vitest/globals"]` from `tests/tsconfig.json` is safe: every Vitest spec imports its globals explicitly and all six e2e specs take theirs from `@playwright/test`.
- No security review: zero `src/` files changed. The path grep matches only `cloudflare-stream-webhook.int.spec.ts`, on the substring `webhook`, and that diff is a type alias plus comments.

Closes #606

🤖 Generated with [Claude Code](https://claude.com/claude-code)
