### PR TITLE
refactor(emails): localize EventVerificationEmail per manager language

### DIFF
--- a/.claude/rules/email.md
+++ b/.claude/rules/email.md
@@ -83,7 +83,7 @@ package (v6 unified them — the older `@react-email/components` and
 | `EmailLayout.tsx` | Shared shell — gradient brand header, card body, footer. Exports `BrandButton`, `BrandButtonRow` (2–3 actions centered together on one row), `DetailRow` (label/value fact-table row, for manager emails), `StackedDetailRow` (label-above-value itinerary row, for guest emails), `SectionHeading` (uppercase section label), and shared `styles`. Reuse these so templates stay visually consistent. |
 | `VerifyEmail.tsx` | Managers email-verification message. |
 | `ResetPasswordEmail.tsx` | Managers password-reset message (replaces Payload's bare default). |
-| `EventVerificationEmail.tsx` | Manager/region event-verification reminder — coloured alert callout keyed on `ReminderLevel`. |
+| `EventVerificationEmail.tsx` | Manager/region event-verification reminder — coloured alert callout keyed on `ReminderLevel`; localized per `Managers.language` (#610). Also exports `verificationSubject`. |
 | `RegistrationConfirmationEmail.tsx` | Registrant confirmation for an event registration — client-branded, localized, ICS attached. Also exports `registrationConfirmationText` (the plain-text alternative). |
 | `SessionReminderEmail.tsx` | Registrant reminder ~24h before a session (#589) — client-branded, localized sibling of the confirmation sharing `StackedDetailRow`; states the single next occurrence, **no** ICS, footer unsubscribe link. Also exports `sessionReminderText`. Sent by the `SendSessionReminders` job. |
 | `EventRegistrationEmail.tsx` | Manager-facing notice that a seeker registered — Sahaj Atlas project brand; event/registrant/start-date `DetailRow`s, the registrant's forwarded question answers (resolved via `buildRegistrationAnswers`), and a `BrandButtonRow` of Reply (a `mailto:` pre-filled with a quoted recap) + View event. Also exports `buildReplyBody`. Informational (no alert callout). |
@@ -171,11 +171,32 @@ in `src/emails/`.
 
 ## Localized copy & plural forms
 
-Registrant-facing chrome (the confirmation / reminder / unsubscribe copy) is
-resolved **server-side** by `resolveEmailStrings()` (`src/lib/translations/emailStrings.ts`)
-from the Atlas translations `emails` group, merged over the English
-`EMAIL_STRING_DEFAULTS`. Templates receive already-resolved strings as props and
-never query — see the group note in `.claude/rules/globals.md`.
+Email chrome is resolved **server-side** by `resolveEmailStrings()`
+(`src/lib/translations/emailStrings.ts`) from the Atlas translations `emails`
+group, merged over the English `EMAIL_STRING_DEFAULTS`. Templates receive
+already-resolved strings as props and never query — see the group note in
+`.claude/rules/globals.md`. Two audiences, one group:
+
+- **Registrant** (confirmation / reminder / unsubscribe) — resolved for the
+  `locale` stored on the registration.
+- **Manager** (`EventVerificationEmail`, the `verify_*` keys) — resolved for
+  `Managers.language`. That field offers every ISO 639-1 language, not just the
+  19 CMS locales, so `sendEmailReminder` maps it through `languageToLocale`
+  (`@/lib/locales`); unset, or a language the CMS isn't translated into,
+  resolves the default locale.
+
+**A localized string interpolates its values; it never concatenates around
+them** — word order differs by language, so `'Verify ' + title` is
+untranslatable. Use `interpolate()` for a plain string (subject, mailto body),
+and `EventVerificationEmail`'s local `interpolateNodes()` when a value carries
+markup (the bold deadline / region / manager name inside a sentence).
+
+The verification copy is keyed as a **ragged matrix**:
+`verify_<audience>_<level>_<slot>`, where a region manager has no `due` level
+(they're escalated to, never notified first). `variantKey()` narrows the union
+so a combination without copy is a `null` → thrown error, and a key missing from
+`EMAIL_STRING_DEFAULTS` is a **compile** error rather than a blank line in a
+sent email.
 
 **Plurals go through `pluralize()`, not `interpolate()`.** A quantity-dependent
 string is stored as a family of keys suffixed with the CLDR categories —

--- a/.claude/rules/globals.md
+++ b/.claude/rules/globals.md
@@ -70,12 +70,16 @@ the global. Versions: max 3.
 
 The Atlas `Emails` group is read **server-side** (not just exported to the
 widget) by `resolveEmailStrings()` in `src/lib/translations/emailStrings.ts`,
-which supplies the localized chrome for registrant mail. Note Payload's locale
-fallback is **per field, not per key**: a JSON blob that exists but omits a key
-yields `undefined`, not the English value — so the resolver merges over English
-key defaults. Add a key to `translationsSchema.json` *and* to
-`EMAIL_STRING_DEFAULTS`, or it renders blank in every locale that has any
-translation at all.
+which supplies the localized chrome for registrant mail *and* — under the
+`verify_*` prefix — the manager-facing event-verification reminder. The two
+resolve against different languages (the registrant's stored `locale`, the
+manager's `Managers.language`) but share one group, one resolver and one set of
+English defaults. Note Payload's locale fallback is **per field, not per key**:
+a JSON blob that exists but omits a key yields `undefined`, not the English
+value — so the resolver merges over English key defaults. Add a key to
+`translationsSchema.json` *and* to `EMAIL_STRING_DEFAULTS`, or it renders blank
+in every locale that has any translation at all; a guard in
+`tests/unit/email-strings.spec.ts` fails if the two sides drift.
 
 ```typescript
 import { buildTranslationTabs, type TranslationsSchema } from '@/fields'

--- a/.claude/rules/scripts.md
+++ b/.claude/rules/scripts.md
@@ -25,7 +25,7 @@ one-time backfills, deployment helpers, etc.
 | File | Purpose |
 |---|---|
 | `setup-stream-webhook.ts` | Register / inspect / delete the account-level Cloudflare Stream webhook |
-| `preview-event-emails.ts` | Send the manager event-verification reminders (all levels/audiences) to an Ethereal inbox |
+| `preview-event-emails.ts` | Send the manager event-verification reminders (all levels/audiences, plus one partly-translated locale) to an Ethereal inbox |
 | `preview-registration-emails.ts` | Send the registrant confirmation in each state (online/offline, locale, branded/fallback, one-off, minimal) to an Ethereal inbox, with the `.ics` attached |
 | `preview-registration-notification-emails.ts` | Send the manager registration notice (#588) in each state (named manager / override address / no session / long title) to an Ethereal inbox |
 | `preview-reminder-digest-emails.ts` | Send the registrant session reminder + manager registration digest (#589) in each state (online/offline, locale, branded/fallback, daily/weekly) to an Ethereal inbox |

--- a/scripts/preview-event-emails.ts
+++ b/scripts/preview-event-emails.ts
@@ -264,11 +264,26 @@ async function persistSampleEvent(): Promise<SampleData> {
   }
 }
 
+/**
+ * A partly-translated locale, to show the two things the English previews
+ * can't: copy resolved for a manager's own language, and the per-key fallback
+ * when a translator hasn't filled everything in (labels stay English here).
+ */
+const CZECH_SAMPLE: Record<string, string> = {
+  verify_greeting: 'Dobrý den, %{name},',
+  verify_manager_due_subject: 'Ověřte prosím svou událost: %{event}',
+  verify_manager_due_heading: 'Ověřte svou hodinu Sahaja Yogy',
+  verify_manager_due_preview: 'Rychlá kontrola, že vaše hodina stále probíhá.',
+  verify_manager_due_cta: 'Ověřit událost',
+  verify_manager_due_body:
+    'Aby byly veřejné výpisy přesné, je potřeba události na %{brand} pravidelně kontrolovat. Neověřené události se automaticky skryjí. Zkontrolujte prosím údaje o své hodině níže.',
+  verify_manager_due_callout: '✅ Ověřte do %{deadline}, aby událost zůstala zveřejněná.',
+  verify_details_heading: 'Údaje o události',
+}
+
 async function main() {
-  const { createElement } = await import('react')
   const nodemailer = (await import('nodemailer')).default
-  const { EventVerificationEmail } = await import('@/emails/EventVerificationEmail')
-  const { renderEmail } = await import('@/plugins/email')
+  const { sendEmailReminder } = await import('@/lib/notifications/channels/email')
   const { signVerifyToken } = await import('@/lib/eventVerification/token')
   const { buildVerifyEmailLink } = await import('@/lib/eventVerification/verifyUrl')
   const { formatLongDate } = await import('@/lib/notifications')
@@ -283,7 +298,7 @@ async function main() {
         managerEmail: 'priya.deshmukh@example.com',
         details: {
           title: 'Saturday Morning Sahaja Yoga Meditation',
-          locationLabel: 'Address',
+          isOnline: false,
           location: '12 MG Road, 2nd Floor, Cultural Hall, Pune, Maharashtra, IN 411001',
           schedule: 'Every week on Saturday at 9:26 AM',
           contact: 'Priya Deshmukh · +91 98765 43210',
@@ -319,8 +334,15 @@ async function main() {
   }
 
   // The event manager gets all four levels; region managers are looped in from
-  // escalated onward (a different framing + the manager's contacts).
-  const combos: { level: ReminderLevel; audience: ReminderAudience }[] = [
+  // escalated onward (a different framing + the manager's contacts). The last
+  // combo is the same `due` reminder for a Czech-speaking manager.
+  const combos: {
+    level: ReminderLevel
+    audience: ReminderAudience
+    language?: string
+    translations?: Record<string, string>
+    note?: string
+  }[] = [
     { level: 'due', audience: 'manager' },
     { level: 'escalated', audience: 'manager' },
     { level: 'urgent', audience: 'manager' },
@@ -328,35 +350,69 @@ async function main() {
     { level: 'escalated', audience: 'region' },
     { level: 'urgent', audience: 'region' },
     { level: 'expired', audience: 'region' },
+    {
+      level: 'due',
+      audience: 'manager',
+      language: 'cs',
+      translations: CZECH_SAMPLE,
+      note: 'partly-translated locale — untranslated keys fall back to English',
+    },
   ]
 
-  const previews: { label: string; url: string | false }[] = []
-  for (const { level, audience } of combos) {
+  const previews: { label: string; note?: string; url: string | false }[] = []
+  for (const { level, audience, language, translations, note } of combos) {
+    const label = `${audience} · ${level}${language ? ` · ${language}` : ''}`
     const token = signVerifyToken({ eventId: sample.eventId, managerId: sample.managerId }, secret)
-    const html = await renderEmail(
-      createElement(EventVerificationEmail, {
-        name: audience === 'region' ? 'Rohan Patil' : sample.managerName,
+    const destination = audience === 'region' ? 'rohan.patil@example.com' : sample.managerEmail
+
+    // Drive the real send path so the preview can't drift from production —
+    // it resolves the manager's language, renders, and builds the subject.
+    // Only the two seams a preview must fake are stubbed: the translations
+    // read and the transport.
+    const payload = {
+      findGlobal: async () => ({ emails: translations ?? {} }),
+      logger: { debug() {}, error() {}, info() {}, warn() {} },
+      sendEmail: async (message: Record<string, unknown>) => {
+        const info = await transport.sendMail({
+          ...message,
+          from: 'Sahaj Atlas <dev@wemeditate.com>',
+          // Label the inbox row so combos are distinguishable at a glance; the
+          // real (localized) subject stays visible inside the message.
+          subject: `[${label}] ${String(message.subject)}`,
+        } as never)
+        previews.push({ label, note, url: nodemailer.getTestMessageUrl(info) })
+      },
+    }
+
+    await sendEmailReminder(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      payload as any,
+      {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        manager: {
+          name: audience === 'region' ? 'Rohan Patil' : sample.managerName,
+          language,
+        } as any,
+        role: audience,
+        channel: 'email',
+        destination,
+        regionName: audience === 'region' ? 'Maharashtra' : undefined,
+      },
+      {
         eventTitle: sample.eventTitle,
+        level,
+        audience,
         verifyUrl: buildVerifyEmailLink(token),
         // Published events link to the map; expired (unpublished) ones don't.
         eventUrl:
           level === 'expired' ? null : `https://wemeditate.com/map#/!/events/${sample.eventId}`,
-        level,
-        audience,
         details: sample.details,
         deadline: level === 'expired' ? today : futureDeadline,
         sinceLastVerified,
         regionName: audience === 'region' ? 'Maharashtra' : undefined,
         eventManager: audience === 'region' ? eventManager : undefined,
-      }),
+      },
     )
-    const info = await transport.sendMail({
-      from: 'Sahaj Atlas <dev@wemeditate.com>',
-      to: audience === 'region' ? 'rohan.patil@example.com' : sample.managerEmail,
-      subject: `[${audience}/${level}] ${sample.eventTitle}`,
-      html,
-    })
-    previews.push({ label: `${audience} · ${level}`, url: nodemailer.getTestMessageUrl(info) })
   }
 
   console.log('\n━━━ Event verification reminder previews ━━━\n')
@@ -370,7 +426,9 @@ async function main() {
   console.log(`  user: ${account.user}`)
   console.log(`  pass: ${account.pass}`)
   console.log(`\nDirect preview links:`)
-  for (const { label, url } of previews) console.log(`  ${label.padEnd(20)} ${url}`)
+  for (const { label, note, url } of previews) {
+    console.log(`  ${label.padEnd(26)} ${url}${note ? `\n  ${' '.repeat(26)} ↳ ${note}` : ''}`)
+  }
   console.log('')
 
   process.exit(0)

--- a/src/app/(frontend)/events/verify/VerificationCard.tsx
+++ b/src/app/(frontend)/events/verify/VerificationCard.tsx
@@ -82,13 +82,17 @@ export function ActionButtons({ brand, actions }: { brand: EmailBrand; actions: 
  * The event's key facts, matching the reminder email's "Event details" table
  * (same fields + order). `details` is the shared `EventDetails` built by
  * `buildEventEmailDetails`, so the page and email never drift.
+ *
+ * The labels are this page's own: the email resolves its own from the
+ * translations global, since it goes out in the manager's language while this
+ * page — like the rest of the verify flow — is English.
  */
 export function EventSummary({ brand, details }: { brand: EmailBrand; details: EventDetails }) {
   const isUrl = /^https?:\/\//.test(details.location)
   const rows: { label: string; value: ReactNode }[] = [{ label: 'Event', value: details.title }]
   if (details.location) {
     rows.push({
-      label: details.locationLabel,
+      label: details.isOnline ? 'Online' : 'Address',
       value: isUrl ? (
         <a href={details.location} style={{ color: brand.colors.primary, wordBreak: 'break-all' }}>
           {details.location}
@@ -119,7 +123,7 @@ export function EventSummary({ brand, details }: { brand: EmailBrand; details: E
       } in the last 30 days`,
     })
   }
-  rows.push({ label: 'Last verified', value: details.lastVerified })
+  rows.push({ label: 'Last verified', value: details.lastVerified ?? 'Never' })
 
   return (
     <div style={summaryWrap}>

--- a/src/emails/EventVerificationEmail.tsx
+++ b/src/emails/EventVerificationEmail.tsx
@@ -1,7 +1,10 @@
 import type { ReactNode } from 'react'
 
+import { Fragment } from 'react'
 import { Hr, Link, Section, Text } from 'react-email'
 
+import type { LocaleCode } from '@/lib/locales'
+import { type EmailStrings, interpolate, pluralize } from '@/lib/translations/emailStrings'
 import type { ProjectSlug } from '@/payload-types'
 import { getEmailBrand } from '@/plugins/email'
 
@@ -13,11 +16,26 @@ export type ReminderLevel = 'due' | 'escalated' | 'urgent' | 'expired'
 /** Who the reminder is going to — its manager, or a region manager above it. */
 export type ReminderAudience = 'manager' | 'region'
 
+/** Levels a region manager sees — they're escalated to, so never at `due`. */
+type RegionLevel = Exclude<ReminderLevel, 'due'>
+
+/** The slots one variation's copy fills. */
+type VariantSlot = 'subject' | 'heading' | 'preview' | 'cta' | 'body' | 'callout'
+
+/**
+ * Translation keys the audience × level matrix can address — deliberately
+ * ragged. Indexing `strings` with this union is what makes a key missing from
+ * `EMAIL_STRING_DEFAULTS` a compile error rather than a blank line in an email.
+ */
+type VariantKey =
+  | `verify_manager_${ReminderLevel}_${VariantSlot}`
+  | `verify_region_${RegionLevel}_${VariantSlot}`
+
 /** Key event facts shown in the email so the manager can verify at a glance. */
 export interface EventDetails {
   title: string
-  /** `Address` (offline) or `Online`. */
-  locationLabel: string
+  /** Whether `location` is a joining URL rather than a street address. */
+  isOnline: boolean
   /** One-line address, or the online URL. */
   location: string
   /** One-line schedule summary. */
@@ -26,8 +44,8 @@ export interface EventDetails {
   contact?: string
   /** Formatted scheduled-break lines, when any. */
   breaks?: string[]
-  /** Date the event was last verified (shown in every email). */
-  lastVerified: string
+  /** Date the event was last verified; `null` when it never has been. */
+  lastVerified: string | null
   /** Registrations in the last 30 days — omitted when there are none. */
   recentRegistrations?: number
 }
@@ -51,6 +69,10 @@ interface EventVerificationEmailProps {
   level: ReminderLevel
   /** Whether the recipient is the event manager or a region manager. */
   audience: ReminderAudience
+  /** Localized copy, pre-resolved for the recipient — a template never queries. */
+  strings: EmailStrings
+  /** Recipient's locale — drives plural-form selection (the registration count). */
+  locale?: LocaleCode | null
   /** Formatted date the event is / was unpublished. */
   deadline?: string
   /** Human duration the event has gone unverified. */
@@ -65,190 +87,6 @@ interface EventVerificationEmailProps {
   project?: ProjectSlug
 }
 
-/** Interpolation values available to every `body` below. */
-interface CopyVars {
-  /** The event title (bold). */
-  title: ReactNode
-  /** The event manager's name (bold) — for region copy. */
-  manager: ReactNode
-  /** The product/brand name, e.g. "Sahaj Atlas". */
-  brandName: string
-  /** The unpublish date (bold), or "shortly" when unknown. */
-  deadline: ReactNode
-  /** The region linking a region manager to the event (bold) — region copy. */
-  region: ReactNode
-  /** How long the event has gone unverified. */
-  sinceLastVerified: string
-}
-
-interface VariantCopy {
-  /** Card heading. */
-  heading: string
-  /** Inbox preview snippet. */
-  preview: string
-  /** Verify-button label. */
-  cta: string
-  /** The main paragraph. */
-  body: (vars: CopyVars) => ReactNode
-  /** Coloured callout banner — the plain-English "do X by {deadline}" instruction. */
-  callout: (vars: CopyVars) => ReactNode
-}
-
-/* ───────────────────────────────────────────────────────────────────────────
- * EMAIL COPY — edit everything here.
- *
- * `COPY.variants[audience][level]` holds the entire wording for one variation
- * (heading, inbox preview, button label, body paragraph, and optional callout)
- * in a single block, so a variation can be reworded without hunting through the
- * component. `{values}` in a `body` come from CopyVars above. Shared lines
- * (greeting, footer, button hint) sit at the top.
- * ─────────────────────────────────────────────────────────────────────────── */
-const COPY: {
-  greeting: (name: string) => ReactNode
-  buttonHint: string
-  footer: (audience: ReminderAudience, brandName: string) => ReactNode
-  /** The pre-filled email a region manager's "Contact manager" button opens. */
-  contactManager: {
-    subject: (eventTitle: string) => string
-    body: (eventTitle: string, managerName: string) => string
-  }
-  variants: {
-    manager: Record<ReminderLevel, VariantCopy>
-    // Region managers are first looped in at `escalated`; there is no `due`.
-    region: Partial<Record<ReminderLevel, VariantCopy>>
-  }
-} = {
-  greeting: (name) => (
-    <>
-      Hello <strong>{name}</strong>,
-    </>
-  ),
-
-  buttonHint: 'If the button doesn’t work, copy and paste this link into your browser:',
-
-  footer: (audience, brandName) => (
-    <>
-      You’re receiving this because you manage{' '}
-      {audience === 'region' ? 'this region' : 'this event'} on {brandName}. The links in this email
-      are unique to you and acts on your behalf — please don’t forward this email.
-    </>
-  ),
-
-  contactManager: {
-    subject: (eventTitle) => `Please verify your Sahaja Yoga class: ${eventTitle}`,
-    body: (eventTitle, managerName) =>
-      `Hello ${managerName},\n\nYour event “${eventTitle}” is going to be automatically unpublished soon if we don't check it. Could you verify it from your reminder email, or let me know if it is no longer running?\n\nThank you.`,
-  },
-
-  variants: {
-    manager: {
-      due: {
-        heading: 'Verify your Sahaja Yoga class',
-        preview: 'A quick check that your class is still running.',
-        cta: 'Verify this event',
-        body: ({ brandName }) => (
-          <>
-            To keep public listings accurate, {brandName} events need to be checked periodically.
-            Events which are not verified are automatically unpublished. Please verify the details
-            of your class below.
-          </>
-        ),
-        callout: ({ deadline }) => <>✅ Verify by {deadline} to keep this event published.</>,
-      },
-      escalated: {
-        heading: 'Sahaja Yoga class still needs verification',
-        preview: 'Your event is overdue for verification.',
-        cta: 'Verify now',
-        body: () => (
-          <>
-            This is a reminder that your event still needs verification. Please check the details
-            below and verify now.
-          </>
-        ),
-        callout: ({ deadline }) => <>⏰ Verify by {deadline} or this event will be unpublished.</>,
-      },
-      urgent: {
-        heading: 'Final reminder: verify your Sahaja Yoga class',
-        preview: 'Last reminder before your class is unpublished.',
-        cta: 'Verify now',
-        body: () => (
-          <>
-            This is the final reminder to verify your event. Please check the details below and
-            verify it immediately.
-          </>
-        ),
-        callout: ({ deadline }) => (
-          <>⚠️ Final reminder — verify by {deadline} or this event will be unpublished.</>
-        ),
-      },
-      expired: {
-        heading: 'Your Sahaja Yoga class has been unpublished',
-        preview: 'Your unverified event is now hidden from the public.',
-        cta: 'Verify to restore',
-        body: ({ sinceLastVerified }) => (
-          <>
-            Your event wasn’t verified in over {sinceLastVerified}, so it has been hidden from the
-            public. If this event is still running, please verify the details below to immediately
-            republish the event.
-          </>
-        ),
-        callout: ({ deadline }) => <>🚫 Unpublished on {deadline}. Verify now to republish.</>,
-      },
-    },
-
-    region: {
-      escalated: {
-        heading: 'Event manager not responding',
-        preview: 'Please contact the event manager to verify their event.',
-        cta: 'Contact manager',
-        body: ({ manager, region }) => (
-          <>
-            The following event in {region} needs verification, but the event manager has not yet
-            responded. Please reach out to {manager} and confirm if it’s still running.
-          </>
-        ),
-        callout: ({ deadline }) => (
-          <>
-            ⏰ Contact the manager. They must verify by {deadline} or this event will be
-            unpublished.
-          </>
-        ),
-      },
-      urgent: {
-        heading: 'Event will soon be unpublished',
-        preview: 'Last notice before an event in your region is unpublished.',
-        cta: 'Contact manager',
-        body: ({ manager, region }) => (
-          <>
-            An event in {region} still needs verification, and its manager hasn’t responded to
-            earlier reminders. Please get in touch with {manager} to check on it.
-          </>
-        ),
-        callout: ({ deadline }) => (
-          <>
-            ⚠️ Final notice — contact the manager. They must verify by {deadline} or this event will
-            be unpublished.
-          </>
-        ),
-      },
-      expired: {
-        heading: 'Event has been unpublished',
-        preview: 'An unverified event in your region is now hidden.',
-        cta: 'Contact manager',
-        body: ({ manager, region, sinceLastVerified }) => (
-          <>
-            An event in {region} was unpublished after going unverified for {sinceLastVerified}. If
-            it’s still running, please contact {manager} and ask them to verify the event.
-          </>
-        ),
-        callout: ({ deadline }) => (
-          <>🚫 Unpublished on {deadline}. Contact the manager to republish.</>
-        ),
-      },
-    },
-  },
-}
-
 // One colour per level — calm at `due`, escalating to red once unpublished.
 const CALLOUT_COLORS: Record<ReminderLevel, { bg: string; border: string }> = {
   due: { bg: '#eef5fc', border: '#4a8cd4' },
@@ -257,31 +95,90 @@ const CALLOUT_COLORS: Record<ReminderLevel, { bg: string; border: string }> = {
   expired: { bg: '#fdecea', border: '#ef4444' },
 }
 
-/** Look up a variation's copy, throwing for unsupported combinations (region/due). */
-function getVariant(audience: ReminderAudience, level: ReminderLevel): VariantCopy {
-  const variant = COPY.variants[audience][level]
-  if (!variant) {
+/** Key for one slot of a variation, or `null` for the unsupported region/due. */
+function variantKey(
+  audience: ReminderAudience,
+  level: ReminderLevel,
+  slot: VariantSlot,
+): VariantKey | null {
+  if (audience === 'region') {
+    if (level === 'due') return null
+    return `verify_region_${level}_${slot}`
+  }
+  return `verify_manager_${level}_${slot}`
+}
+
+/** One slot of a variation's copy, throwing for unsupported combinations. */
+function variantString(
+  strings: EmailStrings,
+  audience: ReminderAudience,
+  level: ReminderLevel,
+  slot: VariantSlot,
+): string {
+  const key = variantKey(audience, level, slot)
+  if (!key) {
     throw new Error(
       `EventVerificationEmail: the "${level}" reminder is not supported for ${audience} recipients`,
     )
   }
-  return variant
+  return strings[key]
+}
+
+/**
+ * The localized subject line for one variation, so the send path doesn't have
+ * to know how the copy is keyed. Throws for region/due, exactly as render does.
+ */
+export function verificationSubject(args: {
+  strings: EmailStrings
+  audience: ReminderAudience
+  level: ReminderLevel
+  eventTitle: string
+}): string {
+  const { strings, audience, level, eventTitle } = args
+  return interpolate(variantString(strings, audience, level, 'subject'), { event: eventTitle })
+}
+
+/**
+ * Interpolate `%{...}` placeholders with ReactNodes, so a value can carry markup
+ * — the deadline, region and manager name render bold inside the sentence.
+ * Placeholders rather than concatenation are what let a translator move a value
+ * to wherever their language puts it. `interpolate()` is the plain-string
+ * equivalent, for a subject or a mailto body. An unknown placeholder is left
+ * intact so a copy mistake is visible in the rendered email.
+ */
+function interpolateNodes(template: string, values: Record<string, ReactNode>): ReactNode {
+  return template.split(/(%\{\w+\})/g).map((part, index) => {
+    const key = /^%\{(\w+)\}$/.exec(part)?.[1]
+    if (key === undefined || !(key in values)) return part
+    return <Fragment key={index}>{values[key]}</Fragment>
+  })
 }
 
 /** mailto a region manager uses to reach the event manager (the region CTA). */
-function contactManagerHref(email: string, eventTitle: string, managerName: string): string {
-  const subject = COPY.contactManager.subject(eventTitle)
-  const body = COPY.contactManager.body(eventTitle, managerName)
+function contactManagerHref(
+  strings: EmailStrings,
+  email: string,
+  eventTitle: string,
+  managerName: string,
+): string {
+  const subject = interpolate(strings.verify_contact_subject, { event: eventTitle })
+  const body = interpolate(strings.verify_contact_body, { event: eventTitle, manager: managerName })
   return `mailto:${email}?subject=${encodeURIComponent(subject)}&body=${encodeURIComponent(body)}`
 }
 
 /**
  * Event verification email — the escalating nudge the ExpireEvents job sends as
- * an event ages `verified → reminded → escalated → urgent → expired`. All
- * wording lives in `COPY` above; this component only wires the chosen variation
- * to the layout, the summary tables, and the tokenized verify button. Region
+ * an event ages `verified → reminded → escalated → urgent → expired`. Every
+ * word comes from the `emails` group of the `sy-atlas-translations` global,
+ * resolved for the recipient's own language before render (`resolveEmailStrings`
+ * off `Managers.language`); this component only wires the chosen variation to
+ * the layout, the summary tables, and the tokenized verify button. Region
  * managers (looped in from `escalated`) get region-framed copy plus the event
  * manager's contacts so they can follow up.
+ *
+ * The event facts themselves — schedule phrase, dates, how long it has gone
+ * unverified — arrive pre-formatted in English from `buildEventEmailDetails`:
+ * as the translations group puts it, event data is never translated.
  */
 export function EventVerificationEmail({
   name,
@@ -290,6 +187,8 @@ export function EventVerificationEmail({
   eventUrl,
   level,
   audience,
+  strings,
+  locale,
   deadline,
   sinceLastVerified,
   details,
@@ -298,30 +197,31 @@ export function EventVerificationEmail({
   project = 'sahaj-atlas',
 }: EventVerificationEmailProps) {
   const brand = getEmailBrand(project)
-  const variant = getVariant(audience, level)
+  const copy = (slot: VariantSlot) => variantString(strings, audience, level, slot)
   const calloutColor = CALLOUT_COLORS[level]
   const isUrl = details ? /^https?:\/\//.test(details.location) : false
-  const vars: CopyVars = {
-    title: <strong>{eventTitle}</strong>,
-    manager: <strong>{eventManager?.name ?? 'the event manager'}</strong>,
-    brandName: brand.productName,
-    deadline: deadline ? <strong>{deadline}</strong> : 'shortly',
-    region: <strong>{regionName ?? 'your region'}</strong>,
-    sinceLastVerified,
+  const vars: Record<string, ReactNode> = {
+    brand: brand.productName,
+    deadline: deadline ? <strong>{deadline}</strong> : strings.verify_fallback_deadline,
+    manager: <strong>{eventManager?.name ?? strings.verify_fallback_manager}</strong>,
+    region: <strong>{regionName ?? strings.verify_fallback_region}</strong>,
+    since: sinceLastVerified,
   }
 
   // Region managers don't verify (they may lack the details); their CTA emails
   // the event manager instead. Everyone else gets the tokenized verify link.
   const contactEmail = eventManager?.contacts.find((entry) => entry.label === 'Email')?.value
   const ctaHref =
-    audience === 'region' && contactEmail
-      ? contactManagerHref(contactEmail, eventTitle, eventManager?.name ?? 'there')
+    audience === 'region' && eventManager && contactEmail
+      ? contactManagerHref(strings, contactEmail, eventTitle, eventManager.name)
       : verifyUrl
 
   return (
-    <EmailLayout brand={brand} heading={variant.heading} previewText={variant.preview}>
-      <Text style={styles.paragraph}>{COPY.greeting(name)}</Text>
-      <Text style={styles.paragraph}>{variant.body(vars)}</Text>
+    <EmailLayout brand={brand} heading={copy('heading')} previewText={copy('preview')}>
+      <Text style={styles.paragraph}>
+        {interpolateNodes(strings.verify_greeting, { name: <strong>{name}</strong> })}
+      </Text>
+      <Text style={styles.paragraph}>{interpolateNodes(copy('body'), vars)}</Text>
 
       <Section
         style={{
@@ -335,13 +235,13 @@ export function EventVerificationEmail({
           lineHeight: 1.5,
         }}
       >
-        {variant.callout(vars)}
+        {interpolateNodes(copy('callout'), vars)}
       </Section>
 
       {audience === 'region' && eventManager ? (
         <Section>
-          <SectionHeading>Event manager</SectionHeading>
-          <DetailRow label="Name">{eventManager.name}</DetailRow>
+          <SectionHeading>{strings.verify_manager_heading}</SectionHeading>
+          <DetailRow label={strings.verify_label_name}>{eventManager.name}</DetailRow>
           {eventManager.contacts.map((entry) => (
             <DetailRow key={entry.label} label={entry.label}>
               {entry.value}
@@ -352,10 +252,12 @@ export function EventVerificationEmail({
 
       {details ? (
         <Section>
-          <SectionHeading>Event details</SectionHeading>
-          <DetailRow label="Event">{details.title}</DetailRow>
+          <SectionHeading>{strings.verify_details_heading}</SectionHeading>
+          <DetailRow label={strings.verify_label_event}>{details.title}</DetailRow>
           {details.location ? (
-            <DetailRow label={details.locationLabel}>
+            <DetailRow
+              label={details.isOnline ? strings.verify_label_online : strings.verify_label_address}
+            >
               {isUrl ? (
                 <Link
                   href={details.location}
@@ -368,9 +270,11 @@ export function EventVerificationEmail({
               )}
             </DetailRow>
           ) : null}
-          {details.schedule ? <DetailRow label="Schedule">{details.schedule}</DetailRow> : null}
+          {details.schedule ? (
+            <DetailRow label={strings.verify_label_schedule}>{details.schedule}</DetailRow>
+          ) : null}
           {details.breaks && details.breaks.length > 0 ? (
-            <DetailRow label="Scheduled breaks">
+            <DetailRow label={strings.verify_label_breaks}>
               {details.breaks.map((line, index) => (
                 <span key={index}>
                   {line}
@@ -379,29 +283,36 @@ export function EventVerificationEmail({
               ))}
             </DetailRow>
           ) : null}
-          {details.contact ? <DetailRow label="Contact">{details.contact}</DetailRow> : null}
+          {details.contact ? (
+            <DetailRow label={strings.verify_label_contact}>{details.contact}</DetailRow>
+          ) : null}
           {typeof details.recentRegistrations === 'number' ? (
-            <DetailRow label="Registrations">
-              {`${details.recentRegistrations} registration${
-                details.recentRegistrations === 1 ? '' : 's'
-              } in the last 30 days`}
+            <DetailRow label={strings.verify_label_registrations}>
+              {pluralize(
+                strings,
+                'verify_registrations_count',
+                details.recentRegistrations,
+                locale,
+              )}
             </DetailRow>
           ) : null}
-          <DetailRow label="Last verified">{details.lastVerified}</DetailRow>
+          <DetailRow label={strings.verify_label_last_verified}>
+            {details.lastVerified ?? strings.verify_never_verified}
+          </DetailRow>
         </Section>
       ) : null}
 
       <BrandButton href={ctaHref} brand={brand}>
-        {variant.cta}
+        {copy('cta')}
       </BrandButton>
       {eventUrl ? (
         <BrandButton href={eventUrl} brand={brand} variant="secondary" tight>
-          View event
+          {strings.verify_view_event_cta}
         </BrandButton>
       ) : null}
       {audience === 'region' ? null : (
         <Text style={styles.hint}>
-          {COPY.buttonHint}
+          {strings.verify_button_hint}
           <br />
           <Link href={verifyUrl} style={{ ...styles.link, color: brand.colors.primary }}>
             {verifyUrl}
@@ -409,7 +320,12 @@ export function EventVerificationEmail({
         </Text>
       )}
       <Hr style={styles.hr} />
-      <Text style={styles.footer}>{COPY.footer(audience, brand.productName)}</Text>
+      <Text style={styles.footer}>
+        {interpolate(
+          audience === 'region' ? strings.verify_footer_region : strings.verify_footer_manager,
+          { brand: brand.productName },
+        )}
+      </Text>
     </EmailLayout>
   )
 }

--- a/src/globals/SahajAtlasTranslations/translationsSchema.json
+++ b/src/globals/SahajAtlasTranslations/translationsSchema.json
@@ -377,7 +377,7 @@
     },
     "emails": {
       "type": "object",
-      "description": "Chrome for emails the CMS sends to registrants. Event data (title, address, times) is never translated — only the surrounding copy is.",
+      "description": "Chrome for the emails the CMS sends: the confirmations and reminders seekers receive in the language they registered in, and the `verify_*` event-verification reminders managers receive in their own language. Event data (title, address, times, durations) is never translated — only the surrounding copy is.",
       "properties": {
         "confirmation_subject": {
           "type": "string",
@@ -493,6 +493,314 @@
         "unsubscribe_error_message": {
           "type": "string",
           "description": "Body of the error card when unsubscribing fails."
+        },
+        "verify_greeting": {
+          "type": "string",
+          "description": "Opening line of the event-verification reminder sent to managers. `%{name}` = the manager's name (shown in bold).",
+          "maxLength": 40
+        },
+        "verify_button_hint": {
+          "type": "string",
+          "description": "Line introducing the plain-text verify URL, shown for email clients that strip buttons."
+        },
+        "verify_footer_manager": {
+          "type": "string",
+          "description": "Footer of the reminder sent to the event's own manager, explaining why they received it and warning against forwarding. `%{brand}` = product name."
+        },
+        "verify_footer_region": {
+          "type": "string",
+          "description": "Same footer, for a region manager escalated to above the event manager. `%{brand}` = product name."
+        },
+        "verify_contact_subject": {
+          "type": "string",
+          "description": "Subject of the pre-filled email a region manager's \"Contact manager\" button opens. `%{event}` = event title.",
+          "maxLength": 78
+        },
+        "verify_contact_body": {
+          "type": "string",
+          "description": "Body of that pre-filled email, asking the event manager to verify. `%{manager}` = their name, `%{event}` = event title. Line breaks are preserved."
+        },
+        "verify_manager_heading": {
+          "type": "string",
+          "description": "Section heading above the event manager's contact card (region reminders only).",
+          "maxLength": 24
+        },
+        "verify_details_heading": {
+          "type": "string",
+          "description": "Section heading above the event's summary table.",
+          "maxLength": 24
+        },
+        "verify_label_name": {
+          "type": "string",
+          "description": "Row label for the event manager's name.",
+          "maxLength": 20
+        },
+        "verify_label_event": {
+          "type": "string",
+          "description": "Row label for the event's title.",
+          "maxLength": 20
+        },
+        "verify_label_online": {
+          "type": "string",
+          "description": "Row label for an online event's joining link (replaces the address label).",
+          "maxLength": 20
+        },
+        "verify_label_address": {
+          "type": "string",
+          "description": "Row label for an in-person event's address.",
+          "maxLength": 20
+        },
+        "verify_label_schedule": {
+          "type": "string",
+          "description": "Row label for the event's schedule. The schedule itself is a formatted date/time and stays untranslated.",
+          "maxLength": 20
+        },
+        "verify_label_breaks": {
+          "type": "string",
+          "description": "Row label for the event's scheduled breaks (holiday pauses).",
+          "maxLength": 20
+        },
+        "verify_label_contact": {
+          "type": "string",
+          "description": "Row label for the event's public contact name and phone.",
+          "maxLength": 20
+        },
+        "verify_label_registrations": {
+          "type": "string",
+          "description": "Row label for how many people registered recently.",
+          "maxLength": 20
+        },
+        "verify_label_last_verified": {
+          "type": "string",
+          "description": "Row label for the date the event was last verified.",
+          "maxLength": 20
+        },
+        "verify_never_verified": {
+          "type": "string",
+          "description": "Value shown in the last-verified row when the event has never been verified.",
+          "maxLength": 20
+        },
+        "verify_view_event_cta": {
+          "type": "string",
+          "description": "Secondary button label opening the event's public page on the map.",
+          "maxLength": 20
+        },
+        "verify_registrations_count": {
+          "type": "string",
+          "plural": true,
+          "maxLength": 48,
+          "description": "Recent-registration count shown in the summary table, entered per plural form. `%{count}` = number of registrations in the last 30 days."
+        },
+        "verify_fallback_manager": {
+          "type": "string",
+          "description": "Stand-in used in place of the event manager's name when it is unknown, e.g. \"the event manager\".",
+          "maxLength": 24
+        },
+        "verify_fallback_region": {
+          "type": "string",
+          "description": "Stand-in used in place of the region's name when it is unknown, e.g. \"your region\".",
+          "maxLength": 24
+        },
+        "verify_fallback_deadline": {
+          "type": "string",
+          "description": "Stand-in used in place of the unpublish date when it is unknown, e.g. \"shortly\".",
+          "maxLength": 24
+        },
+        "verify_manager_due_subject": {
+          "type": "string",
+          "description": "Subject of the first verification reminder to the event manager. `%{event}` = event title.",
+          "maxLength": 78
+        },
+        "verify_manager_due_heading": {
+          "type": "string",
+          "description": "Heading of the first reminder to the event manager.",
+          "maxLength": 60
+        },
+        "verify_manager_due_preview": {
+          "type": "string",
+          "description": "Inbox preview snippet of the first reminder to the event manager.",
+          "maxLength": 90
+        },
+        "verify_manager_due_cta": {
+          "type": "string",
+          "description": "Verify-button label on the first reminder to the event manager.",
+          "maxLength": 24
+        },
+        "verify_manager_due_body": {
+          "type": "string",
+          "description": "Main paragraph of the first reminder: why events are checked periodically. `%{brand}` = product name."
+        },
+        "verify_manager_due_callout": {
+          "type": "string",
+          "description": "Highlighted instruction on the first reminder. `%{deadline}` = the date the event is unpublished (shown in bold)."
+        },
+        "verify_manager_escalated_subject": {
+          "type": "string",
+          "description": "Subject of the overdue reminder to the event manager. `%{event}` = event title.",
+          "maxLength": 78
+        },
+        "verify_manager_escalated_heading": {
+          "type": "string",
+          "description": "Heading of the overdue reminder to the event manager.",
+          "maxLength": 60
+        },
+        "verify_manager_escalated_preview": {
+          "type": "string",
+          "description": "Inbox preview snippet of the overdue reminder to the event manager.",
+          "maxLength": 90
+        },
+        "verify_manager_escalated_cta": {
+          "type": "string",
+          "description": "Verify-button label on the overdue reminder to the event manager.",
+          "maxLength": 24
+        },
+        "verify_manager_escalated_body": {
+          "type": "string",
+          "description": "Main paragraph of the overdue reminder to the event manager."
+        },
+        "verify_manager_escalated_callout": {
+          "type": "string",
+          "description": "Highlighted instruction on the overdue reminder. `%{deadline}` = the date the event is unpublished (shown in bold)."
+        },
+        "verify_manager_urgent_subject": {
+          "type": "string",
+          "description": "Subject of the final reminder to the event manager. `%{event}` = event title.",
+          "maxLength": 78
+        },
+        "verify_manager_urgent_heading": {
+          "type": "string",
+          "description": "Heading of the final reminder to the event manager.",
+          "maxLength": 60
+        },
+        "verify_manager_urgent_preview": {
+          "type": "string",
+          "description": "Inbox preview snippet of the final reminder to the event manager.",
+          "maxLength": 90
+        },
+        "verify_manager_urgent_cta": {
+          "type": "string",
+          "description": "Verify-button label on the final reminder to the event manager.",
+          "maxLength": 24
+        },
+        "verify_manager_urgent_body": {
+          "type": "string",
+          "description": "Main paragraph of the final reminder to the event manager."
+        },
+        "verify_manager_urgent_callout": {
+          "type": "string",
+          "description": "Highlighted instruction on the final reminder. `%{deadline}` = the date the event is unpublished (shown in bold)."
+        },
+        "verify_manager_expired_subject": {
+          "type": "string",
+          "description": "Subject of the notice telling the event manager their event was unpublished. `%{event}` = event title.",
+          "maxLength": 78
+        },
+        "verify_manager_expired_heading": {
+          "type": "string",
+          "description": "Heading of the unpublished notice to the event manager.",
+          "maxLength": 60
+        },
+        "verify_manager_expired_preview": {
+          "type": "string",
+          "description": "Inbox preview snippet of the unpublished notice to the event manager.",
+          "maxLength": 90
+        },
+        "verify_manager_expired_cta": {
+          "type": "string",
+          "description": "Verify-button label on the unpublished notice — verifying republishes the event.",
+          "maxLength": 24
+        },
+        "verify_manager_expired_body": {
+          "type": "string",
+          "description": "Main paragraph of the unpublished notice. `%{since}` = how long the event went unverified (a formatted duration, e.g. \"3 months\")."
+        },
+        "verify_manager_expired_callout": {
+          "type": "string",
+          "description": "Highlighted instruction on the unpublished notice. `%{deadline}` = the date the event was unpublished (shown in bold)."
+        },
+        "verify_region_escalated_subject": {
+          "type": "string",
+          "description": "Subject of the first escalation to a region manager. `%{event}` = event title.",
+          "maxLength": 78
+        },
+        "verify_region_escalated_heading": {
+          "type": "string",
+          "description": "Heading of the first escalation to a region manager.",
+          "maxLength": 60
+        },
+        "verify_region_escalated_preview": {
+          "type": "string",
+          "description": "Inbox preview snippet of the first escalation to a region manager.",
+          "maxLength": 90
+        },
+        "verify_region_escalated_cta": {
+          "type": "string",
+          "description": "Button label that opens a pre-filled email to the event manager.",
+          "maxLength": 24
+        },
+        "verify_region_escalated_body": {
+          "type": "string",
+          "description": "Main paragraph asking the region manager to chase the event manager. `%{region}` = region name, `%{manager}` = event manager's name (both shown in bold)."
+        },
+        "verify_region_escalated_callout": {
+          "type": "string",
+          "description": "Highlighted instruction on the first escalation. `%{deadline}` = the date the event is unpublished (shown in bold)."
+        },
+        "verify_region_urgent_subject": {
+          "type": "string",
+          "description": "Subject of the final escalation to a region manager. `%{event}` = event title.",
+          "maxLength": 78
+        },
+        "verify_region_urgent_heading": {
+          "type": "string",
+          "description": "Heading of the final escalation to a region manager.",
+          "maxLength": 60
+        },
+        "verify_region_urgent_preview": {
+          "type": "string",
+          "description": "Inbox preview snippet of the final escalation to a region manager.",
+          "maxLength": 90
+        },
+        "verify_region_urgent_cta": {
+          "type": "string",
+          "description": "Button label that opens a pre-filled email to the event manager.",
+          "maxLength": 24
+        },
+        "verify_region_urgent_body": {
+          "type": "string",
+          "description": "Main paragraph of the final escalation. `%{region}` = region name, `%{manager}` = event manager's name (both shown in bold)."
+        },
+        "verify_region_urgent_callout": {
+          "type": "string",
+          "description": "Highlighted instruction on the final escalation. `%{deadline}` = the date the event is unpublished (shown in bold)."
+        },
+        "verify_region_expired_subject": {
+          "type": "string",
+          "description": "Subject of the notice telling a region manager an event in their region was unpublished. `%{event}` = event title.",
+          "maxLength": 78
+        },
+        "verify_region_expired_heading": {
+          "type": "string",
+          "description": "Heading of the unpublished notice to a region manager.",
+          "maxLength": 60
+        },
+        "verify_region_expired_preview": {
+          "type": "string",
+          "description": "Inbox preview snippet of the unpublished notice to a region manager.",
+          "maxLength": 90
+        },
+        "verify_region_expired_cta": {
+          "type": "string",
+          "description": "Button label that opens a pre-filled email to the event manager.",
+          "maxLength": 24
+        },
+        "verify_region_expired_body": {
+          "type": "string",
+          "description": "Main paragraph of the unpublished notice to a region manager. `%{region}` = region name, `%{manager}` = event manager's name (both shown in bold), `%{since}` = how long it went unverified (a formatted duration, e.g. \"3 months\")."
+        },
+        "verify_region_expired_callout": {
+          "type": "string",
+          "description": "Highlighted instruction on the unpublished notice. `%{deadline}` = the date the event was unpublished (shown in bold)."
         }
       },
       "additionalProperties": false

--- a/src/jobs/ExpireEvents/ExpireEvents.ts
+++ b/src/jobs/ExpireEvents/ExpireEvents.ts
@@ -159,7 +159,7 @@ async function processEvent(args: {
       regionName: recipient.regionName,
     }
 
-    const delivered = await sendNotification({ client: payload, recipient, reminder })
+    const delivered = await sendNotification({ client: payload, recipient, reminder, req })
     if (!delivered) {
       allDelivered = false
       continue

--- a/src/lib/lectures/nirmalaVidya.ts
+++ b/src/lib/lectures/nirmalaVidya.ts
@@ -1,6 +1,6 @@
 import type { NirmalaVidyaVideoData } from '@/lib/lectures/nirmalaVidyaApi'
 import type { LocaleCode } from '@/lib/locales'
-import { isValidLocale } from '@/lib/locales'
+import { languageToLocale } from '@/lib/locales'
 
 // =============================================================================
 // Language Code Mapping
@@ -11,18 +11,7 @@ import { isValidLocale } from '@/lib/locales'
  * Returns null for unrecognized codes (silently skipped).
  */
 export function apiLanguageToLocale(apiCode: string): LocaleCode | null {
-  if (isValidLocale(apiCode)) return apiCode
-  // Normalize to BCP-47 shape: lowercase language subtag, uppercase region
-  // subtag (e.g. 'pt_BR' / 'pt-br' -> 'pt-BR'), so a lowercased region no
-  // longer collides with the old invalid 'pt-br' spelling.
-  const [language, region] = apiCode.replace('_', '-').split('-')
-  const normalized = region
-    ? `${language.toLowerCase()}-${region.toUpperCase()}`
-    : language.toLowerCase()
-  if (isValidLocale(normalized)) return normalized
-  // Special case: API may use 'pt' for Brazilian Portuguese
-  if (normalized === 'pt') return 'pt-BR'
-  return null
+  return languageToLocale(apiCode)
 }
 
 // =============================================================================

--- a/src/lib/locales/index.ts
+++ b/src/lib/locales/index.ts
@@ -58,6 +58,32 @@ export function isValidLocale(code: string): code is LocaleCode {
 }
 
 /**
+ * Map a language code onto a CMS locale, or `null` when the CMS isn't
+ * translated into it (the caller then falls back to `DEFAULT_LOCALE`).
+ *
+ * The bridge between the two sets this folder exposes: the ~183 ISO 639-1
+ * languages `getLanguageOptions()` offers (what a manager/client picks as their
+ * `language`, and what external APIs send) and the 19 `LOCALES` the CMS is
+ * actually translated into. Accepts the loose spellings those sources use —
+ * `pt_BR`, `pt-br` — and treats bare `pt` as Brazilian Portuguese, the only
+ * Portuguese locale configured.
+ */
+export function languageToLocale(code: string | null | undefined): LocaleCode | null {
+  if (!code) return null
+  if (isValidLocale(code)) return code
+  // Normalize to BCP-47 shape: lowercase language subtag, uppercase region
+  // subtag (e.g. 'pt_BR' / 'pt-br' -> 'pt-BR'), so a lowercased region no
+  // longer collides with the old invalid 'pt-br' spelling.
+  const [language, region] = code.replace('_', '-').split('-')
+  const normalized = region
+    ? `${language.toLowerCase()}-${region.toUpperCase()}`
+    : language.toLowerCase()
+  if (isValidLocale(normalized)) return normalized
+  if (normalized === 'pt') return 'pt-BR'
+  return null
+}
+
+/**
  * Select options for the app's configured locales.
  *
  * Distinct from `getLanguageOptions()`, which offers every ISO 639-1 language.

--- a/src/lib/notifications/channels/email.ts
+++ b/src/lib/notifications/channels/email.ts
@@ -1,44 +1,34 @@
-import type { ReminderAudience, ReminderLevel, ReminderPayload, ResolvedRecipient } from '../types'
-import type { Payload } from 'payload'
+import type { ReminderPayload, ResolvedRecipient } from '../types'
+import type { Payload, PayloadRequest } from 'payload'
 
 import { createElement } from 'react'
 
-import { EventVerificationEmail } from '@/emails/EventVerificationEmail'
+import { EventVerificationEmail, verificationSubject } from '@/emails/EventVerificationEmail'
+import { languageToLocale } from '@/lib/locales'
+import { resolveEmailStrings } from '@/lib/translations/emailStrings'
+import { stripNewlines } from '@/lib/utilities/emailSafeText'
 import { renderEmail } from '@/plugins/email'
-
-function subjectFor(level: ReminderLevel, audience: ReminderAudience, title: string): string {
-  if (audience === 'region') {
-    switch (level) {
-      case 'expired':
-        return `Unpublished — an event in your region: ${title}`
-      case 'urgent':
-        return `Final notice — an event in your region: ${title}`
-      default:
-        return `Needs verification — an event in your region: ${title}`
-    }
-  }
-  switch (level) {
-    case 'due':
-      return `Please verify your event: ${title}`
-    case 'escalated':
-      return `Action needed — verify your event: ${title}`
-    case 'urgent':
-      return `Final reminder — verify your event: ${title}`
-    case 'expired':
-      return `Your event has been unpublished: ${title}`
-  }
-}
 
 /**
  * Email channel — renders the reminder template (branded `sahaj-atlas`, via
  * #483's `renderEmail`) and sends through the configured adapter
  * (Resend in prod, Ethereal in dev).
+ *
+ * Subject and body resolve in the recipient's own language off
+ * `Managers.language`. That field offers every ISO 639-1 language, so it maps
+ * through `languageToLocale` onto a CMS locale; unset — or set to a language the
+ * CMS isn't translated into — resolves the default locale, and an individually
+ * untranslated key falls back to its English default.
  */
 export async function sendEmailReminder(
   client: Payload,
   recipient: ResolvedRecipient,
   reminder: ReminderPayload,
+  req?: PayloadRequest,
 ): Promise<void> {
+  const locale = languageToLocale(recipient.manager.language)
+  const strings = await resolveEmailStrings({ payload: client, locale, req })
+
   const html = await renderEmail(
     createElement(EventVerificationEmail, {
       name: recipient.manager.name || recipient.destination,
@@ -47,6 +37,8 @@ export async function sendEmailReminder(
       eventUrl: reminder.eventUrl,
       level: reminder.level,
       audience: reminder.audience,
+      strings,
+      locale,
       details: reminder.details,
       deadline: reminder.deadline,
       sinceLastVerified: reminder.sinceLastVerified,
@@ -57,7 +49,16 @@ export async function sendEmailReminder(
 
   await client.sendEmail({
     to: recipient.destination,
-    subject: subjectFor(reminder.level, reminder.audience, reminder.eventTitle),
+    // The event title is manager-authored free text; strip line breaks so it
+    // can't inject a second header off the Subject line.
+    subject: stripNewlines(
+      verificationSubject({
+        strings,
+        audience: reminder.audience,
+        level: reminder.level,
+        eventTitle: reminder.eventTitle,
+      }),
+    ),
     html,
   })
 }

--- a/src/lib/notifications/eventDetails.ts
+++ b/src/lib/notifications/eventDetails.ts
@@ -165,6 +165,11 @@ export function humanDurationSince(fromIso: string, now: Date): string {
  * the key facts at a glance: title, location (address one-line, or the online
  * URL), schedule, contact, scheduled breaks, and — only when there are any —
  * registrations in the last 30 days.
+ *
+ * Values only: the reminder email is localized per manager, so every label and
+ * every stand-in for a missing value ("Online", "Never") comes from the
+ * translations global instead. What's returned here is formatted event data,
+ * which is deliberately never translated.
  */
 export async function buildEventEmailDetails(args: {
   payload: Payload
@@ -200,12 +205,12 @@ export async function buildEventEmailDetails(args: {
 
   return {
     title: typeof event.title === 'string' ? event.title : `Event #${event.id}`,
-    locationLabel: isOnline ? 'Online' : 'Address',
+    isOnline,
     location: isOnline ? (event.onlineUrl ?? '') : addressOneLine(event.address ?? {}),
     schedule: scheduleOneLine(event.schedule),
     contact: contact || undefined,
     breaks: breaks.length > 0 ? breaks : undefined,
-    lastVerified: verifiedAt ? formatLongDate(verifiedAt) : 'Never',
+    lastVerified: verifiedAt ? formatLongDate(verifiedAt) : null,
     recentRegistrations,
   }
 }

--- a/src/lib/notifications/send.ts
+++ b/src/lib/notifications/send.ts
@@ -1,5 +1,5 @@
 import type { ReminderPayload, ResolvedRecipient } from './types'
-import type { Payload } from 'payload'
+import type { Payload, PayloadRequest } from 'payload'
 
 import { sendEmailReminder } from './channels/email'
 import { sendStubReminder } from './channels/stubs'
@@ -10,16 +10,20 @@ import { sendStubReminder } from './channels/stubs'
  * failed/throwing send is retried (for un-logged recipients only) on the next
  * run. Errors are caught + logged, never thrown, so one bad recipient doesn't
  * abort the batch.
+ *
+ * `req` is forwarded so the email channel's translations read joins the caller's
+ * transaction, and so its per-locale memo is shared across the whole sweep.
  */
 export async function sendNotification(args: {
   client: Payload
   recipient: ResolvedRecipient
   reminder: ReminderPayload
+  req?: PayloadRequest
 }): Promise<boolean> {
-  const { client, recipient, reminder } = args
+  const { client, recipient, reminder, req } = args
   try {
     if (recipient.channel === 'email') {
-      await sendEmailReminder(client, recipient, reminder)
+      await sendEmailReminder(client, recipient, reminder, req)
     } else {
       await sendStubReminder(client, recipient, reminder)
     }

--- a/src/lib/translations/emailStrings.ts
+++ b/src/lib/translations/emailStrings.ts
@@ -1,6 +1,8 @@
 /**
- * Server-side resolution of the registrant-email copy held in the Sahaj Atlas
- * translations global (`emails` group).
+ * Server-side resolution of the email copy held in the Sahaj Atlas translations
+ * global (`emails` group) — both the registrant-facing chrome (confirmation,
+ * reminder, unsubscribe) and the manager-facing event-verification reminder,
+ * which resolve against the recipient's own language.
  *
  * Templates receive already-resolved strings as props — a template never issues
  * a `payload.find`, so it stays pure and unit-testable.
@@ -67,6 +69,110 @@ export const EMAIL_STRING_DEFAULTS = {
   unsubscribe_error_title: 'Something went wrong',
   unsubscribe_error_message:
     'We could not process your request. Please try again in a little while.',
+
+  // ───────────────────────────────────────────────────────────────────────
+  // Event verification reminder (manager-facing, `EventVerificationEmail`).
+  //
+  // The `verify_<audience>_<level>_<slot>` matrix holds one variation's whole
+  // wording. `audience` is the recipient — the event's own `manager`, or a
+  // `region` manager escalated to above them; `level` is the escalation stage.
+  // The matrix is deliberately ragged: region managers are first looped in at
+  // `escalated`, so there is no `verify_region_due_*` family.
+  // ───────────────────────────────────────────────────────────────────────
+  verify_greeting: 'Hello %{name},',
+  verify_button_hint: 'If the button doesn’t work, copy and paste this link into your browser:',
+  verify_footer_manager:
+    'You’re receiving this because you manage this event on %{brand}. The links in this email are unique to you and act on your behalf — please don’t forward this email.',
+  verify_footer_region:
+    'You’re receiving this because you manage this region on %{brand}. The links in this email are unique to you and act on your behalf — please don’t forward this email.',
+  // The pre-filled email a region manager's "Contact manager" button opens.
+  verify_contact_subject: 'Please verify your Sahaja Yoga class: %{event}',
+  verify_contact_body:
+    'Hello %{manager},\n\nYour event “%{event}” is going to be automatically unpublished soon if we don’t check it. Could you verify it from your reminder email, or let me know if it is no longer running?\n\nThank you.',
+
+  // Summary tables — section headings and row labels.
+  verify_manager_heading: 'Event manager',
+  verify_details_heading: 'Event details',
+  verify_label_name: 'Name',
+  verify_label_event: 'Event',
+  verify_label_online: 'Online',
+  verify_label_address: 'Address',
+  verify_label_schedule: 'Schedule',
+  verify_label_breaks: 'Scheduled breaks',
+  verify_label_contact: 'Contact',
+  verify_label_registrations: 'Registrations',
+  verify_label_last_verified: 'Last verified',
+  verify_never_verified: 'Never',
+  verify_view_event_cta: 'View event',
+  // Plural family for the recent-registration count; see `pluralize()`.
+  verify_registrations_count_one: '%{count} registration in the last 30 days',
+  verify_registrations_count_few: '%{count} registrations in the last 30 days',
+  verify_registrations_count_many: '%{count} registrations in the last 30 days',
+  verify_registrations_count_other: '%{count} registrations in the last 30 days',
+
+  // Stand-ins for a value the reminder couldn't resolve.
+  verify_fallback_manager: 'the event manager',
+  verify_fallback_region: 'your region',
+  verify_fallback_deadline: 'shortly',
+
+  verify_manager_due_subject: 'Please verify your event: %{event}',
+  verify_manager_due_heading: 'Verify your Sahaja Yoga class',
+  verify_manager_due_preview: 'A quick check that your class is still running.',
+  verify_manager_due_cta: 'Verify this event',
+  verify_manager_due_body:
+    'To keep public listings accurate, %{brand} events need to be checked periodically. Events which are not verified are automatically unpublished. Please verify the details of your class below.',
+  verify_manager_due_callout: '✅ Verify by %{deadline} to keep this event published.',
+
+  verify_manager_escalated_subject: 'Action needed — verify your event: %{event}',
+  verify_manager_escalated_heading: 'Sahaja Yoga class still needs verification',
+  verify_manager_escalated_preview: 'Your event is overdue for verification.',
+  verify_manager_escalated_cta: 'Verify now',
+  verify_manager_escalated_body:
+    'This is a reminder that your event still needs verification. Please check the details below and verify now.',
+  verify_manager_escalated_callout: '⏰ Verify by %{deadline} or this event will be unpublished.',
+
+  verify_manager_urgent_subject: 'Final reminder — verify your event: %{event}',
+  verify_manager_urgent_heading: 'Final reminder: verify your Sahaja Yoga class',
+  verify_manager_urgent_preview: 'Last reminder before your class is unpublished.',
+  verify_manager_urgent_cta: 'Verify now',
+  verify_manager_urgent_body:
+    'This is the final reminder to verify your event. Please check the details below and verify it immediately.',
+  verify_manager_urgent_callout:
+    '⚠️ Final reminder — verify by %{deadline} or this event will be unpublished.',
+
+  verify_manager_expired_subject: 'Your event has been unpublished: %{event}',
+  verify_manager_expired_heading: 'Your Sahaja Yoga class has been unpublished',
+  verify_manager_expired_preview: 'Your unverified event is now hidden from the public.',
+  verify_manager_expired_cta: 'Verify to restore',
+  verify_manager_expired_body:
+    'Your event wasn’t verified in over %{since}, so it has been hidden from the public. If this event is still running, please verify the details below to immediately republish the event.',
+  verify_manager_expired_callout: '🚫 Unpublished on %{deadline}. Verify now to republish.',
+
+  verify_region_escalated_subject: 'Needs verification — an event in your region: %{event}',
+  verify_region_escalated_heading: 'Event manager not responding',
+  verify_region_escalated_preview: 'Please contact the event manager to verify their event.',
+  verify_region_escalated_cta: 'Contact manager',
+  verify_region_escalated_body:
+    'The following event in %{region} needs verification, but the event manager has not yet responded. Please reach out to %{manager} and confirm if it’s still running.',
+  verify_region_escalated_callout:
+    '⏰ Contact the manager. They must verify by %{deadline} or this event will be unpublished.',
+
+  verify_region_urgent_subject: 'Final notice — an event in your region: %{event}',
+  verify_region_urgent_heading: 'Event will soon be unpublished',
+  verify_region_urgent_preview: 'Last notice before an event in your region is unpublished.',
+  verify_region_urgent_cta: 'Contact manager',
+  verify_region_urgent_body:
+    'An event in %{region} still needs verification, and its manager hasn’t responded to earlier reminders. Please get in touch with %{manager} to check on it.',
+  verify_region_urgent_callout:
+    '⚠️ Final notice — contact the manager. They must verify by %{deadline} or this event will be unpublished.',
+
+  verify_region_expired_subject: 'Unpublished — an event in your region: %{event}',
+  verify_region_expired_heading: 'Event has been unpublished',
+  verify_region_expired_preview: 'An unverified event in your region is now hidden.',
+  verify_region_expired_cta: 'Contact manager',
+  verify_region_expired_body:
+    'An event in %{region} was unpublished after going unverified for %{since}. If it’s still running, please contact %{manager} and ask them to verify the event.',
+  verify_region_expired_callout: '🚫 Unpublished on %{deadline}. Contact the manager to republish.',
 } as const
 
 export type EmailStringKey = keyof typeof EMAIL_STRING_DEFAULTS

--- a/tests/int/translations-field.int.spec.ts
+++ b/tests/int/translations-field.int.spec.ts
@@ -13,8 +13,6 @@
 import { describe, expect, it } from 'vitest'
 
 import { buildTranslationTabs, type SchemaEntry, type TranslationsSchema } from '@/fields'
-import { PLURAL_CATEGORIES } from '@/fields/translationsField'
-import { EMAIL_STRING_DEFAULTS } from '@/lib/translations/emailStrings'
 
 describe('buildTranslationTabs', () => {
   describe('tab generation', () => {
@@ -196,18 +194,10 @@ describe('buildTranslationTabs', () => {
       expect(validate({ sessions_count: 'nope' })).toContain('Unknown key')
     })
 
-    it('EMAIL_STRING_DEFAULTS covers every plural form the field builder can store', () => {
-      // The field builder expands a plural key to every `PLURAL_CATEGORIES` form,
-      // but `resolveEmailStrings`/`withDefaults` only preserves keys present in the
-      // defaults — so an uncovered category would silently drop a translated
-      // `_few`/`_many`. Guards that the two layers stay in sync.
-      const pluralEmailKeys = ['sessions_count'] // keys declared `plural: true` in the emails group
-      for (const base of pluralEmailKeys) {
-        for (const category of PLURAL_CATEGORIES) {
-          expect(EMAIL_STRING_DEFAULTS).toHaveProperty(`${base}_${category}`)
-        }
-      }
-    })
+    // The defaults-vs-schema sync this used to spot-check (every `plural: true`
+    // key covering all `PLURAL_CATEGORIES` forms) is now asserted over the whole
+    // `emails` group, in both directions and without a hand-kept key list, by
+    // `tests/unit/email-strings.spec.ts`.
 
     it('sets localized: true and no jsonSchema (Ajv breaks on Cloudflare Workers)', () => {
       const schema: TranslationsSchema = {

--- a/tests/unit/email-strings.spec.ts
+++ b/tests/unit/email-strings.spec.ts
@@ -1,15 +1,18 @@
 /**
- * Unit tests for the registrant-email translation resolver.
+ * Unit tests for the email translation resolver.
  *
  * Covers the two fallback layers separately, since they catch different
  * failures: Payload's own locale fallback (a wholly untranslated locale) and
  * the English key defaults (a partially translated locale, an unfilled key, or
- * an empty global).
+ * an empty global). Plus the contract between those defaults and the schema
+ * that decides what a translator can fill in.
  */
 import type { Payload } from 'payload'
 
 import { describe, expect, it, vi } from 'vitest'
 
+import { PLURAL_CATEGORIES } from '@/fields/translationsField'
+import atlasSchema from '@/globals/SahajAtlasTranslations/translationsSchema.json' with { type: 'json' }
 import {
   EMAIL_STRING_DEFAULTS,
   type EmailStrings,
@@ -17,6 +20,12 @@ import {
   pluralize,
   resolveEmailStrings,
 } from '@/lib/translations/emailStrings'
+
+/** One string key as declared in `translationsSchema.json`. */
+interface EmailKeySchema {
+  type: string
+  plural?: boolean
+}
 
 /** A stub Payload whose `findGlobal` returns the given `emails` blob. */
 function stubPayload(emails: unknown, opts: { reject?: boolean } = {}) {
@@ -180,5 +189,23 @@ describe('resolveEmailStrings', () => {
     await resolveEmailStrings({ payload, locale: 'de', req })
 
     expect(payload.findGlobal).toHaveBeenCalledTimes(2)
+  })
+})
+
+describe('EMAIL_STRING_DEFAULTS ↔ translations schema', () => {
+  // The defaults and the schema are two halves of one contract: the schema
+  // decides what a translator can fill in, the defaults decide what
+  // `withDefaults` will keep. A key in only one half is silently useless —
+  // untranslatable, or translated but dropped on resolve.
+  const emails = (
+    atlasSchema as { properties: Record<string, { properties: Record<string, EmailKeySchema> }> }
+  ).properties.emails.properties
+
+  const schemaKeys = Object.entries(emails).flatMap(([key, prop]) =>
+    prop.plural ? PLURAL_CATEGORIES.map((category) => `${key}_${category}`) : [key],
+  )
+
+  it('declares exactly the keys the defaults define', () => {
+    expect(schemaKeys.slice().sort()).toEqual(Object.keys(EMAIL_STRING_DEFAULTS).sort())
   })
 })

--- a/tests/unit/event-verification-email.spec.ts
+++ b/tests/unit/event-verification-email.spec.ts
@@ -1,16 +1,24 @@
+import type { Payload } from 'payload'
+
 import { createElement } from 'react'
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
 import {
   EventVerificationEmail,
+  verificationSubject,
   type EventDetails,
   type EventManagerContact,
 } from '@/emails/EventVerificationEmail'
+import {
+  EMAIL_STRING_DEFAULTS,
+  resolveEmailStrings,
+  type EmailStrings,
+} from '@/lib/translations/emailStrings'
 import { getEmailBrand, renderEmail } from '@/plugins/email'
 
 const details: EventDetails = {
   title: 'Saturday Morning Sahaja Yoga Meditation',
-  locationLabel: 'Address',
+  isOnline: false,
   location: '12 MG Road, Pune, Maharashtra, IN 411001',
   schedule: 'Every week on Saturday at 9:26 AM',
   contact: 'Priya Deshmukh · +91 98765 43210',
@@ -27,11 +35,15 @@ const eventManager: EventManagerContact = {
   ],
 }
 
+/** English copy — what a manager with no `language` set receives. */
+const english: EmailStrings = { ...EMAIL_STRING_DEFAULTS }
+
 const baseProps = {
   name: 'Jo Manager',
   eventTitle: 'Morning Meditation',
   verifyUrl: 'https://cloud.test/events/verify?token=TKN123',
   audience: 'manager' as const,
+  strings: english,
   details,
   deadline: 'Saturday, 19 July 2026',
   sinceLastVerified: '3 months',
@@ -172,10 +184,215 @@ describe('EventVerificationEmail', () => {
         verifyUrl: 'https://cloud.test/verify',
         level: 'escalated',
         audience: 'manager',
+        strings: english,
         sinceLastVerified: '3 months',
       }),
     )
     expect(html).toContain('Sam') // renders (greeting), just without a table
     expect(html).not.toContain('registrations in the last 30 days')
+  })
+})
+
+/**
+ * Czech translations for part of the reminder — deliberately partial, which is
+ * the realistic state of a locale a translator is still working through.
+ */
+const CZECH: Record<string, string> = {
+  verify_greeting: 'Dobrý den, %{name},',
+  verify_manager_due_subject: 'Ověřte prosím svou událost: %{event}',
+  verify_manager_due_heading: 'Ověřte svou hodinu Sahaja Yogy',
+  verify_manager_due_preview: 'Rychlá kontrola, že vaše hodina stále probíhá.',
+  verify_manager_due_cta: 'Ověřit událost',
+  verify_manager_due_body:
+    'Aby byly veřejné výpisy přesné, je potřeba události na %{brand} pravidelně kontrolovat.',
+  verify_manager_due_callout: '✅ Ověřte do %{deadline}, aby událost zůstala zveřejněná.',
+  verify_details_heading: 'Údaje o události',
+  verify_label_last_verified: 'Naposledy ověřeno',
+  verify_region_escalated_body:
+    'Událost v oblasti %{region} potřebuje ověření. Kontaktujte prosím %{manager}.',
+  verify_registrations_count_one: '%{count} registrace za posledních 30 dní',
+  verify_registrations_count_few: '%{count} registrace za posledních 30 dní',
+  verify_registrations_count_many: '%{count} registrací za posledních 30 dní',
+  verify_registrations_count_other: '%{count} registrací za posledních 30 dní',
+}
+
+/** Resolve the strings a Czech-speaking manager gets, through the real resolver. */
+function czechStrings(): Promise<EmailStrings> {
+  const payload = {
+    findGlobal: vi.fn().mockResolvedValue({ emails: CZECH }),
+    logger: { debug: vi.fn(), error: vi.fn(), info: vi.fn(), warn: vi.fn() },
+  } as unknown as Payload
+  return resolveEmailStrings({ payload, locale: 'cs' })
+}
+
+describe('EventVerificationEmail — localized copy', () => {
+  it('renders the reminder in the manager’s language', async () => {
+    const html = await renderEmail(
+      createElement(EventVerificationEmail, {
+        ...baseProps,
+        level: 'due',
+        strings: await czechStrings(),
+        locale: 'cs',
+      }),
+    )
+    expect(html).toContain('Ověřte svou hodinu Sahaja Yogy') // heading
+    expect(html).toContain('Aby byly veřejné výpisy přesné') // body
+    expect(html).toContain('Ověřit událost') // CTA
+    expect(html).toContain('Údaje o události') // summary-table heading
+    expect(html).toContain('Naposledy ověřeno') // row label
+    // The English it replaced is gone, not merely appended to.
+    expect(html).not.toContain('Verify your Sahaja Yoga class')
+  })
+
+  it('falls back to the English default for a key the locale has not translated', async () => {
+    const html = await renderEmail(
+      createElement(EventVerificationEmail, {
+        ...baseProps,
+        level: 'due',
+        strings: await czechStrings(),
+        locale: 'cs',
+      }),
+    )
+    // CZECH translates neither the button hint nor the footer — English, not
+    // blank and not a raw key.
+    expect(html).toContain('copy and paste this link into your browser')
+    expect(html).toContain('please don’t forward this email')
+    expect(html).not.toContain('verify_button_hint')
+  })
+
+  it('interpolates values into the translated sentence rather than around it', async () => {
+    const html = await renderEmail(
+      createElement(EventVerificationEmail, {
+        ...baseProps,
+        level: 'due',
+        strings: await czechStrings(),
+        locale: 'cs',
+      }),
+    )
+    // `%{deadline}` sits mid-sentence in Czech and keeps its bold styling.
+    expect(html).toContain('✅ Ověřte do ')
+    expect(html).toContain('<strong>Saturday, 19 July 2026</strong>')
+    expect(html).toContain(', aby událost zůstala zveřejněná.')
+    expect(html).toContain('Dobrý den, ')
+    expect(html).toContain('<strong>Jo Manager</strong>')
+  })
+
+  it('localizes the region variation, naming region and manager in place', async () => {
+    const html = await renderEmail(
+      createElement(EventVerificationEmail, {
+        ...baseProps,
+        audience: 'region',
+        level: 'escalated',
+        name: 'Rohan Patil',
+        regionName: 'Maharashtra',
+        eventManager,
+        strings: await czechStrings(),
+        locale: 'cs',
+      }),
+    )
+    expect(html).toContain('Událost v oblasti ')
+    expect(html).toContain('<strong>Maharashtra</strong>')
+    expect(html).toContain('. Kontaktujte prosím ')
+    expect(html).toContain('<strong>Priya Deshmukh</strong>')
+  })
+
+  it('selects the locale’s plural form for the registration count', async () => {
+    const strings = await czechStrings()
+    const render = (recentRegistrations: number) =>
+      renderEmail(
+        createElement(EventVerificationEmail, {
+          ...baseProps,
+          level: 'due',
+          strings,
+          locale: 'cs',
+          details: { ...details, recentRegistrations },
+        }),
+      )
+
+    // Czech: 4 → few, 8 → other. English would spell both the same way.
+    expect(await render(4)).toContain('4 registrace za posledních 30 dní')
+    expect(await render(8)).toContain('8 registrací za posledních 30 dní')
+  })
+
+  it.each([
+    ['manager', 'due'],
+    ['manager', 'escalated'],
+    ['manager', 'urgent'],
+    ['manager', 'expired'],
+    ['region', 'escalated'],
+    ['region', 'urgent'],
+    ['region', 'expired'],
+  ] as const)('leaves no %s/%s placeholder unsubstituted', async (audience, level) => {
+    const html = await renderEmail(
+      createElement(EventVerificationEmail, {
+        ...baseProps,
+        audience,
+        level,
+        regionName: 'Maharashtra',
+        eventManager,
+      }),
+    )
+    expect(html).not.toContain('%{')
+  })
+
+  it('shows the localized stand-in when the event has never been verified', async () => {
+    const html = await renderEmail(
+      createElement(EventVerificationEmail, {
+        ...baseProps,
+        level: 'due',
+        details: { ...details, lastVerified: null },
+      }),
+    )
+    expect(html).toContain('Never')
+  })
+
+  it('labels an online event’s location differently from an address', async () => {
+    const online = await renderEmail(
+      createElement(EventVerificationEmail, {
+        ...baseProps,
+        level: 'due',
+        details: { ...details, isOnline: true, location: 'https://meet.test/room' },
+      }),
+    )
+    expect(online).toContain('Online')
+    expect(online).toContain('https://meet.test/room')
+  })
+})
+
+describe('verificationSubject', () => {
+  it.each([
+    ['manager', 'due', 'Please verify your event: Morning Meditation'],
+    ['manager', 'escalated', 'Action needed — verify your event: Morning Meditation'],
+    ['manager', 'urgent', 'Final reminder — verify your event: Morning Meditation'],
+    ['manager', 'expired', 'Your event has been unpublished: Morning Meditation'],
+    ['region', 'escalated', 'Needs verification — an event in your region: Morning Meditation'],
+    ['region', 'urgent', 'Final notice — an event in your region: Morning Meditation'],
+    ['region', 'expired', 'Unpublished — an event in your region: Morning Meditation'],
+  ] as const)('names the event in the %s/%s subject', (audience, level, expected) => {
+    expect(
+      verificationSubject({ strings: english, audience, level, eventTitle: 'Morning Meditation' }),
+    ).toBe(expected)
+  })
+
+  it('resolves the subject in the manager’s language', async () => {
+    expect(
+      verificationSubject({
+        strings: await czechStrings(),
+        audience: 'manager',
+        level: 'due',
+        eventTitle: 'Ranní meditace',
+      }),
+    ).toBe('Ověřte prosím svou událost: Ranní meditace')
+  })
+
+  it('throws for the unsupported region "due" reminder, like the render does', () => {
+    expect(() =>
+      verificationSubject({
+        strings: english,
+        audience: 'region',
+        level: 'due',
+        eventTitle: 'Morning Meditation',
+      }),
+    ).toThrow(/not supported for region/)
   })
 })

--- a/tests/unit/locales.spec.ts
+++ b/tests/unit/locales.spec.ts
@@ -7,7 +7,7 @@
 
 import { describe, it, expect } from 'vitest'
 
-import { buildPayloadLocales } from '../../src/lib/locales'
+import { buildPayloadLocales, languageToLocale } from '../../src/lib/locales'
 
 // Build locales once for all tests
 const allLocales = buildPayloadLocales()
@@ -80,5 +80,32 @@ describe('Locale Configuration (buildPayloadLocales)', () => {
 
     const dutchLocale = allLocales.find((l) => l.code === 'nl')
     expect(dutchLocale?.label).toBe('Dutch')
+  })
+})
+
+describe('languageToLocale', () => {
+  it('passes through a code that is already a CMS locale', () => {
+    expect(languageToLocale('en')).toBe('en')
+    expect(languageToLocale('cs')).toBe('cs')
+    expect(languageToLocale('pt-BR')).toBe('pt-BR')
+  })
+
+  it('normalizes the loose spellings language fields and APIs use', () => {
+    expect(languageToLocale('pt_BR')).toBe('pt-BR')
+    expect(languageToLocale('pt-br')).toBe('pt-BR')
+    expect(languageToLocale('EN_au')).toBe('en-AU')
+  })
+
+  it('treats bare Portuguese as Brazilian Portuguese, the only one configured', () => {
+    expect(languageToLocale('pt')).toBe('pt-BR')
+  })
+
+  it('returns null for an unset language or one the CMS has no locale for', () => {
+    // A manager picks from every ISO 639-1 language, most of which the CMS
+    // isn't translated into; the caller falls back to the default locale.
+    expect(languageToLocale('sw')).toBeNull()
+    expect(languageToLocale('')).toBeNull()
+    expect(languageToLocale(null)).toBeNull()
+    expect(languageToLocale(undefined)).toBeNull()
   })
 })


### PR DESCRIPTION
## Summary

- Event managers now get their verification reminders in their own language, not English — the copy resolves off `Managers.language` the way registrant mail already resolves off the registration's locale.
- Every variation is covered: both audiences × every escalation level, the subject line, the summary-table labels, and the "Contact manager" mailto.
- A manager with no language set, a language the CMS isn't translated into, or a half-finished translation still gets readable English — per key, never a blank or a raw key.

## Changes

- `src/globals/SahajAtlasTranslations/translationsSchema.json` — 66 new keys in the `emails` group (visible + editable per locale on the Emails tab), keyed `verify_<audience>_<level>_<slot>`. The matrix is deliberately ragged: region managers are escalated to, so there is no `verify_region_due_*`.
- `src/lib/translations/emailStrings.ts` — the same keys as English defaults, so the existing per-key merge in `resolveEmailStrings` covers manager mail too. No new resolver.
- `src/emails/EventVerificationEmail.tsx` — `COPY` deleted; takes pre-resolved `strings` + `locale` props like its registrant siblings. Values are interpolated as **ReactNodes** (`%{deadline}`, `%{region}`, `%{manager}`), so a translator can move them wherever their language puts them and they keep their bold styling. Exports `verificationSubject`.
- `src/lib/notifications/channels/email.ts` — `subjectFor()` gone; resolves the recipient's locale + strings, then renders. Subject now also goes through `stripNewlines`, like the registrant sends (a manager-authored title reaches a header here).
- `src/lib/locales/index.ts` — `languageToLocale()`, generalized out of `apiLanguageToLocale`, which delegates to it. `Managers.language` offers all ~183 ISO 639-1 languages, not the 19 CMS locales, so the two sets need bridging (`pt` → `pt-BR`, `pt_BR`/`pt-br` normalized).
- `src/lib/notifications/eventDetails.ts` — returns `isOnline: boolean` and `lastVerified: string | null` instead of the English `'Online'`/`'Address'`/`'Never'` chrome, which the email now localizes; the (English) verify page supplies its own labels.
- `src/lib/notifications/send.ts`, `src/jobs/ExpireEvents/ExpireEvents.ts` — `req` threaded to the send, so the translations read joins the sweep's transaction and its per-locale memo is shared across the whole run (N recipients in M languages = M reads, not N).
- `scripts/preview-event-emails.ts` — now drives the real `sendEmailReminder` path instead of re-rendering the template itself, so the preview shows the actual localized subject, and adds a partly-translated Czech combo.

## Test Results

- Unit: 1006 passed (85 files) — including 46 in `event-verification-email.spec.ts`
- Integration (targeted): 44 passed — `translations-field`, `expire-events`, `event-verification`
- Lint: ✓ no errors · Typecheck (`src` + `tests`): ✓ clean
- Preview script run end-to-end against Ethereal: all 7 English combos + the Czech one render and send

No migration: string keys pack into the existing `emails` JSON blob, so there is no schema change.

## Manual verification

1. `/admin` → Globals → Sahaj Atlas Translations → **Emails** tab: the `verify_*` rows appear with translator descriptions and per-key length hints, and are editable per locale.
2. `pnpm tsx scripts/preview-event-emails.ts` — the last preview link is a Czech `due` reminder; its translated slots are Czech and everything untranslated is English.

## Notes for reviewer

- **English output is unchanged**, deliberately — the defaults are the previous hardcoded copy verbatim, with one grammar fix: "the links… are unique to you and **act** on your behalf" (was "acts").
- **What is not translated**, and why: the formatted event data — schedule phrase, dates, and `sinceLastVerified` ("3 months") — still arrives in English from `buildEventEmailDetails`. That matches the `emails` group's own contract ("event data is never translated") and is the same boundary the registrant emails draw. Localizing those means per-locale date/duration formatting; worth its own ticket if we want it.
- `variantKey()` narrows the audience × level union to a template-literal key type, so a key missing from `EMAIL_STRING_DEFAULTS` is a **compile** error rather than a blank line in a sent email. A `/simplify` pass suggested collapsing it into one function with an `as` cast — rejected, that is exactly the guarantee it would trade away.
- The unit lane now asserts the schema ↔ defaults contract whole and in both directions, which subsumes (and replaces) the hand-kept plural-key list that was in `translations-field.int.spec.ts`. Mutation-checked: adding a stray default fails it.
- `region` + `due` has no copy and throws, as it did before — reachable from neither the job (region enters at `escalated`) nor the subject helper.

Closes #610

🤖 Generated with [Claude Code](https://claude.com/claude-code)
