### PR TITLE
fix(seeds): let the shell environment win over .env files

### DIFF
--- a/scripts/backfill-schedule-last-date.ts
+++ b/scripts/backfill-schedule-last-date.ts
@@ -62,8 +62,8 @@ function parseArgs(argv: string[]): Args {
  * and the config has to be pulled in dynamically.
  */
 async function loadPayload(): Promise<Payload> {
-  dotenv.config({ path: '.env' })
-  dotenv.config({ path: '.env.local', override: true })
+  // Shell env wins, then .env.local, then .env (see seeds/env.ts).
+  dotenv.config({ path: ['.env.local', '.env'] })
   const { default: configPromise } = await import('../src/payload.config')
   return getPayload({ config: await configPromise })
 }

--- a/scripts/preview-event-emails.ts
+++ b/scripts/preview-event-emails.ts
@@ -20,8 +20,8 @@ import type { Event } from '@/payload-types'
 
 import dotenv from 'dotenv'
 
-dotenv.config({ path: '.env' })
-dotenv.config({ path: '.env.local', override: true })
+// Shell env wins, then .env.local, then .env (see seeds/env.ts).
+dotenv.config({ path: ['.env.local', '.env'] })
 
 const DAY_MS = 24 * 60 * 60 * 1000
 const iso = (offsetDays: number) => new Date(Date.now() + offsetDays * DAY_MS).toISOString()

--- a/scripts/preview-registration-emails.ts
+++ b/scripts/preview-registration-emails.ts
@@ -37,8 +37,8 @@ import dotenv from 'dotenv'
 
 import { isValidLocale } from '@/lib/locales'
 
-dotenv.config({ path: '.env' })
-dotenv.config({ path: '.env.local', override: true })
+// Shell env wins, then .env.local, then .env (see seeds/env.ts).
+dotenv.config({ path: ['.env.local', '.env'] })
 
 // Absolute icon URLs must resolve for the reviewer's mail client, so default to
 // production rather than a localhost the Ethereal viewer can't reach.

--- a/scripts/preview-registration-notification-emails.ts
+++ b/scripts/preview-registration-notification-emails.ts
@@ -23,8 +23,8 @@ import type { Event } from '@/payload-types'
 
 import dotenv from 'dotenv'
 
-dotenv.config({ path: '.env' })
-dotenv.config({ path: '.env.local', override: true })
+// Shell env wins, then .env.local, then .env (see seeds/env.ts).
+dotenv.config({ path: ['.env.local', '.env'] })
 
 // Absolute icon + admin-link URLs must resolve for the reviewer, so default to
 // production rather than a localhost the Ethereal viewer can't reach.

--- a/scripts/preview-reminder-digest-emails.ts
+++ b/scripts/preview-reminder-digest-emails.ts
@@ -27,8 +27,8 @@ import type { Event } from '@/payload-types'
 import { Temporal } from '@js-temporal/polyfill'
 import dotenv from 'dotenv'
 
-dotenv.config({ path: '.env' })
-dotenv.config({ path: '.env.local', override: true })
+// Shell env wins, then .env.local, then .env (see seeds/env.ts).
+dotenv.config({ path: ['.env.local', '.env'] })
 
 process.env.SAHAJCLOUD_URL ||= 'https://cloud.sydevelopers.com'
 

--- a/seeds/AGENTS.md
+++ b/seeds/AGENTS.md
@@ -26,8 +26,11 @@ SAHAJCLOUD_URL=https://cloud.sydevelopers.com pnpm seed <script>
 **Environment variables**:
 
 - `SAHAJCLOUD_URL` - Target URL (default: `http://localhost:PORT`)
-- `ADMIN_EMAIL` / `ADMIN_PASSWORD` - **only needed for a remote target** (loaded
-  from `.env.local` by `seeds/env.ts`)
+- `ADMIN_EMAIL` / `ADMIN_PASSWORD` - **only needed for a remote target**.
+  `seeds/env.ts` resolves them the way Next.js does: a value exported in the
+  shell (or prefixed onto the command) wins, then `.env.local`, then `.env` — so
+  the blank `ADMIN_PASSWORD=` that local dev keeps in `.env.local` never
+  clobbers a credential you pass for a production run.
 
 **Seeding localhost needs no credentials.** Local dev enables Payload's
 `admin.autoLogin` (`src/payload.config.ts`), which Payload applies in its JWT

--- a/seeds/env.ts
+++ b/seeds/env.ts
@@ -9,9 +9,12 @@ import { z } from 'zod'
 
 // Load env files BEFORE parsing process.env
 // This must happen at module load time, before the IIFE below runs
-// Following Next.js convention: .env.local takes precedence over .env
-dotenv.config({ path: '.env' })
-dotenv.config({ path: '.env.local', override: true })
+// Next.js precedence: the real shell environment wins, then .env.local, then
+// .env. dotenv walks the array in order and never overwrites a key that is
+// already set, so listing .env.local first gives all three rules at once.
+// Do NOT reintroduce `override: true` — it lets a blank `FOO=` in a file clobber
+// a credential passed on the command line (see tests/unit/env-file-precedence).
+dotenv.config({ path: ['.env.local', '.env'] })
 
 /**
  * Make a var optional *and* tolerate an empty value.

--- a/seeds/lib/BaseImporter.ts
+++ b/seeds/lib/BaseImporter.ts
@@ -14,10 +14,9 @@ import * as path from 'path'
 import dotenv from 'dotenv'
 import { getPayload, Payload, CollectionSlug, Where, TypedLocale } from 'payload'
 
-// Load env files in order (later files override earlier)
-// Following Next.js convention: .env.local takes precedence over .env
-dotenv.config({ path: '.env' })
-dotenv.config({ path: '.env.local', override: true })
+// Next.js precedence: the real shell environment wins, then .env.local, then
+// .env. dotenv walks the array in order and never overwrites an already-set key.
+dotenv.config({ path: ['.env.local', '.env'] })
 
 import { parseArgs, CLIArgs } from './cliParser'
 import { isRetryableError } from './delays'

--- a/tests/unit/env-file-precedence.spec.ts
+++ b/tests/unit/env-file-precedence.spec.ts
@@ -1,0 +1,127 @@
+import { mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+
+import dotenv from 'dotenv'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+
+/**
+ * Guards how the CLI-side entry points load `.env` files.
+ *
+ * Seeding a remote target takes its admin credentials from the shell:
+ *
+ *   ADMIN_EMAIL=… ADMIN_PASSWORD=… pnpm seed:prod atlas
+ *
+ * That only works while the loaders leave an already-set variable alone. The
+ * original pair — `dotenv.config({ path: '.env' })` followed by
+ * `dotenv.config({ path: '.env.local', override: true })` — did not: the blank
+ * `ADMIN_PASSWORD=` that local dev keeps in `.env.local` overwrote the value
+ * passed on the command line, and `seeds/env.ts` then rejected it as missing.
+ *
+ * Two assertions below, because either one alone can pass vacuously: the first
+ * pins dotenv's own precedence semantics (an upgrade could change them), the
+ * second pins that every call site actually asks for those semantics.
+ */
+
+const REPO_ROOT = path.resolve(__dirname, '../..')
+
+describe('env-file precedence', () => {
+  let fixtureDir: string
+  let envPath: string
+  let envLocalPath: string
+
+  beforeAll(() => {
+    fixtureDir = mkdtempSync(path.join(tmpdir(), 'env-precedence-'))
+    envPath = path.join(fixtureDir, '.env')
+    envLocalPath = path.join(fixtureDir, '.env.local')
+
+    // `BLANK_IN_LOCAL` reproduces the ADMIN_PASSWORD shape exactly: a real value
+    // in the shell, an empty assignment in .env.local.
+    writeFileSync(envPath, 'SHARED=from_env\nONLY_IN_ENV=env_value\n')
+    writeFileSync(
+      envLocalPath,
+      'SHARED=from_env_local\nONLY_IN_LOCAL=local_value\nBLANK_IN_LOCAL=\n',
+    )
+  })
+
+  afterAll(() => {
+    rmSync(fixtureDir, { recursive: true, force: true })
+  })
+
+  /** Load the fixtures the way the source does, into a throwaway env object. */
+  function load(shellEnv: Record<string, string>): Record<string, string> {
+    const processEnv = { ...shellEnv }
+    dotenv.config({ path: [envLocalPath, envPath], processEnv })
+    return processEnv
+  }
+
+  it('lets the shell win over both files', () => {
+    const env = load({ SHARED: 'from_shell', BLANK_IN_LOCAL: 'prod-password' })
+
+    expect(env.SHARED).toBe('from_shell')
+    // The regression: a blank assignment in .env.local must not erase this.
+    expect(env.BLANK_IN_LOCAL).toBe('prod-password')
+  })
+
+  it('lets .env.local win over .env when the shell is silent', () => {
+    const env = load({})
+
+    expect(env.SHARED).toBe('from_env_local')
+    expect(env.BLANK_IN_LOCAL).toBe('')
+  })
+
+  it('still loads keys that only .env defines', () => {
+    const env = load({})
+
+    expect(env.ONLY_IN_ENV).toBe('env_value')
+    expect(env.ONLY_IN_LOCAL).toBe('local_value')
+  })
+
+  it('has no call site that overrides an already-set variable', () => {
+    const callSites = findDotenvCallSites()
+
+    // Sanity: the scan itself must not silently find nothing.
+    expect(callSites.length).toBeGreaterThanOrEqual(7)
+
+    for (const { file, line } of callSites) {
+      expect(line, `${file} must not pass override: true`).not.toContain('override')
+      expect(line, `${file} must load .env.local ahead of .env`).toContain(
+        "path: ['.env.local', '.env']",
+      )
+    }
+  })
+})
+
+/** Every `dotenv.config(...)` line under the CLI-side directories. */
+function findDotenvCallSites(): { file: string; line: string }[] {
+  const results: { file: string; line: string }[] = []
+
+  for (const dir of ['seeds', 'scripts', 'src']) {
+    for (const file of walkTypeScript(path.join(REPO_ROOT, dir))) {
+      for (const line of readFileSync(file, 'utf-8').split('\n')) {
+        if (line.includes('dotenv.config(')) {
+          results.push({ file: path.relative(REPO_ROOT, file), line })
+        }
+      }
+    }
+  }
+
+  return results
+}
+
+function walkTypeScript(dir: string): string[] {
+  const files: string[] = []
+
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    if (entry.name === 'node_modules' || entry.name === 'cache') continue
+
+    const full = path.join(dir, entry.name)
+    if (entry.isDirectory()) {
+      files.push(...walkTypeScript(full))
+    } else if (entry.name.endsWith('.ts')) {
+      files.push(full)
+    }
+  }
+
+  return files
+}


### PR DESCRIPTION
## Problem

Seeding a remote target the way [seeds/AGENTS.md](seeds/AGENTS.md) documents it fails:

```
$ ADMIN_EMAIL=… ADMIN_PASSWORD=… pnpm seed:prod atlas --dry-run
❌ Error: Missing authentication credentials.
Set ADMIN_EMAIL and ADMIN_PASSWORD environment variables.
```

The credentials **were** set. `seeds/env.ts` loaded env files like this:

```ts
dotenv.config({ path: '.env' })
dotenv.config({ path: '.env.local', override: true })
```

`override: true` replaces variables that are already present in the real environment. Local dev keeps a blank `ADMIN_PASSWORD=` in `.env.local` (correctly — auto-login means localhost needs no credentials), so that empty string overwrote the value passed on the command line, and `emptyAsUndefined` then reported it as unset.

The file could never lose to the shell, which inverts Next.js precedence and made the documented production-seeding path unusable as written.

## Fix

dotenv walks a `path` array in order and, without `override`, never replaces an already-set key — so one call expresses all three rules:

```ts
dotenv.config({ path: ['.env.local', '.env'] })
```

Shell > `.env.local` > `.env`. Applied to all **seven** call sites: the two seed entry points (`seeds/env.ts`, `seeds/lib/BaseImporter.ts`) and the five operator scripts, which all carried the same copy-pasted pair. The same trap applied to `STORYBLOK_ACCESS_TOKEN` and the R2 keys.

## Verification

`tests/unit/env-file-precedence.spec.ts` pins two things, because either alone can pass vacuously:

1. **dotenv's precedence semantics** against fixture `.env` / `.env.local` files — including the exact regression shape (a real shell value vs. a blank assignment in `.env.local`).
2. **Every call site** actually asks for those semantics — no `override`, `.env.local` listed first.

Both dimensions were mutation-checked — the spec fails when the bug is reintroduced, rather than passing regardless:

| Mutation | Result |
| --- | --- |
| `override: true` restored in `seeds/env.ts` | ✗ `has no call site that overrides an already-set variable` |
| `override: true` added to the loader under test | ✗ `lets the shell win…`, ✗ `lets .env.local win over .env…` |
| Neither (as committed) | 4 passed |

Also verified live against a real `.env.local` containing the blank `ADMIN_PASSWORD=`:

- Shell-provided credentials now survive (`matches shell value = true`) — the originally failing command.
- Local dev is unchanged: `ADMIN_PASSWORD` still resolves to `undefined`, so the CLI still takes the auto-login path.
- `.env`-only keys still load (`STORYBLOK_ACCESS_TOKEN`), confirming dropping the second `config()` call lost nothing.

Tier 2 gate green locally: lint, `typecheck`, `typecheck:tests`, and the unit lane (995 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)