### PR TITLE
refactor(fields): adopt jsonSchema for structured json fields

### DIFF
--- a/.claude/docs/architecture.md
+++ b/.claude/docs/architecture.md
@@ -318,7 +318,7 @@ Registrants who unsubscribe do so via the logged-out, token-gated page at
 | --- | --- |
 | `src/jobs/RegistrationNotifications/SendSessionReminders.ts` | Reminder task |
 | `src/jobs/RegistrationNotifications/SendRegistrationDigests.ts` | Digest task |
-| `src/jobs/RegistrationNotifications/reminderLedger.ts` | Per-registration dedup ledger |
+| `src/lib/registrations/reminderLog.ts` | Per-registration dedup ledger + the field's `jsonSchema` (shared with the Registrations collection) |
 | `tests/int/session-reminders.int.spec.ts` / `registration-digests.int.spec.ts` | Integration tests |
 
 ### Usage tracking (`src/plugins/usage/tasks.ts`)

--- a/.claude/rules/collections.md
+++ b/.claude/rules/collections.md
@@ -140,6 +140,13 @@ Four things that bite:
 - **Empty values skip validation entirely** — `undefined`, `null`, `[]`, and
   `{}` are all "no value" to Payload's json validator, so an optional field
   needs no special-casing (and a bare `[]` slips past an `type: 'object'` schema).
+- **`additionalProperties: false` is a claim about the rows already in the
+  database.** Validation runs on every write of the field, so a key that only
+  legacy data carries doesn't fail once — it 400s every later save of an
+  otherwise untouched document. Check each existing writer (and any legacy
+  import) before tightening. `Videos`/`Lessons` subtitles derive from a
+  **loose** cue for exactly this reason; the generated type gains
+  `[k: string]: unknown`, which is the honest shape.
 - **Target draft-07.** Ajv's default export is a draft-07 instance. Deriving
   from Zod: `z.toJSONSchema(schema, { target: 'draft-7' })` (Zod 4, built in —
   no `zod-to-json-schema` needed).

--- a/.claude/rules/collections.md
+++ b/.claude/rules/collections.md
@@ -102,6 +102,74 @@ Returning `true` for null in your custom validator silently overrides
 When `admin.condition` is false, PayloadCMS skips both `required` and
 your custom `validate` entirely. When it's true, it runs both normally.
 
+## `type: 'json'` fields — reach for `jsonSchema`
+
+A `json` field with no `jsonSchema` is typed `unknown` in `payload-types.ts`
+and validated by nothing. Setting one buys **both** at once: Payload feeds
+`jsonSchema.schema` to Ajv on write (a `ValidationError` → 400) *and* to the
+TypeScript generator. So the default for any json field with a known structure
+is a `jsonSchema` **derived from that structure's source of truth** — never
+hand-copied, or it drifts.
+
+```typescript
+{
+  name: 'questions',
+  type: 'json',
+  jsonSchema: {
+    uri: SCHEMA_URI,          // must be unique per schema; also identifies it
+    fileMatch: [SCHEMA_URI],  // to the admin's JSON editor
+    schema: derivedFromTheSourceOfTruth,
+  },
+}
+```
+
+Four things that bite:
+
+- **A custom `validate` replaces the built-in json validation**, so it silently
+  disables `jsonSchema` (`payload/dist/fields/config/sanitize.js` only installs
+  the default when `validate` is `undefined`). To keep a rule JSON Schema can't
+  express, delegate first — the field is spread into the validate options, so
+  `jsonSchema` arrives for free:
+  ```typescript
+  validate: (value, options) => {
+    const schemaResult = validations.json(value, options)   // from 'payload'
+    if (schemaResult !== true) return schemaResult
+    return myCrossFieldRule(value)
+  }
+  ```
+- **Empty values skip validation entirely** — `undefined`, `null`, `[]`, and
+  `{}` are all "no value" to Payload's json validator, so an optional field
+  needs no special-casing (and a bare `[]` slips past an `type: 'object'` schema).
+- **Target draft-07.** Ajv's default export is a draft-07 instance. Deriving
+  from Zod: `z.toJSONSchema(schema, { target: 'draft-7' })` (Zod 4, built in —
+  no `zod-to-json-schema` needed).
+- **`typescriptSchema` is redundant** once `jsonSchema` is set, and wins over it
+  for type generation. Use one or the other, not both.
+
+### Audit (#597)
+
+Every `type: 'json'` field, and why it does or doesn't carry a schema:
+
+| Field(s) | Schema derived from |
+|---|---|
+| translations leaf groups (`translationsField.ts`, all 3 globals) | the group's own `properties` |
+| `Registrations.questions` | `EVENT_REGISTRATION_QUESTIONS` (#595) |
+| `Registrations.reminderLog` | `ReminderLogEntry` (`lib/registrations/reminderLog.ts`) |
+| `Managers.notificationPreferences` | `NOTIFICATION_TYPES` |
+| `Videos.subtitles`, `Lessons.introSubtitles`, `Lessons.panels.*.subtitles` | `subtitlesZodSchema` via `z.toJSONSchema` |
+| `Events.notificationLog` | the entry builders + `VERIFICATION_STAGES` |
+| `Meditations.subtleSystemNodeWeights` | `Record<slug, seconds>` |
+
+| Field(s) | Deliberately no schema |
+|---|---|
+| `legacyFields.legacyData`, `Clients.legacyConfig`, `TextBoxBlock.importData` | verbatim legacy import blobs — no structure to pin |
+| `SyncLectureMetadata` / `CleanupOrphanedMedia` task fields | internal job state, never read as a typed API surface |
+| `Images/Songs/Videos/Frames.fileMetadata` | probe output; keys vary by source format and adapter |
+| `Lectures.metadata` | third-party Nirmala Vidya payload — not ours to pin |
+| `Meditations.frames` | a `beforeChange` hook normalises and repairs input; a strict schema would 400 what it's designed to fix |
+| `TableOfContentsBlock.headings` | written only by its own admin component from Lexical editor state, and richText block fields don't surface in `payload-types.ts` |
+| virtual/computed reads — `Events.qualityReport`, `Clients.usage.abuseScore`, `AppCards.viewSchedule`, `scheduleFields.upcomingDates`, `virtualReadinessField`, the Meditations virtual joins | computed in `afterRead`, so a schema buys nothing on write but would still validate one if a client sent the field |
+
 ## `defaultPopulate`
 
 `defaultPopulate` controls what's included **only when a doc is loaded

--- a/.claude/rules/project-structure.md
+++ b/.claude/rules/project-structure.md
@@ -73,8 +73,10 @@ No loose files at the root — every file lives in a named folder:
   `branding/`, `status/`, `lectures/`, `schedule/`, `subtleSystem/`,
   `pageTags/`, `cascadeDeletion/`, `registrations/` (the
   `EVENT_REGISTRATION_QUESTIONS` contract + `questions` validation/shaping,
-  shared by Events, Registrations, and the notification email; plus the
-  `unsubscribeToken` / `unsubscribeUrl` helpers for the reminder unsubscribe link)
+  shared by Events, Registrations, and the notification email; the
+  `unsubscribeToken` / `unsubscribeUrl` helpers for the reminder unsubscribe
+  link; and `reminderLog` — the session-reminder dedup ledger, read and appended
+  by the reminder job, typed onto the column by the Registrations collection)
 
 **Barrels.** A folder gets an `index.ts` barrel when it presents one cohesive
 public surface imported as a unit (`@/lib/locales`, `@/lib/status`,

--- a/src/collections/Events/Events.ts
+++ b/src/collections/Events/Events.ts
@@ -23,6 +23,7 @@ import {
 import { getRegionWebPaths } from '@/lib/atlas/regionWebPaths'
 import { revalidateAtlasSidebarHook } from '@/lib/atlasSidebar/cache'
 import { serverEnv } from '@/lib/env/server'
+import { notificationLogJsonSchema } from '@/lib/eventVerification/log'
 import { DEFAULT_VERIFICATION_STAGE } from '@/lib/eventVerification/stages'
 import { getLanguageOptions } from '@/lib/locales'
 import { EVENT_REGISTRATION_QUESTIONS } from '@/lib/registrations/questions'
@@ -482,6 +483,7 @@ export const Events: CollectionConfig = {
               // stage). Read-only, rendered by NotificationLogTable.
               name: 'notificationLog',
               type: 'json',
+              jsonSchema: notificationLogJsonSchema,
               admin: {
                 readOnly: true,
                 description:

--- a/src/collections/Lessons/Lessons.ts
+++ b/src/collections/Lessons/Lessons.ts
@@ -4,7 +4,7 @@ import { mediaField } from '@/fields'
 import { fullRichTextEditor } from '@/lib/richEditor'
 import { QuoteBlock } from '@/lib/richEditor/blocks'
 import { removeDanglingLexicalReferencesAfterRead } from '@/lib/richEditor/lexicalHooks'
-import { subtitlesJsonSchema, validateSubtitles } from '@/lib/utilities/subtitles'
+import { subtitlesJsonSchema } from '@/lib/utilities/subtitles'
 
 export const Lessons: CollectionConfig = {
   slug: 'lessons',
@@ -79,8 +79,7 @@ export const Lessons: CollectionConfig = {
                     description:
                       'Subtitles for video media: [{ startTimeMs, endTimeMs, durationMs?, content }].',
                   },
-                  validate: validateSubtitles,
-                  typescriptSchema: [() => subtitlesJsonSchema],
+                  jsonSchema: subtitlesJsonSchema,
                 },
               ],
             },
@@ -138,8 +137,7 @@ export const Lessons: CollectionConfig = {
                 description:
                   'Subtitles for intro audio: [{ startTimeMs, endTimeMs, durationMs?, content }].',
               },
-              validate: validateSubtitles,
-              typescriptSchema: [() => subtitlesJsonSchema],
+              jsonSchema: subtitlesJsonSchema,
             },
           ],
         },

--- a/src/collections/Managers/Managers.ts
+++ b/src/collections/Managers/Managers.ts
@@ -1,9 +1,11 @@
 import type { CollectionConfig } from 'payload'
 
+import { validations } from 'payload'
 import { createElement } from 'react'
 
 import {
   buildDefaultNotificationPreferences,
+  buildNotificationPreferencesJsonSchema,
   NOTIFICATION_TYPES,
   validateNotificationPreferences,
 } from '@/components/admin/NotificationPreferences/config'
@@ -229,7 +231,16 @@ export const Managers: CollectionConfig = {
               name: 'notificationPreferences',
               type: 'json',
               defaultValue: buildDefaultNotificationPreferences(),
-              validate: (value: unknown) => validateNotificationPreferences(value),
+              jsonSchema: buildNotificationPreferencesJsonSchema(),
+              // A custom `validate` REPLACES Payload's built-in json validation,
+              // so the schema above would never run if this only checked the
+              // cross-field rule. Delegate first, then add what JSON Schema
+              // can't express with a message worth reading.
+              validate: (value, options) => {
+                const schemaResult = validations.json(value, options)
+                if (schemaResult !== true) return schemaResult
+                return validateNotificationPreferences(value)
+              },
               admin: {
                 description: 'Choose how and how often to receive each kind of notification.',
                 custom: { notificationTypes: NOTIFICATION_TYPES },

--- a/src/collections/Meditations/Meditations.ts
+++ b/src/collections/Meditations/Meditations.ts
@@ -20,6 +20,9 @@ import { filterMeditationsByLocale } from './hooks/filterMeditationsByLocale'
 import { invalidateMeditationNodeWeights } from './hooks/invalidateMeditationNodeWeights'
 import { recomputeMeditationNodeWeights } from './hooks/recomputeMeditationNodeWeights'
 
+const SUBTLE_SYSTEM_NODE_WEIGHTS_SCHEMA_URI =
+  'https://sahajcloud.dev/schemas/subtle-system-node-weights.json'
+
 /**
  * Factory for afterRead hooks that find UserChoices referencing this meditation
  * for a specific timing field. Returns an array of { id, title } objects.
@@ -230,6 +233,28 @@ export const Meditations: CollectionConfig = {
               // and cascaded from Frames via `cascadeFrameNodeChange`.
               name: 'subtleSystemNodeWeights',
               type: 'json',
+              // Types the cache as `{ [slug]: seconds } | null` for the two
+              // ranking endpoints that read it. Type-only in practice: the sole
+              // writer goes through `payload.db.updateOne`, which skips
+              // validation. `null` is spelled out because clearing the cache is
+              // a real operation (persistMeditationNodeWeightsCache) — Payload
+              // doesn't add `| null` to a jsonSchema-typed field on its own.
+              jsonSchema: {
+                uri: SUBTLE_SYSTEM_NODE_WEIGHTS_SCHEMA_URI,
+                fileMatch: [SUBTLE_SYSTEM_NODE_WEIGHTS_SCHEMA_URI],
+                schema: {
+                  anyOf: [
+                    {
+                      type: 'object',
+                      additionalProperties: {
+                        type: 'number',
+                        description: 'On-screen seconds for the node slug.',
+                      },
+                    },
+                    { type: 'null' },
+                  ],
+                },
+              },
               admin: {
                 readOnly: true,
                 hidden: true,

--- a/src/collections/Registrations/Registrations.ts
+++ b/src/collections/Registrations/Registrations.ts
@@ -3,6 +3,7 @@ import type { CollectionConfig } from 'payload'
 import { legacyMigrationFields } from '@/fields'
 import { DEFAULT_LOCALE, getLocaleOptions } from '@/lib/locales'
 import { registrationQuestionsJsonSchema } from '@/lib/registrations/questions'
+import { reminderLogJsonSchema } from '@/lib/registrations/reminderLog'
 
 import { syncFullnessAfterChange, syncFullnessAfterDelete } from './hooks/syncFullness'
 
@@ -127,6 +128,7 @@ export const Registrations: CollectionConfig = {
       // `notificationLog` pattern.
       name: 'reminderLog',
       type: 'json',
+      jsonSchema: reminderLogJsonSchema,
       admin: { readOnly: true },
     },
     ...legacyMigrationFields(),

--- a/src/collections/Registrations/Registrations.ts
+++ b/src/collections/Registrations/Registrations.ts
@@ -84,11 +84,7 @@ export const Registrations: CollectionConfig = {
       // Payload generates the `questions` TS type AND validates on write (an unknown
       // key or non-string answer throws a ValidationError → 400 at the register
       // endpoint, surfaced verbatim rather than a 500).
-      jsonSchema: {
-        uri: 'https://sahajcloud.dev/schemas/registration-questions.json',
-        fileMatch: ['https://sahajcloud.dev/schemas/registration-questions.json'],
-        schema: registrationQuestionsJsonSchema,
-      },
+      jsonSchema: registrationQuestionsJsonSchema,
       admin: {
         description:
           "Raw registrant answers, keyed by the event's enabled registration questions (EVENT_REGISTRATION_QUESTIONS — priorExperience, referralSource, healthInfo, accessibility, guests).",

--- a/src/collections/Videos/Videos.ts
+++ b/src/collections/Videos/Videos.ts
@@ -1,7 +1,7 @@
 import type { CollectionConfig } from 'payload'
 
 import { mediaField } from '@/fields'
-import { subtitlesJsonSchema, validateSubtitles } from '@/lib/utilities/subtitles'
+import { subtitlesJsonSchema } from '@/lib/utilities/subtitles'
 import { restrictUploadToAdmin } from '@/plugins/access'
 import { getCloudflareStreamThumbnailUrl } from '@/plugins/storage/cloudflareStreamAdapter'
 import {
@@ -64,8 +64,7 @@ export const Videos: CollectionConfig = {
       admin: {
         description: 'Subtitle cues: [{ startTimeMs, endTimeMs, durationMs?, content }]',
       },
-      validate: validateSubtitles,
-      typescriptSchema: [() => subtitlesJsonSchema],
+      jsonSchema: subtitlesJsonSchema,
     },
     {
       name: 'tags',

--- a/src/components/admin/NotificationPreferences/config.ts
+++ b/src/components/admin/NotificationPreferences/config.ts
@@ -8,6 +8,8 @@
  * by the field's `defaultValue`/`validate` and unit-tested directly.
  */
 
+import type { JSONField } from 'payload'
+
 export const NEVER_FREQUENCY = 'Never'
 export const DEFAULT_NOTIFICATION_METHOD = 'email'
 
@@ -108,9 +110,55 @@ export function buildDefaultNotificationPreferences(
   return prefs
 }
 
+const NOTIFICATION_PREFERENCES_SCHEMA_URI =
+  'https://sahajcloud.dev/schemas/notification-preferences.json'
+
+/**
+ * JSON Schema for the stored preferences: one optional entry per configured
+ * notification type, each `{ frequency, method }` with the frequency confined
+ * to that type's own options. Derived from `NOTIFICATION_TYPES` so it can't
+ * drift from the rows the field renders.
+ *
+ * Payload uses it to BOTH validate on write (Ajv → `ValidationError` → 400) AND
+ * generate the field's TypeScript type in `payload-types.ts`, which would
+ * otherwise be `unknown`. The one rule it deliberately doesn't carry is
+ * "a method is required unless the frequency is Never" — expressing that as
+ * `if`/`then` costs the message that names the offending types, so
+ * `validateNotificationPreferences` keeps it (see Managers.ts).
+ */
+export function buildNotificationPreferencesJsonSchema(
+  types: NotificationType[] = NOTIFICATION_TYPES,
+): NonNullable<JSONField['jsonSchema']> {
+  return {
+    uri: NOTIFICATION_PREFERENCES_SCHEMA_URI,
+    fileMatch: [NOTIFICATION_PREFERENCES_SCHEMA_URI],
+    schema: {
+      type: 'object',
+      additionalProperties: false,
+      properties: Object.fromEntries(
+        types.map((type) => [
+          type.key,
+          {
+            type: 'object',
+            description: type.title,
+            additionalProperties: false,
+            required: ['frequency', 'method'],
+            properties: {
+              frequency: { type: 'string', enum: [...type.frequencyOptions] },
+              // Empty for a "Never" frequency, which needs no delivery channel.
+              method: { type: 'string' },
+            },
+          },
+        ]),
+      ),
+    },
+  }
+}
+
 /**
  * Every configured preference requires a delivery method unless its frequency
- * is "Never". Returns an error message naming the offending types, or `true`.
+ * is "Never". The one constraint `buildNotificationPreferencesJsonSchema` above
+ * leaves out. Returns an error message naming the offending types, or `true`.
  */
 export function validateNotificationPreferences(
   value: unknown,

--- a/src/fields/translationsField.ts
+++ b/src/fields/translationsField.ts
@@ -1,3 +1,4 @@
+import type { JSONSchema4 } from 'json-schema'
 import type { Field, GroupField, JSONField, RichTextField, TabsField, UIField } from 'payload'
 
 import { toWords } from 'payload/shared'
@@ -109,6 +110,9 @@ function isRichTextProp(prop: LeafPropertySchema | GroupSchema): prop is RichTex
 // Helpers
 // ============================================================================
 
+/** Namespace for the per-group `jsonSchema` URIs (see createStringsJsonField). */
+const TRANSLATIONS_SCHEMA_URI_BASE = 'https://sahajcloud.dev/schemas/translations'
+
 function createScreenshotField(
   groupSlug: string,
   groupSchema: GroupSchema,
@@ -143,12 +147,11 @@ function createScreenshotField(
  * RichText keys are emitted as sibling richText fields at the same level
  * (see createRichTextField), not packed into this JSON blob.
  *
- * NOTE — no `jsonSchema` is set. Payload would compile it to a validator via
- * Ajv which uses `new Function()` for performance. Cloudflare Workers' V8
- * isolate disallows dynamic code generation, so any write to a
- * `jsonSchema`-validated field throws "Code generation from strings
- * disallowed" in prod. A pure-JS `validate` function enforces the same
- * key/type constraints instead.
+ * The group's own schema is projected into the field's `jsonSchema`, which
+ * Payload uses to BOTH validate on write (Ajv rejects an unknown key or a
+ * non-string value → `ValidationError` → 400) AND generate the field's
+ * TypeScript type in `payload-types.ts` — every translations global gets a
+ * real per-group type instead of `unknown`.
  */
 function createStringsJsonField(
   fieldName: string,
@@ -166,19 +169,37 @@ function createStringsJsonField(
     plural: prop.plural === true ? true : undefined,
   }))
   // A plural key is declared once but stored as its CLDR family, so the JSON
-  // blob holds `<key>_one`/`_few`/… — validate against the expanded keys.
-  const allowedKeys = new Set(
-    stringProps.flatMap(([key, prop]) =>
-      prop.plural === true ? PLURAL_CATEGORIES.map((cat) => `${key}_${cat}`) : [key],
-    ),
-  )
-  const allowAdditional = group.additionalProperties === true
+  // blob holds `<key>_one`/`_few`/… — the schema declares the expanded keys.
+  const properties: Record<string, JSONSchema4> = {}
+  for (const [key, prop] of stringProps) {
+    const storedKeys =
+      prop.plural === true ? PLURAL_CATEGORIES.map((cat) => `${key}_${cat}`) : [key]
+    for (const storedKey of storedKeys) {
+      properties[storedKey] = {
+        type: 'string',
+        ...(prop.description && { description: prop.description }),
+      }
+    }
+  }
+  // One URI per field — it identifies this group's schema to the admin editor.
+  const uri = `${TRANSLATIONS_SCHEMA_URI_BASE}/${[globalSlug, parentGroup, fieldName]
+    .filter(Boolean)
+    .join('/')}.json`
 
   return {
     name: fieldName,
     type: 'json',
     localized: true,
     label: false,
+    jsonSchema: {
+      uri,
+      fileMatch: [uri],
+      schema: {
+        type: 'object',
+        properties,
+        additionalProperties: group.additionalProperties === true,
+      },
+    },
     admin: {
       components: { Field: '@/components/admin/TranslationsRow' },
       custom: {
@@ -186,21 +207,6 @@ function createStringsJsonField(
         globalSlug,
         parentGroup,
       },
-    },
-    validate: (value): true | string => {
-      if (value === null || value === undefined) return true
-      if (typeof value !== 'object' || Array.isArray(value)) return 'Value must be a JSON object'
-      const obj = value as Record<string, unknown>
-      if (!allowAdditional) {
-        for (const key of Object.keys(obj)) {
-          if (!allowedKeys.has(key)) return `Unknown key "${key}" (not in schema)`
-        }
-      }
-      for (const key of allowedKeys) {
-        if (!(key in obj)) continue
-        if (typeof obj[key] !== 'string') return `Key "${key}" must be a string`
-      }
-      return true
     },
   }
 }

--- a/src/jobs/RegistrationNotifications/SendSessionReminders.ts
+++ b/src/jobs/RegistrationNotifications/SendSessionReminders.ts
@@ -5,13 +5,13 @@ import * as Sentry from '@sentry/nextjs'
 import type { LocaleCode } from '@/lib/locales'
 import type { EmailClient } from '@/lib/notifications/sendRegistrationConfirmation'
 import { sendSessionReminder } from '@/lib/notifications/sendSessionReminder'
+import { asReminderLog, hasReminderFor, type ReminderLogEntry } from '@/lib/registrations/reminderLog'
 import type { ScheduleSubFields } from '@/lib/schedule/scheduleHooks'
 import { buildRRuleTemporal } from '@/lib/schedule/scheduleHooks'
 import { relationId } from '@/lib/utilities/relationId'
 import type { Event } from '@/payload-types'
 
 import { loadUsers } from './loadUsers'
-import { asReminderLog, hasReminderFor, type ReminderLogEntry } from './reminderLedger'
 
 const PAGINATION_LIMIT = 200
 /** 24 hours — how far ahead a run reminds. */

--- a/src/lib/eventVerification/log.ts
+++ b/src/lib/eventVerification/log.ts
@@ -1,7 +1,11 @@
 import type { VerificationStage } from './stages'
+import type { JSONSchema4 } from 'json-schema'
+import type { JSONField } from 'payload'
+
 
 import type { ReminderAudience, ReminderLevel } from '@/lib/notifications'
 
+import { VERIFICATION_STAGES } from './stages'
 
 /**
  * The on-document `notificationLog` — the **current verification cycle**.
@@ -15,7 +19,9 @@ import type { ReminderAudience, ReminderLevel } from '@/lib/notifications'
  */
 
 /** How a verification was triggered. */
-export type VerificationMethod = 're-save' | 'verify-action' | 'email-link' | 'import'
+export const VERIFICATION_METHODS = ['re-save', 'verify-action', 'email-link', 'import'] as const
+
+export type VerificationMethod = (typeof VERIFICATION_METHODS)[number]
 
 /** A manager reference captured in the log (id + display name). */
 export interface ActorRef {
@@ -106,4 +112,79 @@ export function hasReminderForStage(
 /** Narrow an unknown json value (the stored field) to a log-entry array. */
 export function asNotificationLog(value: unknown): NotificationLogEntry[] {
   return Array.isArray(value) ? (value as NotificationLogEntry[]) : []
+}
+
+const NOTIFICATION_LOG_SCHEMA_URI = 'https://sahajcloud.dev/schemas/event-notification-log.json'
+
+/** `ActorRef` as JSON Schema. */
+const actorRefSchema: JSONSchema4 = {
+  type: 'object',
+  additionalProperties: false,
+  required: ['id', 'name'],
+  properties: {
+    id: { type: 'number' },
+    name: { type: 'string' },
+  },
+}
+
+/**
+ * `jsonSchema` for `Events.notificationLog` — the two entry shapes above as a
+ * discriminated union on `kind`. Nothing but the builders in this file writes
+ * the field, so this is primarily about the generated TypeScript type: without
+ * it the whole log reads back as `unknown`. Validation is the free bonus, and
+ * it holds a hand-written fixture to the same shape the builders produce.
+ *
+ * `level` and `role` stay plain strings: their vocabulary is declared by
+ * `EventVerificationEmail`, and this module is value-imported by admin client
+ * components — enumerating them here would pull react-email into that bundle.
+ */
+export const notificationLogJsonSchema: NonNullable<JSONField['jsonSchema']> = {
+  uri: NOTIFICATION_LOG_SCHEMA_URI,
+  fileMatch: [NOTIFICATION_LOG_SCHEMA_URI],
+  schema: {
+    type: 'array',
+    items: {
+      anyOf: [
+        {
+          type: 'object',
+          description: 'The verification that opened the current cycle.',
+          additionalProperties: false,
+          required: ['kind', 'at', 'by', 'method'],
+          properties: {
+            kind: { enum: ['verification'] },
+            at: { type: 'string', description: 'ISO 8601 timestamp.' },
+            by: {
+              anyOf: [actorRefSchema, { type: 'null' }],
+              description: 'The manager who verified, or null for an automated verification.',
+            },
+            method: { type: 'string', enum: [...VERIFICATION_METHODS] },
+          },
+        },
+        {
+          type: 'object',
+          description: 'One reminder delivery, appended per recipient per stage.',
+          additionalProperties: false,
+          required: ['kind', 'stage', 'level', 'role', 'at', 'manager', 'channel', 'destination'],
+          properties: {
+            kind: { enum: ['reminder'] },
+            stage: {
+              type: 'string',
+              enum: [...VERIFICATION_STAGES],
+              description: 'The from-stage — the per-recipient dedup key.',
+            },
+            level: { type: 'string', description: 'due / escalated / urgent / expired.' },
+            role: { type: 'string', description: "manager (the event's own) or region." },
+            region: {
+              type: 'string',
+              description: 'The ancestor region that linked a region manager to the event.',
+            },
+            at: { type: 'string', description: 'ISO 8601 timestamp.' },
+            manager: actorRefSchema,
+            channel: { type: 'string', description: 'Delivery method used, e.g. email.' },
+            destination: { type: 'string', description: 'Address/handle the reminder went to.' },
+          },
+        },
+      ],
+    },
+  },
 }

--- a/src/lib/eventVerification/log.ts
+++ b/src/lib/eventVerification/log.ts
@@ -2,7 +2,6 @@ import type { VerificationStage } from './stages'
 import type { JSONSchema4 } from 'json-schema'
 import type { JSONField } from 'payload'
 
-
 import type { ReminderAudience, ReminderLevel } from '@/lib/notifications'
 
 import { VERIFICATION_STAGES } from './stages'

--- a/src/lib/registrations/questions.ts
+++ b/src/lib/registrations/questions.ts
@@ -10,7 +10,7 @@
  * `.claude/rules/project-structure.md`).
  */
 
-import type { JSONSchema4 } from 'json-schema'
+import type { JSONField } from 'payload'
 
 /**
  * Optional questions an event can ask registrants. Rendered as a group of
@@ -32,27 +32,33 @@ export interface RegistrationAnswer {
   value: string
 }
 
+const QUESTIONS_SCHEMA_URI = 'https://sahajcloud.dev/schemas/registration-questions.json'
+
 /**
- * JSON Schema for the stored `questions` answers: an object keyed by the
+ * `jsonSchema` for the stored `questions` answers: an object keyed by the
  * configured question names, each answer a string, no other keys allowed.
  * Derived from `EVENT_REGISTRATION_QUESTIONS` so it can't drift.
  *
- * Wired onto `Registrations.questions` via the field's `jsonSchema`, which
- * Payload uses to BOTH validate on write (an unknown key or non-string answer
- * throws a `ValidationError` → the register endpoint returns 400) AND generate
- * the field's TypeScript type in `payload-types.ts`. (This compiles an Ajv
- * `new Function()` validator — fine on Railway/Node; the old comments warning it
- * breaks under Cloudflare Workers predate the migration off Workers.)
+ * Wired onto `Registrations.questions`, which Payload uses to BOTH validate on
+ * write (an unknown key or non-string answer throws a `ValidationError` → the
+ * register endpoint returns 400) AND generate the field's TypeScript type in
+ * `payload-types.ts`. (This compiles an Ajv `new Function()` validator — fine on
+ * Railway/Node; the old comments warning it breaks under Cloudflare Workers
+ * predate the migration off Workers.)
  */
-export const registrationQuestionsJsonSchema: JSONSchema4 = {
-  type: 'object',
-  additionalProperties: false,
-  properties: Object.fromEntries(
-    EVENT_REGISTRATION_QUESTIONS.map((question) => [
-      question.name,
-      { type: 'string', description: question.label },
-    ]),
-  ),
+export const registrationQuestionsJsonSchema: NonNullable<JSONField['jsonSchema']> = {
+  uri: QUESTIONS_SCHEMA_URI,
+  fileMatch: [QUESTIONS_SCHEMA_URI],
+  schema: {
+    type: 'object',
+    additionalProperties: false,
+    properties: Object.fromEntries(
+      EVENT_REGISTRATION_QUESTIONS.map((question) => [
+        question.name,
+        { type: 'string', description: question.label },
+      ]),
+    ),
+  },
 }
 
 const CONFIGURED_QUESTION_NAMES = new Set<string>(

--- a/src/lib/registrations/reminderLog.ts
+++ b/src/lib/registrations/reminderLog.ts
@@ -5,7 +5,13 @@
  * job checks membership before sending and appends immediately after, so a task
  * retry or an overlapping run never double-sends. Mirrors the Events
  * `notificationLog` shape and helpers (`asNotificationLog` / `hasReminderForStage`).
+ *
+ * Lives in `src/lib/` because two owners share it: the SendSessionReminders job
+ * reads and appends, and the Registrations collection types the column from the
+ * schema below.
  */
+
+import type { JSONField } from 'payload'
 
 /** One reminded occurrence. */
 export interface ReminderLogEntry {
@@ -29,4 +35,31 @@ export function asReminderLog(value: unknown): ReminderLogEntry[] {
 /** Has this registration already been reminded for `occurrenceIso`? */
 export function hasReminderFor(log: ReminderLogEntry[], occurrenceIso: string): boolean {
   return log.some((entry) => entry.occurrence === occurrenceIso)
+}
+
+const REMINDER_LOG_SCHEMA_URI = 'https://sahajcloud.dev/schemas/registration-reminder-log.json'
+
+/**
+ * `jsonSchema` for `Registrations.reminderLog`. Only the reminder job writes the
+ * field, so the point is the generated TypeScript type — the ledger reads back
+ * as the entry shape above instead of `unknown`.
+ */
+export const reminderLogJsonSchema: NonNullable<JSONField['jsonSchema']> = {
+  uri: REMINDER_LOG_SCHEMA_URI,
+  fileMatch: [REMINDER_LOG_SCHEMA_URI],
+  schema: {
+    type: 'array',
+    items: {
+      type: 'object',
+      additionalProperties: false,
+      required: ['occurrence', 'sentAt'],
+      properties: {
+        occurrence: {
+          type: 'string',
+          description: 'ISO start of the reminded occurrence — the exactly-once dedup key.',
+        },
+        sentAt: { type: 'string', description: 'When the reminder was sent (ISO).' },
+      },
+    },
+  },
 }

--- a/src/lib/utilities/subtitles.ts
+++ b/src/lib/utilities/subtitles.ts
@@ -3,20 +3,19 @@ import type { JSONField } from 'payload'
 
 import { z } from 'zod'
 
+/** The subtitle-cue contract, and the single source of truth for it. */
+const subtitleCue = z.object({
+  content: z.string(),
+  startTimeMs: z.number(),
+  endTimeMs: z.number(),
+  durationMs: z.number().optional(),
+})
+
 /**
- * The subtitle-cue contract, and the single source of truth for it. The
- * Storyblok seed importer parses raw subtitle files with this schema, and
- * `subtitlesJsonSchema` below is derived from it — so the field's write
- * validation and its generated TypeScript type can't drift from the parser.
+ * Strict cue list — the Storyblok seed importer parses raw subtitle files with
+ * this, which drops any key not declared above.
  */
-export const subtitlesZodSchema = z.array(
-  z.object({
-    content: z.string(),
-    startTimeMs: z.number(),
-    endTimeMs: z.number(),
-    durationMs: z.number().optional(),
-  }),
-)
+export const subtitlesZodSchema = z.array(subtitleCue)
 
 export type Subtitles = z.infer<typeof subtitlesZodSchema>
 
@@ -28,6 +27,13 @@ const SUBTITLES_SCHEMA_URI = 'https://sahajcloud.dev/schemas/subtitles.json'
  * `ValidationError` (a 400 over REST) — AND generate the field's TypeScript
  * type in `payload-types.ts`, which would otherwise be `unknown`.
  *
+ * Derived from the **loose** cue so an unrecognised key is tolerated rather
+ * than rejected. That is deliberate and load-bearing: stored rows carry legacy
+ * cue keys (`startOfParagraph`, …), the Zod-based field validator this replaces
+ * accepted them, and rejecting them here would 400 every later save of an
+ * otherwise untouched lesson or video. Sharing `subtitleCue` keeps the declared
+ * fields identical to the strict parser above — only the tolerance differs.
+ *
  * Emitted at `draft-7` because Ajv's default export, the one Payload's json
  * validator instantiates, is a draft-07 instance.
  *
@@ -38,5 +44,5 @@ const SUBTITLES_SCHEMA_URI = 'https://sahajcloud.dev/schemas/subtitles.json'
 export const subtitlesJsonSchema: NonNullable<JSONField['jsonSchema']> = {
   uri: SUBTITLES_SCHEMA_URI,
   fileMatch: [SUBTITLES_SCHEMA_URI],
-  schema: z.toJSONSchema(subtitlesZodSchema, { target: 'draft-7' }) as JSONSchema4,
+  schema: z.toJSONSchema(z.array(subtitleCue.loose()), { target: 'draft-7' }) as JSONSchema4,
 }

--- a/src/lib/utilities/subtitles.ts
+++ b/src/lib/utilities/subtitles.ts
@@ -1,12 +1,14 @@
 import type { JSONSchema4 } from 'json-schema'
-import type { JSONFieldValidation } from 'payload'
+import type { JSONField } from 'payload'
 
 import { z } from 'zod'
 
-// Zod schema and JSON schema below mirror each other. If you change one,
-// change the other — they describe the same shape but feed different
-// systems (Zod = runtime validation, JSON schema = `typescriptSchema`
-// for generated TypeScript types).
+/**
+ * The subtitle-cue contract, and the single source of truth for it. The
+ * Storyblok seed importer parses raw subtitle files with this schema, and
+ * `subtitlesJsonSchema` below is derived from it — so the field's write
+ * validation and its generated TypeScript type can't drift from the parser.
+ */
 export const subtitlesZodSchema = z.array(
   z.object({
     content: z.string(),
@@ -18,45 +20,23 @@ export const subtitlesZodSchema = z.array(
 
 export type Subtitles = z.infer<typeof subtitlesZodSchema>
 
-// Mirrors `subtitlesZodSchema` — see the note above.
-export const subtitlesJsonSchema: JSONSchema4 = {
-  type: 'array',
-  items: {
-    type: 'object',
-    properties: {
-      content: { type: 'string' },
-      startTimeMs: { type: 'number' },
-      endTimeMs: { type: 'number' },
-      durationMs: { type: 'number' },
-    },
-    required: ['content', 'startTimeMs', 'endTimeMs'],
-    additionalProperties: false,
-  },
+const SUBTITLES_SCHEMA_URI = 'https://sahajcloud.dev/schemas/subtitles.json'
+
+/**
+ * `jsonSchema` for every subtitles field (Videos, Lessons). Payload uses it to
+ * BOTH validate on write — Ajv rejects a malformed cue, raising a
+ * `ValidationError` (a 400 over REST) — AND generate the field's TypeScript
+ * type in `payload-types.ts`, which would otherwise be `unknown`.
+ *
+ * Emitted at `draft-7` because Ajv's default export, the one Payload's json
+ * validator instantiates, is a draft-07 instance.
+ *
+ * Empty values (`undefined` / `null` / `[]` / `{}`) skip validation entirely —
+ * Payload's json validator treats them as "no value" — so the field stays
+ * optional with no special-casing here.
+ */
+export const subtitlesJsonSchema: NonNullable<JSONField['jsonSchema']> = {
+  uri: SUBTITLES_SCHEMA_URI,
+  fileMatch: [SUBTITLES_SCHEMA_URI],
+  schema: z.toJSONSchema(subtitlesZodSchema, { target: 'draft-7' }) as JSONSchema4,
 }
-
-const isEmpty = (value: unknown): boolean => {
-  if (value === undefined || value === null) return true
-  if (Array.isArray(value) && value.length === 0) return true
-  if (typeof value === 'object' && value !== null && Object.keys(value).length === 0) return true
-  return false
-}
-
-// Workers-safe replacement for Payload's built-in jsonSchema validation,
-// which compiles via AJV's `new Function(...)` and is blocked by the V8
-// isolate (issue #317). Uses Zod, which is already a project dependency
-// and runs cleanly under Workers.
-export const parseSubtitles = (value: unknown): true | string => {
-  if (isEmpty(value)) return true
-
-  const result = subtitlesZodSchema.safeParse(value)
-  if (result.success) return true
-
-  return result.error.issues
-    .map((issue) => {
-      const path = issue.path.join('.')
-      return path ? `${path}: ${issue.message}` : issue.message
-    })
-    .join('; ')
-}
-
-export const validateSubtitles: JSONFieldValidation = (value) => parseSubtitles(value)

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -1315,18 +1315,36 @@ export interface Manager {
         id?: string | null;
       }[]
     | null;
-  /**
-   * Choose how and how often to receive each kind of notification.
-   */
-  notificationPreferences?:
-    | {
-        [k: string]: unknown;
-      }
-    | unknown[]
-    | string
-    | number
-    | boolean
-    | null;
+  notificationPreferences?: {
+    /**
+     * New Responsibility
+     */
+    new_responsibility?: {
+      frequency: 'Immediate' | 'Never';
+      method: string;
+    };
+    /**
+     * Event Verification
+     */
+    event_verification?: {
+      frequency: 'Monthly' | '3 Months' | '6 Months';
+      method: string;
+    };
+    /**
+     * Event Registration
+     */
+    event_registration?: {
+      frequency: 'Immediate' | 'Daily Summary' | 'Weekly Summary' | 'Never';
+      method: string;
+    };
+    /**
+     * Regional Summary
+     */
+    regional_summary?: {
+      frequency: 'Monthly' | 'Never';
+      method: string;
+    };
+  };
   lastRegistrationDigestSentAt?: string | null;
   legacyId?: number | null;
   legacyData?:
@@ -1793,18 +1811,58 @@ export interface Event {
   manager: number | Manager;
   verificationStage: 'verified' | 'reminded' | 'escalated' | 'urgent' | 'expired' | 'finished';
   nextCheckAt?: string | null;
-  /**
-   * Current verification cycle — the verification that opened it plus each reminder sent. Reset on every verification.
-   */
-  notificationLog?:
+  notificationLog?: (
     | {
-        [k: string]: unknown;
+        kind: 'verification';
+        /**
+         * ISO 8601 timestamp.
+         */
+        at: string;
+        /**
+         * The manager who verified, or null for an automated verification.
+         */
+        by: {
+          id: number;
+          name: string;
+        } | null;
+        method: 're-save' | 'verify-action' | 'email-link' | 'import';
       }
-    | unknown[]
-    | string
-    | number
-    | boolean
-    | null;
+    | {
+        kind: 'reminder';
+        /**
+         * The from-stage — the per-recipient dedup key.
+         */
+        stage: 'verified' | 'reminded' | 'escalated' | 'urgent' | 'expired' | 'finished';
+        /**
+         * due / escalated / urgent / expired.
+         */
+        level: string;
+        /**
+         * manager (the event's own) or region.
+         */
+        role: string;
+        /**
+         * The ancestor region that linked a region manager to the event.
+         */
+        region?: string;
+        /**
+         * ISO 8601 timestamp.
+         */
+        at: string;
+        manager: {
+          id: number;
+          name: string;
+        };
+        /**
+         * Delivery method used, e.g. email.
+         */
+        channel: string;
+        /**
+         * Address/handle the reminder went to.
+         */
+        destination: string;
+      }
+  )[];
   webPath?: string | null;
   webUrl?: string | null;
   appUrl?: string | null;
@@ -1894,15 +1952,16 @@ export interface Registration {
   uuid: string;
   mailingListSubscribedAt?: string | null;
   remindersUnsubscribedAt?: string | null;
-  reminderLog?:
-    | {
-        [k: string]: unknown;
-      }
-    | unknown[]
-    | string
-    | number
-    | boolean
-    | null;
+  reminderLog?: {
+    /**
+     * ISO start of the reminded occurrence — the exactly-once dedup key.
+     */
+    occurrence: string;
+    /**
+     * When the reminder was sent (ISO).
+     */
+    sentAt: string;
+  }[];
   legacyId?: number | null;
   legacyData?:
     | {

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -4900,51 +4900,80 @@ export interface WmWebConfig {
  */
 export interface WmWebTranslation {
   id: number;
-  common?:
-    | {
-        [k: string]: unknown;
-      }
-    | unknown[]
-    | string
-    | number
-    | boolean
-    | null;
-  navigation?:
-    | {
-        [k: string]: unknown;
-      }
-    | unknown[]
-    | string
-    | number
-    | boolean
-    | null;
-  footer?:
-    | {
-        [k: string]: unknown;
-      }
-    | unknown[]
-    | string
-    | number
-    | boolean
-    | null;
-  page_tags?:
-    | {
-        [k: string]: unknown;
-      }
-    | unknown[]
-    | string
-    | number
-    | boolean
-    | null;
-  errors?:
-    | {
-        [k: string]: unknown;
-      }
-    | unknown[]
-    | string
-    | number
-    | boolean
-    | null;
+  common?: {
+    /**
+     * Loading indicator text shown while content is being fetched.
+     */
+    loading?: string;
+    /**
+     * Generic error message shown when something goes wrong.
+     */
+    error?: string;
+    /**
+     * Button text to retry a failed action.
+     */
+    retry?: string;
+  };
+  navigation?: {
+    /**
+     * Primary navigation link opening the "About Meditation" knowledge section.
+     */
+    about_meditation?: string;
+    /**
+     * Navigation link to educational content and resources.
+     */
+    learn_more?: string;
+    /**
+     * Call-to-action navigation link inviting users to start meditating.
+     */
+    come_meditate?: string;
+    /**
+     * Label for the language selector in the header/navigation.
+     */
+    languages?: string;
+    /**
+     * Action link inviting users to find in-person meditation classes near their location (frontend: "Classes near me").
+     */
+    classes_near_me?: string;
+  };
+  footer?: {
+    /**
+     * Heading for the footer's "Info" column, which lists informational pages (about, contact, privacy, etc.) (frontend: "Info").
+     */
+    info?: string;
+  };
+  page_tags?: {
+    /**
+     * Category label for pages tagged "Wisdom" (frontend: "Wisdom").
+     */
+    wisdom?: string;
+    /**
+     * Category label for pages tagged "Lifestyle" (frontend: "Lifestyle").
+     */
+    lifestyle?: string;
+    /**
+     * Category label for pages tagged "Creativity" (frontend: "Creativity").
+     */
+    creativity?: string;
+    /**
+     * Category label for pages tagged "Event" (frontend: "Event").
+     */
+    event?: string;
+    /**
+     * Category label for pages tagged "Technique" (frontend: "Technique").
+     */
+    technique?: string;
+  };
+  errors?: {
+    /**
+     * Error shown on a meditation page when the meditation has no playable audio source (frontend: "This meditation is missing a required audio URL.").
+     */
+    meditation_missing_audio?: string;
+    /**
+     * Error shown on a lecture page when the lecture has no playable video source (frontend: "This lecture is missing a playable video source.").
+     */
+    lecture_missing_video?: string;
+  };
   _status?: ('draft' | 'published') | null;
   updatedAt?: string | null;
   createdAt?: string | null;
@@ -5057,15 +5086,40 @@ export interface WmAppConfig {
 export interface WmAppTranslation {
   id: number;
   onboarding?: {
-    welcome?:
-      | {
-          [k: string]: unknown;
-        }
-      | unknown[]
-      | string
-      | number
-      | boolean
-      | null;
+    welcome?: {
+      /**
+       * Hero title on the welcome screen. Short greeting (e.g. 'Welcome, friend').
+       */
+      title?: string;
+      /**
+       * Hero subtitle below the welcome title.
+       */
+      subtitle?: string;
+      /**
+       * Primary CTA that begins onboarding for a new user.
+       */
+      get_started?: string;
+      /**
+       * Secondary CTA for returning users who already have an account.
+       */
+      use_existing_account?: string;
+      /**
+       * Title of the in-app webview screen that displays the Privacy Policy. The Privacy Policy body itself is the CMS page referenced by wm-app-config.privacyPolicyPage, not a translation string.
+       */
+      privacy_policy_title?: string;
+      /**
+       * Title of the in-app webview screen that displays the Terms & Conditions. The body itself is the CMS page referenced by wm-app-config.termsAndConditionsPage.
+       */
+      terms_and_conditions_title?: string;
+      /**
+       * Error toast shown when the OS cannot find an installed email client to handle a mailto: link from the welcome screen.
+       */
+      email_app_unavailable?: string;
+      /**
+       * Generic error toast shown when an inline link on the welcome screen fails to open.
+       */
+      link_open_failed?: string;
+    };
     /**
      * Inline legal disclaimer below the primary CTAs. Renders two inline links to the in-app Terms and Privacy Policy webviews (URLs use the wemeditate://legal/* scheme — see ticket for full reference). Translators control word order, link placement, and the connector between the two link labels.
      */
@@ -5084,33 +5138,48 @@ export interface WmAppTranslation {
       };
       [k: string]: unknown;
     } | null;
-    name?:
-      | {
-          [k: string]: unknown;
-        }
-      | unknown[]
-      | string
-      | number
-      | boolean
-      | null;
-    greeting?:
-      | {
-          [k: string]: unknown;
-        }
-      | unknown[]
-      | string
-      | number
-      | boolean
-      | null;
-    user_type?:
-      | {
-          [k: string]: unknown;
-        }
-      | unknown[]
-      | string
-      | number
-      | boolean
-      | null;
+    name?: {
+      /**
+       * Screen prompt asking the user for their name (e.g. “What’s your name?”).
+       */
+      title?: string;
+      /**
+       * Input field placeholder hint for the name field.
+       */
+      placeholder?: string;
+      /**
+       * Primary CTA to confirm the entered name and continue onboarding.
+       */
+      continue?: string;
+    };
+    greeting?: {
+      /**
+       * Multi-line greeting prefix shown above the user’s name. Preserve the embedded line breaks (\n) — they control where the text wraps in the hero layout.
+       */
+      message_prefix?: string;
+    };
+    user_type?: {
+      /**
+       * Primary CTA used after the user picks their classification.
+       */
+      get_started?: string;
+      /**
+       * Selectable option for users completely new to meditation. Maps to userType = user-complete-beginner.
+       */
+      option_complete_beginner?: string;
+      /**
+       * Selectable option for users who have tried meditation before but not deeply. Maps to userType = user-tried-before.
+       */
+      option_tried_before?: string;
+      /**
+       * Selectable option for users currently in an in-person or online newcomer class. Maps to userType = user-attending-classes.
+       */
+      option_attending_classes?: string;
+      /**
+       * Selectable option for long-time Sahaja Yoga practitioners. Maps to userType = yogi (excluded from the ad-measurement path).
+       */
+      option_yogi?: string;
+    };
     /**
      * Screen title prompt (e.g. 'Have you tried Sahaja Yoga before?'). The brand fragment 'Sahaja Yoga' is rendered as a bold inline span; translators may choose a different word to bold or apply no bold per locale convention.
      */
@@ -5129,15 +5198,28 @@ export interface WmAppTranslation {
       };
       [k: string]: unknown;
     } | null;
-    carousel?:
-      | {
-          [k: string]: unknown;
-        }
-      | unknown[]
-      | string
-      | number
-      | boolean
-      | null;
+    carousel?: {
+      /**
+       * Slide 1 title (e.g. 'A moment of peace').
+       */
+      page_moment_title?: string;
+      /**
+       * Slide 1 supporting copy.
+       */
+      page_moment_subtitle?: string;
+      /**
+       * Slide 2 supporting copy.
+       */
+      page_true_self_subtitle?: string;
+      /**
+       * Slide 3 title (e.g. 'Unlock your potential').
+       */
+      page_unlock_potential_title?: string;
+      /**
+       * Slide 3 supporting copy.
+       */
+      page_unlock_potential_subtitle?: string;
+    };
     /**
      * Slide 2 title (e.g. 'Get to know your true self'). The 'true self' fragment is rendered as a bold inline span; the Flutter renderer may also apply an accent colour to bolded segments on this slide.
      */
@@ -5156,15 +5238,28 @@ export interface WmAppTranslation {
       };
       [k: string]: unknown;
     } | null;
-    consent_modal?:
-      | {
-          [k: string]: unknown;
-        }
-      | unknown[]
-      | string
-      | number
-      | boolean
-      | null;
+    consent_modal?: {
+      /**
+       * Modal title (e.g. 'Help spread the word').
+       */
+      title?: string;
+      /**
+       * Second paragraph explaining the benefits of granting consent (improving campaigns, using donations responsibly, suppressing ads to existing users, reaching similar people).
+       */
+      body_benefits?: string;
+      /**
+       * Fifth paragraph telling the user they can change this anytime via Settings → Privacy & advertising. Preserve the arrow character (→) or substitute the locale equivalent.
+       */
+      body_settings_hint?: string;
+      /**
+       * Primary CTA granting consent (sets adsMarketingConsent = true).
+       */
+      allow?: string;
+      /**
+       * Decline CTA. Decline is a single tap and must not block account creation (see analytics-simplified/05-flutter-implementation.md §9).
+       */
+      reject?: string;
+    };
     /**
      * Third paragraph listing categories that are never sent for advertising (mood, goals, hand sensations, reflections, class location, spiritual-practice details). Lead phrase 'We'll never share' is rendered as a bold inline span. Must remain consistent with the privacy filter in analytics-simplified/03-marketing-event-taxonomy.md §2.
      */
@@ -5221,192 +5316,1072 @@ export interface WmAppTranslation {
     } | null;
   };
   daily?: {
-    main?:
-      | {
-          [k: string]: unknown;
-        }
-      | unknown[]
-      | string
-      | number
-      | boolean
-      | null;
-    common?:
-      | {
-          [k: string]: unknown;
-        }
-      | unknown[]
-      | string
-      | number
-      | boolean
-      | null;
-    load_info?:
-      | {
-          [k: string]: unknown;
-        }
-      | unknown[]
-      | string
-      | number
-      | boolean
-      | null;
+    main?: {
+      /**
+       * Primary CTA on the hero card that begins the suggested meditation.
+       */
+      start_meditation?: string;
+      /**
+       * Compact CTA used on secondary cards to start a meditation immediately.
+       */
+      start_now?: string;
+      /**
+       * CTA on the Path promo card when the user has not started the course.
+       */
+      start_course?: string;
+      /**
+       * CTA on the Path promo card when the user has progress to resume.
+       */
+      continue_course?: string;
+      /**
+       * Long-form variant of start_course used in alternate layouts.
+       */
+      start_the_course?: string;
+      /**
+       * Long-form variant of continue_course used in alternate layouts.
+       */
+      continue_the_course?: string;
+      /**
+       * Accessibility / link label inviting the user to scroll down to the Path section.
+       */
+      scroll_to_the_path?: string;
+      /**
+       * Eyebrow label above the Path promo block (typically uppercase, e.g. 'THE PATH: GOING DEEPER').
+       */
+      the_path_going_deeper?: string;
+      /**
+       * Hero title used in the morning time-of-day variant.
+       */
+      your_morning_meditation?: string;
+      /**
+       * Hero title used in the afternoon time-of-day variant.
+       */
+      your_afternoon_meditation?: string;
+      /**
+       * Hero title used in the evening time-of-day variant.
+       */
+      your_evening_meditation?: string;
+      /**
+       * Hero subtitle for the morning variant. Preserve the embedded line break (\n) — it controls hero layout.
+       */
+      morning_meditation_subtitle?: string;
+      /**
+       * Hero subtitle for the afternoon variant. Preserve the embedded line break (\n).
+       */
+      afternoon_meditation_subtitle?: string;
+      /**
+       * Hero subtitle for the evening variant.
+       */
+      evening_meditation_subtitle?: string;
+      /**
+       * Title of the Path promo card on Home. Preserve the embedded line break (\n).
+       */
+      path_going_deeper_title?: string;
+      /**
+       * Subtitle of the Path promo card on Home.
+       */
+      path_going_deeper_subtitle?: string;
+      /**
+       * Eyebrow label above the Shri Mataji talks section on Home (typically uppercase).
+       */
+      learn_from_source?: string;
+      /**
+       * Eyebrow chip label on the hero card for pre-activation users (‘Get started’).
+       */
+      hero_label_get_started?: string;
+      /**
+       * Eyebrow chip label on the hero card encouraging variation.
+       */
+      hero_label_try_something_new?: string;
+      /**
+       * Eyebrow chip label on the hero card promoting Shri Mataji content.
+       */
+      hero_label_learn_from_source?: string;
+      /**
+       * Eyebrow chip label on the hero card promoting community sessions.
+       */
+      hero_label_meditate_with_others?: string;
+      /**
+       * Eyebrow chip label on the hero card promoting discovery / Explore.
+       */
+      hero_label_discover?: string;
+      /**
+       * Section title of the Shri Mataji talks block on Home.
+       */
+      shri_mataji_talks_title?: string;
+      /**
+       * Section subtitle of the Shri Mataji talks block on Home.
+       */
+      shri_mataji_talks_subtitle?: string;
+      /**
+       * Inline link/CTA to expand a section or view more items.
+       */
+      see_more?: string;
+      /**
+       * Eyebrow above the priority chooser on Home, daytime variant (typically uppercase).
+       */
+      whats_your_priority_today?: string;
+      /**
+       * Eyebrow above the priority chooser on Home, evening variant (typically uppercase).
+       */
+      whats_your_priority_tonight?: string;
+      /**
+       * Chip tag label categorising priority-chooser cards.
+       */
+      whats_your_priority_tag?: string;
+      /**
+       * Chip tag label categorising community-session cards.
+       */
+      meditate_with_others_tag?: string;
+      /**
+       * Chip tag label categorising improvement / techniques cards.
+       */
+      improve_meditation_tag?: string;
+      /**
+       * Quick-meditation card title (morning). Preserve the embedded line break (\n).
+       */
+      quick_morning?: string;
+      /**
+       * Quick-meditation card title (afternoon). Preserve the embedded line break (\n) and quoted punctuation.
+       */
+      quick_afternoon?: string;
+      /**
+       * Quick-meditation card title (evening). Preserve the embedded line break (\n).
+       */
+      quick_evening?: string;
+      /**
+       * Card title for the longer/personalised session. Preserve the embedded line break (\n).
+       */
+      longer_session?: string;
+      /**
+       * Card title inviting users to find a meditation matched to a current feeling. Preserve the embedded line break (\n).
+       */
+      help_me_deal?: string;
+      /**
+       * Title of the follow-up screen after the user taps the 'Help me deal' card. Preserve the embedded line break (\n).
+       */
+      help_me_deal_custom_title?: string;
+      /**
+       * Card title promoting deeper exploration of the practice. Preserve the embedded line break (\n).
+       */
+      explore_deeper?: string;
+      /**
+       * Locked-state label shown on cards gated behind the first meditation.
+       */
+      unlock_guided_meditations?: string;
+      /**
+       * Eyebrow above the community block on Home (typically uppercase).
+       */
+      meditate_with_others?: string;
+      /**
+       * Community card inviting the user to find a local in-person class. Preserve the embedded line break (\n).
+       */
+      find_class_near_you?: string;
+      /**
+       * Community card inviting the user to join a live online class. Preserve the embedded line break (\n).
+       */
+      join_live_online_class?: string;
+      /**
+       * Eyebrow above the improvement / techniques block on Home (typically uppercase).
+       */
+      improve_your_meditation?: string;
+      /**
+       * Title of the Techniques card in the Improve block.
+       */
+      improve_card_techniques_title?: string;
+      /**
+       * Subtitle of the Techniques card in the Improve block.
+       */
+      improve_card_techniques_subtitle?: string;
+      /**
+       * Title of the Subtle System card in the Improve block.
+       */
+      improve_card_subtle_system_title?: string;
+      /**
+       * Subtitle of the Subtle System card in the Improve block.
+       */
+      improve_card_subtle_system_subtitle?: string;
+      /**
+       * Eyebrow above the Highlights carousel on Home (typically uppercase).
+       */
+      highlights_title?: string;
+      /**
+       * Title used on the resume-card prompting the user back into the flow. Preserve the embedded line break (\n).
+       */
+      get_back_in_the_flow?: string;
+      /**
+       * Badge shown on the live-meditation card when a live session is currently in progress.
+       */
+      live_now?: string;
+      /**
+       * Short abbreviation for minutes used in card chips (e.g. 'min').
+       */
+      minutes_short?: string;
+      /**
+       * Unit label for the days portion of the live-meditation countdown.
+       */
+      live_countdown_days?: string;
+      /**
+       * Unit label for the hours portion of the live-meditation countdown.
+       */
+      live_countdown_hours?: string;
+      /**
+       * Unit label for the minutes portion of the live-meditation countdown.
+       */
+      live_countdown_minutes?: string;
+      /**
+       * Label shown on the live-meditation reminder button when a 30-minute reminder is already scheduled.
+       */
+      live_reminder_button_active?: string;
+      /**
+       * Title of the scheduled local notification that reminds the user about an upcoming live meditation.
+       */
+      live_reminder_notification_title?: string;
+      /**
+       * Body of the scheduled local notification that reminds the user about an upcoming live meditation.
+       */
+      live_reminder_notification_body?: string;
+      /**
+       * Inline message shown after the user denies the notification permission required for live-meditation reminders.
+       */
+      live_reminder_permission_denied?: string;
+      /**
+       * Inline message asking the user to enable notifications in OS Settings to receive live-meditation reminders.
+       */
+      live_reminder_permission_settings?: string;
+    };
+    common?: {
+      /**
+       * Locked-state message shown on Home cards that are gated behind completing the first meditation.
+       */
+      unlock_after_first_meditation?: string;
+      /**
+       * Placeholder shown when the Path tile on Home is not yet available for the current user/locale.
+       */
+      path_coming_soon?: string;
+      /**
+       * Generic error message shown on Home when a section fails to load.
+       */
+      something_went_wrong?: string;
+      /**
+       * Retry CTA used on Home error states.
+       */
+      retry?: string;
+      /**
+       * Toast shown when an external link card on Home is not yet wired up.
+       */
+      external_link_coming_soon?: string;
+      /**
+       * Toast shown when tapping a Home card whose action is not yet implemented.
+       */
+      card_action_not_available?: string;
+      /**
+       * Placeholder shown for the in-person class finder on Home before the feature ships.
+       */
+      map_coming_soon?: string;
+      /**
+       * Placeholder shown for the music section on Home before the feature ships.
+       */
+      music_coming_soon?: string;
+    };
+    load_info?: {
+      /**
+       * Banner shown when the hero Daily meditation could not be resolved at all.
+       */
+      top_daily_unavailable?: string;
+      /**
+       * Banner shown when the hero Daily meditation failed to load due to a network or content error.
+       */
+      top_daily_failed?: string;
+      /**
+       * Banner shown when the hero Daily meditation has been replaced by a random meditation fallback.
+       */
+      top_daily_random?: string;
+      /**
+       * Banner shown when the Quick meditations row could not be resolved.
+       */
+      quick_daily_unavailable?: string;
+      /**
+       * Banner shown when the Quick meditations row failed to load.
+       */
+      quick_daily_failed?: string;
+      /**
+       * Banner shown when the Quick meditations row has been replaced by random fallbacks.
+       */
+      quick_daily_random?: string;
+    };
   };
   path?: {
-    overview?:
-      | {
-          [k: string]: unknown;
-        }
-      | unknown[]
-      | string
-      | number
-      | boolean
-      | null;
-    info?:
-      | {
-          [k: string]: unknown;
-        }
-      | unknown[]
-      | string
-      | number
-      | boolean
-      | null;
-    step_1?:
-      | {
-          [k: string]: unknown;
-        }
-      | unknown[]
-      | string
-      | number
-      | boolean
-      | null;
-    step_2?:
-      | {
-          [k: string]: unknown;
-        }
-      | unknown[]
-      | string
-      | number
-      | boolean
-      | null;
-    step_3?:
-      | {
-          [k: string]: unknown;
-        }
-      | unknown[]
-      | string
-      | number
-      | boolean
-      | null;
-    step_4?:
-      | {
-          [k: string]: unknown;
-        }
-      | unknown[]
-      | string
-      | number
-      | boolean
-      | null;
-    step_complete?:
-      | {
-          [k: string]: unknown;
-        }
-      | unknown[]
-      | string
-      | number
-      | boolean
-      | null;
+    overview?: {
+      /**
+       * Error message shown when the Path tab fails to load.
+       */
+      error_message?: string;
+      /**
+       * Eyebrow label above each unit on the Path overview (typically uppercase, e.g. 'UNIT').
+       */
+      unit?: string;
+      /**
+       * Retry CTA on the Path error state.
+       */
+      retry?: string;
+      /**
+       * Placeholder shown at the bottom of the Path when no further steps are released yet (typically uppercase).
+       */
+      more_steps_coming_soon?: string;
+    };
+    info?: {
+      /**
+       * Carousel slide 1 title.
+       */
+      first_title?: string;
+      /**
+       * Carousel slide 1 body. Two paragraphs separated by \\n\\n in the source.
+       */
+      first_text?: string;
+      /**
+       * Carousel slide 2 title.
+       */
+      second_title?: string;
+      /**
+       * Carousel slide 2 body. Two paragraphs separated by \\n\\n in the source.
+       */
+      second_text?: string;
+      /**
+       * Carousel slide 3 title.
+       */
+      third_title?: string;
+      /**
+       * Carousel slide 3 body. Two paragraphs separated by \\n\\n in the source.
+       */
+      third_text?: string;
+    };
+    step_1?: {
+      /**
+       * Default intro quote used when no CMS-driven quote is available.
+       */
+      default_intro_quote?: string;
+      /**
+       * Attribution under the intro quote.
+       */
+      author?: string;
+      /**
+       * Primary CTA that begins step 1.
+       */
+      begin?: string;
+      /**
+       * Title of the exit-confirmation prompt shown when the user tries to leave step 1 early.
+       */
+      skip_title?: string;
+      /**
+       * CTA on the exit-confirmation prompt that keeps the user inside step 1.
+       */
+      skip_continue?: string;
+      /**
+       * CTA on the exit-confirmation prompt that returns the user to the Path overview.
+       */
+      back_to_path?: string;
+    };
+    step_2?: {
+      /**
+       * Continue CTA used in step 2 screens.
+       */
+      continue_button?: string;
+    };
+    step_3?: {
+      /**
+       * Eyebrow above the step 3 meditation intro (typically uppercase).
+       */
+      meditation_intro?: string;
+      /**
+       * Default calm copy shown before a Path step's meditation or video starts (e.g. 'find a quiet place\ntake a breath'). Used when a step does not override it via the lesson's preMeditationLines field. Preserve the embedded line breaks (\n) — they are intentional and control where each line wraps.
+       */
+      pre_meditation_lines?: string;
+      /**
+       * Inline action that opens the skip-intro confirmation.
+       */
+      skip_intro?: string;
+      /**
+       * Primary CTA that starts the step 3 meditation.
+       */
+      start_meditation?: string;
+      /**
+       * Title of the skip-intro confirmation prompt.
+       */
+      skip_title?: string;
+      /**
+       * Confirm CTA on the skip-intro prompt that jumps to the meditation.
+       */
+      skip_continue?: string;
+      /**
+       * Decline CTA on the skip-intro prompt that returns to the intro.
+       */
+      back_to_intro?: string;
+      /**
+       * Exit CTA used on the step 3 screen.
+       */
+      exit?: string;
+      /**
+       * Back CTA returning the user to the step overview.
+       */
+      back_to_step?: string;
+    };
+    step_4?: {
+      /**
+       * Eyebrow on the step 4 screen (typically uppercase).
+       */
+      delving_deeper?: string;
+      /**
+       * Prompt above the lecture media inviting the user to keep meditating while listening.
+       */
+      lecture_prompt?: string;
+      /**
+       * Fallback title used on the lecture media card when no CMS-driven title is available. Source uses curly quotes “” intentionally.
+       */
+      media_card_fallback_title?: string;
+      /**
+       * Author label on the lecture media card (e.g. 'Talk by Shri Mataji').
+       */
+      media_card_author?: string;
+      /**
+       * Author subtitle on the lecture media card (e.g. 'The founder of Sahaja Yoga').
+       */
+      media_card_author_subtitle?: string;
+      /**
+       * Secondary CTA on the lecture media card.
+       */
+      media_card_watch_later?: string;
+      /**
+       * Primary CTA that completes step 4.
+       */
+      complete_step?: string;
+    };
+    step_complete?: {
+      /**
+       * Title of the step-complete confirmation.
+       */
+      title?: string;
+      /**
+       * Subtitle of the step-complete confirmation.
+       */
+      subtitle?: string;
+      /**
+       * CTA returning the user to the Path overview after completing a step.
+       */
+      back_to_path?: string;
+    };
   };
   explore?: {
-    overview?:
-      | {
-          [k: string]: unknown;
-        }
-      | unknown[]
-      | string
-      | number
-      | boolean
-      | null;
-    subtle_system?:
-      | {
-          [k: string]: unknown;
-        }
-      | unknown[]
-      | string
-      | number
-      | boolean
-      | null;
-    talks_intro?:
-      | {
-          [k: string]: unknown;
-        }
-      | unknown[]
-      | string
-      | number
-      | boolean
-      | null;
-    talks_list?:
-      | {
-          [k: string]: unknown;
-        }
-      | unknown[]
-      | string
-      | number
-      | boolean
-      | null;
-    talks_player?:
-      | {
-          [k: string]: unknown;
-        }
-      | unknown[]
-      | string
-      | number
-      | boolean
-      | null;
+    overview?: {
+      /**
+       * Eyebrow label for the embedded Explore block.
+       */
+      section_label?: string;
+      /**
+       * Section header for the Meditate column.
+       */
+      section_meditate_title?: string;
+      /**
+       * Section header for the Learn column.
+       */
+      section_learn_title?: string;
+      /**
+       * Section header for the Join Free Classes column.
+       */
+      section_join_title?: string;
+      /**
+       * Card title for the Daily entry in the Explore block.
+       */
+      card_daily_title?: string;
+      /**
+       * Card subtitle for the Daily entry in the Explore block.
+       */
+      card_daily_subtitle?: string;
+      /**
+       * Card title for the Path entry in the Explore block.
+       */
+      card_path_title?: string;
+      /**
+       * Card subtitle for the Path entry in the Explore block.
+       */
+      card_path_subtitle?: string;
+      /**
+       * Card title for the Techniques entry in the Explore block.
+       */
+      card_techniques_title?: string;
+      /**
+       * Card subtitle for the Techniques entry in the Explore block.
+       */
+      card_techniques_subtitle?: string;
+      /**
+       * Card title for the Vibes Check entry in the Explore block.
+       */
+      card_vibes_check_title?: string;
+      /**
+       * Card subtitle for the Vibes Check entry in the Explore block.
+       */
+      card_vibes_check_subtitle?: string;
+      /**
+       * Card title for the Music for Meditation entry in the Explore block.
+       */
+      card_music_title?: string;
+      /**
+       * Card title for the Challenges entry in the Explore block.
+       */
+      card_challenges_title?: string;
+      /**
+       * Card title for the Shri Mataji Talks entry in the Explore block. Preserve the embedded line break (\n).
+       */
+      card_talks_title?: string;
+      /**
+       * Card title for the Subtle System entry in the Explore block.
+       */
+      card_subtle_system_title?: string;
+      /**
+       * Card title for the 'Who is Shri Mataji' entry in the Explore block. Preserve the embedded line break (\n).
+       */
+      card_who_is_title?: string;
+      /**
+       * Card title for the 'What is Sahaja Yoga?' entry in the Explore block.
+       */
+      card_what_is_title?: string;
+      /**
+       * Card title for the Live Online Classes entry in the Explore block. Preserve the embedded line break (\n).
+       */
+      card_live_online_title?: string;
+      /**
+       * Card title for the in-person class finder entry in the Explore block. Preserve the embedded line break (\n).
+       */
+      card_find_classes_title?: string;
+      /**
+       * Generic 'Coming soon' badge used on locked Explore-block cards.
+       */
+      card_coming_soon?: string;
+    };
+    subtle_system?: {
+      /**
+       * Eyebrow / route label for the subtle-system screen.
+       */
+      screen_label?: string;
+      /**
+       * Diagram title.
+       */
+      diagram_title?: string;
+      /**
+       * Diagram subtitle prompting the user to tap to learn more.
+       */
+      diagram_subtitle?: string;
+      /**
+       * Tab label switching the diagram to chakra view.
+       */
+      mode_chakras?: string;
+      /**
+       * Tab label switching the diagram to channel view.
+       */
+      mode_channels?: string;
+      /**
+       * Caption clarifying that the diagram shows a front view (left/right are mirrored relative to the viewer).
+       */
+      front_view_mirrored?: string;
+      /**
+       * Filter chip label for the Right channel.
+       */
+      chip_right?: string;
+      /**
+       * Filter chip label for the Center channel.
+       */
+      chip_center?: string;
+      /**
+       * Filter chip label for the Left channel.
+       */
+      chip_left?: string;
+      /**
+       * Detail label for the Right Aspect of a chakra.
+       */
+      aspect_right?: string;
+      /**
+       * Detail label for the Center Aspect of a chakra.
+       */
+      aspect_center?: string;
+      /**
+       * Detail label for the Left Aspect of a chakra.
+       */
+      aspect_left?: string;
+    };
+    talks_intro?: {
+      /**
+       * Inline message when a talk is temporarily unavailable to play.
+       */
+      unavailable?: string;
+      /**
+       * Title of the talks intro screen.
+       */
+      title?: string;
+      /**
+       * Long-form description of Shri Mataji and Sahaja Yoga used as fallback intro copy when a specific talk-clip description is unavailable.
+       */
+      generic_description?: string;
+      /**
+       * Short clip-level description shown before a specific talk clip starts.
+       */
+      clip_description?: string;
+      /**
+       * Speaker name shown on the talk card placed after the first meditation (e.g. 'Shri Mataji,'). The trailing comma is intentional — it precedes the role line.
+       */
+      post_first_meditation_name?: string;
+      /**
+       * Speaker role/subtitle on the post-first-meditation talk card (e.g. 'The founder of Sahaja Yoga').
+       */
+      post_first_meditation_subtitle?: string;
+      /**
+       * Body copy on the post-first-meditation talk card.
+       */
+      post_first_meditation_description?: string;
+      /**
+       * Primary CTA that begins the talk.
+       */
+      start?: string;
+      /**
+       * Decline CTA on the post-first-meditation talk card.
+       */
+      maybe_later?: string;
+      /**
+       * Alternative CTA used on inline talk placements.
+       */
+      watch_now?: string;
+    };
+    talks_list?: {
+      /**
+       * Eyebrow / route title for the talks list screen (typically uppercase).
+       */
+      screen_title?: string;
+      /**
+       * Section title above the list.
+       */
+      section_title?: string;
+      /**
+       * Section description above the list.
+       */
+      description?: string;
+      /**
+       * Default filter chip label ('All tags').
+       */
+      all_tags?: string;
+      /**
+       * Inline link/CTA opening more information about a talk.
+       */
+      learn_more?: string;
+      /**
+       * Card CTA that begins a talk.
+       */
+      start?: string;
+      /**
+       * Status label shown on talks that the user has already watched.
+       */
+      watched?: string;
+    };
+    talks_player?: {
+      /**
+       * Error message shown when the player cannot load the requested talk.
+       */
+      unavailable?: string;
+      /**
+       * Player play-control label.
+       */
+      play?: string;
+      /**
+       * Player pause-control label.
+       */
+      pause?: string;
+      /**
+       * Player replay-control label.
+       */
+      replay?: string;
+      /**
+       * Title of the subtitles bottom sheet.
+       */
+      subtitles_title?: string;
+      /**
+       * Subtitles option label disabling captions.
+       */
+      subtitles_off?: string;
+      /**
+       * Subtitles language label — English.
+       */
+      subtitles_english?: string;
+      /**
+       * Subtitles language label — Turkish.
+       */
+      subtitles_turkish?: string;
+      /**
+       * Subtitles language label — Bulgarian.
+       */
+      subtitles_bulgarian?: string;
+      /**
+       * Subtitles language label — Brazilian Portuguese.
+       */
+      subtitles_portuguese_brazil?: string;
+      /**
+       * Subtitles language label — French.
+       */
+      subtitles_french?: string;
+      /**
+       * Subtitles language label — Spanish.
+       */
+      subtitles_spanish?: string;
+    };
   };
   profile?: {
-    main?:
-      | {
-          [k: string]: unknown;
-        }
-      | unknown[]
-      | string
-      | number
-      | boolean
-      | null;
-    favourites?:
-      | {
-          [k: string]: unknown;
-        }
-      | unknown[]
-      | string
-      | number
-      | boolean
-      | null;
-    history?:
-      | {
-          [k: string]: unknown;
-        }
-      | unknown[]
-      | string
-      | number
-      | boolean
-      | null;
-    account?:
-      | {
-          [k: string]: unknown;
-        }
-      | unknown[]
-      | string
-      | number
-      | boolean
-      | null;
-    privacy?:
-      | {
-          [k: string]: unknown;
-        }
-      | unknown[]
-      | string
-      | number
-      | boolean
-      | null;
+    main?: {
+      /**
+       * Eyebrow above the favourites preview block on Profile (typically uppercase).
+       */
+      favourites_header?: string;
+      /**
+       * Inline link expanding a preview block to its full screen.
+       */
+      see_all?: string;
+      /**
+       * Empty-state title in the favourites preview block.
+       */
+      no_favourites_title?: string;
+      /**
+       * Empty-state subtitle in the favourites preview block.
+       */
+      no_favourites_subtitle?: string;
+      /**
+       * Title of the History entry in the Profile menu.
+       */
+      history_title?: string;
+      /**
+       * Subtitle of the History entry in the Profile menu.
+       */
+      history_subtitle?: string;
+      /**
+       * Title of the Account entry in the Profile menu.
+       */
+      account_title?: string;
+      /**
+       * Subtitle of the Account entry in the Profile menu.
+       */
+      account_subtitle?: string;
+      /**
+       * Title of the Privacy & advertising entry in the Profile menu — opens the consent settings screen (see consent.settings).
+       */
+      privacy_and_advertising_title?: string;
+      /**
+       * Subtitle of the Privacy & Advertising entry in the Profile menu (e.g. 'Privacy choices and ad preferences').
+       */
+      privacy_and_advertising_subtitle?: string;
+      /**
+       * Eyebrow above the feedback block on Profile (typically uppercase).
+       */
+      feedback_header?: string;
+      /**
+       * Title of the Contact us entry in the Profile menu.
+       */
+      contact_title?: string;
+      /**
+       * Subtitle of the Contact us entry in the Profile menu.
+       */
+      contact_subtitle?: string;
+      /**
+       * Fallback joined-date string when no usable creation timestamp is available.
+       */
+      joined_fallback?: string;
+      /**
+       * Joined-date string for exactly one month ago (singular).
+       */
+      joined_one_month?: string;
+      /**
+       * Joined-date string for the multi-month range. MUST preserve the {months} placeholder — it is replaced at runtime with the month count.
+       */
+      joined_months?: string;
+      /**
+       * Joined-date string for less than a year ago (fallback before the months-since helper).
+       */
+      joined_less_than_year?: string;
+      /**
+       * Joined-date string for exactly one year ago (singular).
+       */
+      joined_one_year?: string;
+      /**
+       * Joined-date string for multiple years ago. MUST preserve the {years} placeholder — it is replaced at runtime with the year count.
+       */
+      joined_years?: string;
+      /**
+       * Section header above the legal-page navigation rows in the Profile menu (typically capitalised, e.g. 'LEGAL'). Sits between the Contact-us feedback row and the Privacy Policy / Terms & Conditions / Privacy & Advertising rows.
+       */
+      legal_header?: string;
+      /**
+       * Title of the Privacy Policy entry in the Profile menu's Legal section. Tapping opens the Privacy Policy page (CMS page id 73).
+       */
+      privacy_policy_title?: string;
+      /**
+       * Subtitle of the Privacy Policy entry in the Profile menu's Legal section (e.g. 'How we collect and use data').
+       */
+      privacy_policy_subtitle?: string;
+      /**
+       * Title of the Terms & Conditions entry in the Profile menu's Legal section. Tapping opens the Terms & Conditions page (CMS page id 76).
+       */
+      terms_and_conditions_title?: string;
+      /**
+       * Subtitle of the Terms & Conditions entry in the Profile menu's Legal section (e.g. 'Legal terms for using WeMeditate').
+       */
+      terms_and_conditions_subtitle?: string;
+    };
+    favourites?: {
+      /**
+       * Screen title (typically uppercase).
+       */
+      title?: string;
+      /**
+       * Snackbar shown after a favourite is removed (paired with the global Undo action from the general group).
+       */
+      removed_from_favourites?: string;
+    };
+    history?: {
+      /**
+       * Screen title (typically uppercase).
+       */
+      title?: string;
+      /**
+       * Empty-state title when the user has no history entries.
+       */
+      empty_title?: string;
+      /**
+       * Empty-state subtitle when the user has no history entries.
+       */
+      empty_subtitle?: string;
+    };
+    account?: {
+      /**
+       * Screen title.
+       */
+      title?: string;
+      /**
+       * Eyebrow above the details block (typically uppercase).
+       */
+      details_header?: string;
+      /**
+       * Label for the name input.
+       */
+      name_label?: string;
+      /**
+       * Placeholder hint for the name input.
+       */
+      name_hint?: string;
+      /**
+       * Save CTA used on inline forms.
+       */
+      save?: string;
+      /**
+       * Loading-state label shown on the Save CTA while saving.
+       */
+      saving?: string;
+      /**
+       * Confirmation toast shown after settings are saved.
+       */
+      saved?: string;
+      /**
+       * Label used by the dedicated first-name edit row.
+       */
+      first_name_label?: string;
+      /**
+       * Label used by the email row.
+       */
+      email_label?: string;
+      /**
+       * Label used by the password row.
+       */
+      password_label?: string;
+      /**
+       * Edit CTA used on read-only rows that open an edit modal.
+       */
+      edit_action?: string;
+      /**
+       * Title of the edit-first-name modal.
+       */
+      edit_first_name_title?: string;
+      /**
+       * Title of the edit-email modal.
+       */
+      edit_email_title?: string;
+      /**
+       * Cancel CTA used in edit modals.
+       */
+      cancel?: string;
+      /**
+       * Primary CTA in edit modals.
+       */
+      save_changes?: string;
+      /**
+       * Error shown when saving account settings fails.
+       */
+      save_failed?: string;
+      /**
+       * Title of the reset-password modal.
+       */
+      reset_password_title?: string;
+      /**
+       * Body copy of the reset-password modal.
+       */
+      reset_password_description?: string;
+      /**
+       * Primary CTA in the reset-password modal.
+       */
+      reset_password_action?: string;
+      /**
+       * Confirmation toast shown after the reset link has been emailed.
+       */
+      reset_password_sent?: string;
+      /**
+       * Error shown when sending the reset link fails.
+       */
+      reset_password_error?: string;
+      /**
+       * Toast shown when email editing is not yet available.
+       */
+      email_edit_unavailable?: string;
+      /**
+       * Inline placeholder shown when no email is available for the account.
+       */
+      email_unavailable?: string;
+      /**
+       * CTA shown for guest users prompting them to create an account.
+       */
+      create_account?: string;
+      /**
+       * Title of the delete-account confirmation.
+       */
+      delete_account_title?: string;
+      /**
+       * Body copy of the delete-account confirmation.
+       */
+      delete_account_description?: string;
+      /**
+       * Error shown when delete-account fails.
+       */
+      delete_account_error?: string;
+      /**
+       * Error shown when delete-account requires the user to log in again first.
+       */
+      delete_account_requires_recent_login?: string;
+      /**
+       * Title of the password re-entry modal used before destructive actions.
+       */
+      reauthenticate_title?: string;
+      /**
+       * Body copy of the password re-entry modal.
+       */
+      reauthenticate_description?: string;
+      /**
+       * Validation error shown when the password field is empty in the re-entry modal.
+       */
+      reauthenticate_required?: string;
+      /**
+       * Error shown when the re-entered password is incorrect.
+       */
+      reauthenticate_invalid?: string;
+      /**
+       * Primary CTA on the password re-entry modal.
+       */
+      continue_action?: string;
+      /**
+       * Inline prompt shown on the email row for guest users.
+       */
+      guest_email_prompt?: string;
+      /**
+       * Inline prompt shown on the password row for guest users.
+       */
+      guest_password_prompt?: string;
+      /**
+       * Login CTA used in the guest prompts.
+       */
+      login?: string;
+      /**
+       * Logout CTA in the account screen.
+       */
+      logout?: string;
+      /**
+       * Inline link opening the Privacy Policy webview from the account screen.
+       */
+      privacy_policy?: string;
+      /**
+       * Destructive CTA opening the delete-account flow.
+       */
+      delete_account?: string;
+    };
+    privacy?: {
+      /**
+       * Screen title (e.g. 'Help spread the word and make the app better').
+       */
+      screen_title?: string;
+      /**
+       * Status label shown next to a toggle that is currently allowed. MUST preserve the {date} placeholder — it is replaced at runtime with the localized date of the most recent consent decision (e.g. '16 May 2026').
+       */
+      status_allowed?: string;
+      /**
+       * Status label shown next to a toggle that is currently disallowed.
+       */
+      status_not_allowed?: string;
+      /**
+       * Section title for the anonymous product analytics toggle (e.g. 'Anonymous product analytics'). Drives productAnalyticsOptOut.
+       */
+      product_analytics_title?: string;
+      /**
+       * Section body explaining anonymous product analytics: we log aggregated usage data to fix bugs and improve We Meditate, no individual data, no advertisers, no user profile. Must remain consistent with the TelemetryDeck posture in analytics-simplified/01-strategy.md §4.
+       */
+      product_analytics_description?: string;
+      /**
+       * Section title for the advertising-measurement toggle (e.g. 'Advertising measurement and improvement'). Drives adsMarketingConsent.
+       */
+      advertising_title?: string;
+      /**
+       * Second paragraph of the advertising section: how granting consent helps WeMeditate use donations responsibly, improve campaigns, suppress ads to existing users, and reach similar people.
+       */
+      advertising_body_benefits?: string;
+      /**
+       * Fourth paragraph of the advertising section explaining that the user can change their choice anytime using the toggle at the top of this screen.
+       */
+      advertising_body_change_hint?: string;
+      /**
+       * Sub-section header listing current advertising platforms (e.g. 'Current advertising platforms').
+       */
+      advertising_platforms_header?: string;
+      /**
+       * Bullet item for Meta (Facebook + Instagram + Audience Network). Brand name — usually kept as 'Meta'.
+       */
+      advertising_platform_meta?: string;
+      /**
+       * Bullet item for Google Ads. Brand name — usually kept as 'Google Ads'.
+       */
+      advertising_platform_google_ads?: string;
+      /**
+       * Bullet item for Apple Search Ads. Brand name — usually kept as 'Apple Search Ads'.
+       */
+      advertising_platform_apple_search_ads?: string;
+      /**
+       * Section header above the legal-page navigation rows at the bottom of the Privacy & Advertising screen (e.g. 'Learn more'). Below this header sit the Privacy Policy and Terms & Conditions rows, which reuse the same labels as the Profile-tab Legal section.
+       */
+      learn_more_header?: string;
+      /**
+       * Title of the Privacy Policy row in the Learn-more section at the bottom of the Privacy & Advertising screen. Tapping opens the Privacy Policy page (CMS page id 73). Reuses the same English label as profile_main.privacy_policy_title.
+       */
+      privacy_policy_title?: string;
+      /**
+       * Subtitle of the Privacy Policy row in the Learn-more section (e.g. 'How we collect and use data').
+       */
+      privacy_policy_subtitle?: string;
+      /**
+       * Title of the Terms & Conditions row in the Learn-more section at the bottom of the Privacy & Advertising screen. Tapping opens the Terms & Conditions page (CMS page id 76).
+       */
+      terms_and_conditions_title?: string;
+      /**
+       * Subtitle of the Terms & Conditions row in the Learn-more section (e.g. 'Legal terms for using WeMeditate').
+       */
+      terms_and_conditions_subtitle?: string;
+    };
     /**
      * Third paragraph of the advertising section. Covers both the never-shared categories AND the never-sell statement in a single paragraph with two bold spans ('We'll never share' / 'we never sell'). Must remain consistent with analytics-simplified/03-marketing-event-taxonomy.md §2.
      */
@@ -5443,44 +6418,360 @@ export interface WmAppTranslation {
       };
       [k: string]: unknown;
     } | null;
-    contact?:
-      | {
-          [k: string]: unknown;
-        }
-      | unknown[]
-      | string
-      | number
-      | boolean
-      | null;
+    contact?: {
+      /**
+       * Screen title (typically uppercase).
+       */
+      title?: string;
+      /**
+       * Hero copy above the form.
+       */
+      header?: string;
+      /**
+       * Subtitle below the hero copy.
+       */
+      subtitle?: string;
+      /**
+       * Input field placeholder hint for the feedback text area.
+       */
+      placeholder?: string;
+      /**
+       * Submit CTA on the form.
+       */
+      send?: string;
+      /**
+       * Loading-state label shown on the Submit CTA while sending.
+       */
+      sending?: string;
+      /**
+       * Confirmation toast shown after the feedback is sent.
+       */
+      sent?: string;
+      /**
+       * Validation error shown when the feedback field is empty.
+       */
+      empty_error?: string;
+      /**
+       * Validation error shown when the feedback is shorter than the minimum length (50 characters).
+       */
+      min_length_error?: string;
+      /**
+       * Error shown when sending the feedback fails.
+       */
+      send_error?: string;
+    };
   };
   meditation?: {
-    intent?:
-      | {
-          [k: string]: unknown;
-        }
-      | unknown[]
-      | string
-      | number
-      | boolean
-      | null;
-    reminder?:
-      | {
-          [k: string]: unknown;
-        }
-      | unknown[]
-      | string
-      | number
-      | boolean
-      | null;
-    footsoak?:
-      | {
-          [k: string]: unknown;
-        }
-      | unknown[]
-      | string
-      | number
-      | boolean
-      | null;
+    intent?: {
+      /**
+       * Continue CTA on the intent carousel.
+       */
+      carousel_continue?: string;
+      /**
+       * Skip-link shown over the intent video that lets the user proceed without watching.
+       */
+      skip_video_and_continue?: string;
+      /**
+       * Replay-link shown after the intent video ends.
+       */
+      repeat_video?: string;
+      /**
+       * Primary CTA that starts the actual meditation after the intent flow.
+       */
+      start_meditation?: string;
+      /**
+       * Tertiary CTA letting a new user skip the first meditation and just browse the app. Tied to the onboarding_ready_action / skip_and_explore_app_press analytics event.
+       */
+      skip_and_explore_the_app?: string;
+      /**
+       * Step indicator (e.g. 'Step 1 of 3') at the top of the intent flow.
+       */
+      step_label?: string;
+      /**
+       * Intent screen title shown during the day. Preserve the embedded line break (\n).
+       */
+      title_today?: string;
+      /**
+       * Intent screen title shown in the evening. Preserve the embedded line break (\n).
+       */
+      title_tonight?: string;
+      /**
+       * Title of the locked first-meditation card before activation.
+       */
+      first_meditation_title?: string;
+      /**
+       * Subtitle of the locked first-meditation card.
+       */
+      first_meditation_subtitle?: string;
+      /**
+       * Title shown when a returning user is invited to repeat the first meditation.
+       */
+      repeat_first_meditation_title?: string;
+      /**
+       * Subtitle shown when a returning user is invited to repeat the first meditation.
+       */
+      repeat_first_meditation_subtitle?: string;
+      /**
+       * Title shown on the 'ready to try?' confirmation step before starting the first meditation.
+       */
+      ready_to_try_title?: string;
+      /**
+       * Subtitle for the 'ready to try?' step, beginner variant.
+       */
+      ready_to_try_subtitle_beginner?: string;
+      /**
+       * Subtitle for the 'ready to try?' step, repeat variant.
+       */
+      ready_to_try_subtitle_repeat?: string;
+      /**
+       * Title of the morning quick-meditation card in the intent flow.
+       */
+      quick_morning_title?: string;
+      /**
+       * Title of the afternoon quick-meditation card in the intent flow.
+       */
+      quick_afternoon_title?: string;
+      /**
+       * Title of the evening quick-meditation card in the intent flow.
+       */
+      quick_evening_title?: string;
+      /**
+       * Subtitle of the morning quick-meditation card.
+       */
+      quick_morning_subtitle?: string;
+      /**
+       * Subtitle of the afternoon quick-meditation card. Preserve the embedded line break (\n).
+       */
+      quick_afternoon_subtitle?: string;
+      /**
+       * Subtitle of the evening quick-meditation card.
+       */
+      quick_evening_subtitle?: string;
+      /**
+       * Title of the personalised long-session card in the intent flow.
+       */
+      personalized_title?: string;
+      /**
+       * Subtitle of the personalised long-session card.
+       */
+      personalized_subtitle?: string;
+      /**
+       * Subtitle shown on cards that are locked until the user completes their first meditation.
+       */
+      locked_subtitle?: string;
+      /**
+       * Inline link/CTA used on intent-flow cards to view more detail.
+       */
+      learn_more?: string;
+      /**
+       * CTA on a locked card that takes the user back to the first meditation flow.
+       */
+      go_to_first_meditation?: string;
+      /**
+       * CTA opening the 'schedule for later' bottom sheet.
+       */
+      set_reminder_for_later?: string;
+      /**
+       * Title shown in the locked-preview card for Quick meditations (‘Start right away’).
+       */
+      locked_quick_start_title?: string;
+      /**
+       * Locked-preview description for morning Quick meditations.
+       */
+      locked_quick_start_description_morning?: string;
+      /**
+       * Locked-preview description for afternoon Quick meditations.
+       */
+      locked_quick_start_description_afternoon?: string;
+      /**
+       * Locked-preview description for evening Quick meditations.
+       */
+      locked_quick_start_description_evening?: string;
+      /**
+       * Title of the custom-time row in the Quick locked preview.
+       */
+      locked_quick_custom_time_title?: string;
+      /**
+       * Description of the custom-time row in the Quick locked preview.
+       */
+      locked_quick_custom_time_description?: string;
+      /**
+       * Title of the feeling-picker row in the Personalised locked preview.
+       */
+      locked_personalized_feeling_title?: string;
+      /**
+       * Description of the feeling-picker row in the Personalised locked preview.
+       */
+      locked_personalized_feeling_description?: string;
+      /**
+       * Title of the custom-time row in the Personalised locked preview.
+       */
+      locked_personalized_custom_time_title?: string;
+      /**
+       * Description of the custom-time row in the Personalised locked preview.
+       */
+      locked_personalized_custom_time_description?: string;
+    };
+    reminder?: {
+      /**
+       * Title of the prompt that suggests scheduling the first meditation for later. Preserve the embedded line break (\n).
+       */
+      prompt_title?: string;
+      /**
+       * Subtitle of the same scheduling prompt. Preserve the embedded line break (\n).
+       */
+      prompt_subtitle?: string;
+      /**
+       * Primary CTA on the scheduling prompt.
+       */
+      prompt_set_reminder?: string;
+      /**
+       * Decline CTA on the scheduling prompt.
+       */
+      prompt_no_thanks?: string;
+      /**
+       * Title of the rationale screen explaining why notification permission is needed before showing the OS prompt.
+       */
+      prompt_allow_notifications_title?: string;
+      /**
+       * Subtitle of the same rationale screen. References the wording on the next (OS) screen — keep 'Allow' consistent with the OS prompt translation if locale-specific.
+       */
+      prompt_allow_notifications_subtitle?: string;
+      /**
+       * Primary CTA on the notification-rationale screen that triggers the OS permission prompt.
+       */
+      prompt_allow_notifications_primary?: string;
+      /**
+       * Decline CTA on the notification-rationale screen.
+       */
+      prompt_not_now?: string;
+      /**
+       * Title shown when notifications were previously denied and need to be re-enabled from OS Settings.
+       */
+      prompt_turn_on_notifications_title?: string;
+      /**
+       * Subtitle of the same 'open Settings' prompt.
+       */
+      prompt_turn_on_notifications_subtitle?: string;
+      /**
+       * CTA that deep-links to the app’s OS notification settings.
+       */
+      prompt_open_settings?: string;
+      /**
+       * Title of the bottom sheet where the user picks a reminder time. Preserve the embedded line break (\n).
+       */
+      sheet_title?: string;
+      /**
+       * Dismiss action on the reminder bottom sheet.
+       */
+      sheet_dont_set?: string;
+      /**
+       * Confirm CTA on the reminder bottom sheet.
+       */
+      sheet_done?: string;
+      /**
+       * CTA letting the user return to the meditation flow from the reminder sheet.
+       */
+      sheet_return_to_meditation?: string;
+      /**
+       * CTA letting the user exit the meditation flow from the reminder sheet.
+       */
+      sheet_leave_meditation?: string;
+      /**
+       * Title of the success confirmation after a reminder is scheduled.
+       */
+      sheet_success_title?: string;
+      /**
+       * Subtitle of the success confirmation after a reminder is scheduled.
+       */
+      sheet_success_subtitle?: string;
+      /**
+       * CTA on the success confirmation suggesting the user explores the app while waiting.
+       */
+      sheet_explore_app?: string;
+      /**
+       * CTA on the success confirmation suggesting the user starts the first meditation immediately instead.
+       */
+      sheet_start_first_meditation?: string;
+      /**
+       * Error toast shown when scheduling the reminder fails.
+       */
+      sheet_error?: string;
+      /**
+       * Preset chip label suggesting a reminder later the same day.
+       */
+      preset_unwind_later_today?: string;
+      /**
+       * Preset chip label suggesting a reminder at the start of the week.
+       */
+      preset_start_your_week_calm?: string;
+      /**
+       * Preset chip label suggesting a reminder midweek.
+       */
+      preset_find_your_midweek_balance?: string;
+      /**
+       * Preset chip label suggesting a recharge break.
+       */
+      preset_pause_and_recharge?: string;
+      /**
+       * Preset chip label suggesting a reminder before the weekend.
+       */
+      preset_mindful_break_before_weekend?: string;
+      /**
+       * Preset chip label suggesting a reminder at the end of the work week.
+       */
+      preset_end_your_week_with_peace?: string;
+      /**
+       * Preset chip label suggesting a weekend slow-down reminder.
+       */
+      preset_slow_down_weekend?: string;
+      /**
+       * Preset chip label suggesting a Sunday reset reminder.
+       */
+      preset_reset_for_week_ahead?: string;
+      /**
+       * Title of the scheduled local notification used by the generic meditation reminder.
+       */
+      notification_title?: string;
+      /**
+       * Notification body used when the meditation is still locked at the time the reminder fires.
+       */
+      notification_body_locked?: string;
+      /**
+       * Notification body used when the reminder is for a previously exited meditation.
+       */
+      notification_body_exit?: string;
+      /**
+       * Title of the dedicated full-screen rationale used when reminder scheduling requires notification permission.
+       */
+      allow_notifications_screen_title?: string;
+      /**
+       * Subtitle of the same full-screen rationale. Preserve the embedded line break (\n) and the trailing sparkle emoji (✨) if used in copy.
+       */
+      allow_notifications_screen_subtitle?: string;
+    };
+    footsoak?: {
+      /**
+       * Step indicator (e.g. 'Step 3 of 3') at the top of the foot-soak screen.
+       */
+      step_label?: string;
+      /**
+       * Screen title asking whether the user wants to foot-soak with this meditation.
+       */
+      title?: string;
+      /**
+       * Inline link/CTA opening the foot-soak tutorial.
+       */
+      tutorial_cta?: string;
+      /**
+       * Primary CTA that starts the meditation with a foot-soak.
+       */
+      start_with_footsoak?: string;
+      /**
+       * Secondary CTA that starts the meditation without a foot-soak.
+       */
+      start_meditation?: string;
+    };
     /**
      * Body copy of the foot-soak screen. Contains a short emphasised span (typically italic, e.g. 'really') that translators position freely within the sentence.
      */
@@ -5499,80 +6790,400 @@ export interface WmAppTranslation {
       };
       [k: string]: unknown;
     } | null;
-    player?:
-      | {
-          [k: string]: unknown;
-        }
-      | unknown[]
-      | string
-      | number
-      | boolean
-      | null;
-    vibes_check?:
-      | {
-          [k: string]: unknown;
-        }
-      | unknown[]
-      | string
-      | number
-      | boolean
-      | null;
-    feedback?:
-      | {
-          [k: string]: unknown;
-        }
-      | unknown[]
-      | string
-      | number
-      | boolean
-      | null;
+    player?: {
+      /**
+       * Error title shown when the meditation track fails to load in the player.
+       */
+      load_error_title?: string;
+    };
+    vibes_check?: {
+      /**
+       * Initial Vibes Check question shown before the per-hand prompt. Preserve the embedded line break (\n).
+       */
+      intro_question?: string;
+      /**
+       * Per-hand question prefix; combined with left_hand or right_hand and question_suffix to form the full prompt (e.g. 'What do you feel on your left hand?'). Preserve the trailing line break (\n).
+       */
+      question_prefix?: string;
+      /**
+       * Per-hand question suffix (typically ' hand?'). Include the leading space.
+       */
+      question_suffix?: string;
+      /**
+       * Inline noun for the left hand, plugged into the per-hand question template.
+       */
+      left_hand?: string;
+      /**
+       * Inline noun for the right hand, plugged into the per-hand question template.
+       */
+      right_hand?: string;
+      /**
+       * Selectable sensation: cool. Maps to raw selection 'cool' (first-party storage only).
+       */
+      cool?: string;
+      /**
+       * Selectable sensation: warm.
+       */
+      warm?: string;
+      /**
+       * Selectable sensation: fingers tingling.
+       */
+      fingers_tingling?: string;
+      /**
+       * Selectable sensation: nothing felt.
+       */
+      nothing?: string;
+      /**
+       * Primary CTA to confirm the current Vibes Check answer and continue.
+       */
+      continue_action?: string;
+      /**
+       * Skip-like CTA used when the user is unsure what they felt. Maps to derived firstMedExperience = not_sure.
+       */
+      not_sure?: string;
+      /**
+       * Acknowledge CTA at the end of the Vibes Check explanation.
+       */
+      got_it?: string;
+      /**
+       * Reassurance shown when the user selects 'nothing' for both hands.
+       */
+      interpretation_nothing?: string;
+      /**
+       * Intro line of the Vibes Check interpretation screen.
+       */
+      interpretation_intro?: string;
+      /**
+       * Per-hand detail copy in the Vibes Check interpretation screen.
+       */
+      interpretation_detail?: string;
+      /**
+       * Inline action that opens the skip-confirmation prompt.
+       */
+      skip_vibes_check?: string;
+      /**
+       * Title of the skip-confirmation prompt.
+       */
+      skip_prompt_title?: string;
+      /**
+       * Body copy of the skip-confirmation prompt.
+       */
+      skip_prompt_description?: string;
+      /**
+       * CTA returning the user from the skip prompt to the Vibes Check explanation.
+       */
+      back_to_explanation?: string;
+      /**
+       * Title of the prompt offering to restart the first meditation from the beginning.
+       */
+      return_to_meditation_prompt_title?: string;
+      /**
+       * Body copy of the same restart prompt.
+       */
+      return_to_meditation_prompt_description?: string;
+      /**
+       * Primary CTA on the restart prompt.
+       */
+      return_to_meditation_action?: string;
+      /**
+       * Decline CTA on the restart prompt.
+       */
+      skip_it?: string;
+    };
+    feedback?: {
+      /**
+       * Form title.
+       */
+      title?: string;
+      /**
+       * Form description / prompt for free-text feedback.
+       */
+      description?: string;
+      /**
+       * Validation error shown when the feedback is shorter than the minimum length (50 characters).
+       */
+      error_length?: string;
+      /**
+       * Input field placeholder hint for the feedback text area.
+       */
+      hint?: string;
+      /**
+       * Submit CTA on the feedback form.
+       */
+      send?: string;
+      /**
+       * Title of the thank-you confirmation after the feedback is submitted.
+       */
+      thank_you?: string;
+      /**
+       * Body of the thank-you confirmation. Preserve the embedded line breaks (\n) — they control the hero layout.
+       */
+      thank_you_description?: string;
+      /**
+       * Close CTA on the thank-you confirmation.
+       */
+      close?: string;
+    };
   };
   auth?: {
-    common?:
-      | {
-          [k: string]: unknown;
-        }
-      | unknown[]
-      | string
-      | number
-      | boolean
-      | null;
-    login?:
-      | {
-          [k: string]: unknown;
-        }
-      | unknown[]
-      | string
-      | number
-      | boolean
-      | null;
-    restore_password?:
-      | {
-          [k: string]: unknown;
-        }
-      | unknown[]
-      | string
-      | number
-      | boolean
-      | null;
-    restore_password_email_sent?:
-      | {
-          [k: string]: unknown;
-        }
-      | unknown[]
-      | string
-      | number
-      | boolean
-      | null;
-    create_account?:
-      | {
-          [k: string]: unknown;
-        }
-      | unknown[]
-      | string
-      | number
-      | boolean
-      | null;
+    common?: {
+      /**
+       * Divider label between email and social-provider auth options.
+       */
+      or?: string;
+      /**
+       * Social-auth button label for Apple Sign-In.
+       */
+      continue_with_apple?: string;
+      /**
+       * Social-auth button label for Google Sign-In.
+       */
+      continue_with_google?: string;
+      /**
+       * Social-auth button label for Facebook Sign-In.
+       */
+      continue_with_facebook?: string;
+      /**
+       * Auth-method button label that opens the email/password flow.
+       */
+      continue_with_email?: string;
+      /**
+       * Generic cancel CTA used on auth modals and prompts.
+       */
+      cancel?: string;
+      /**
+       * Validation error shown when the email field is empty.
+       */
+      error_enter_email?: string;
+      /**
+       * Validation error shown when the email field is not a valid email.
+       */
+      error_invalid_email?: string;
+      /**
+       * Validation error shown when the password field is empty.
+       */
+      error_enter_password?: string;
+      /**
+       * Validation error shown when the password is shorter than the minimum length (6 characters).
+       */
+      error_password_min_length?: string;
+    };
+    login?: {
+      /**
+       * Login screen title.
+       */
+      title?: string;
+      /**
+       * Label for the email input.
+       */
+      email_label?: string;
+      /**
+       * Placeholder hint for the email input.
+       */
+      email_placeholder?: string;
+      /**
+       * Label for the password input.
+       */
+      password_label?: string;
+      /**
+       * Placeholder hint for the password input.
+       */
+      password_placeholder?: string;
+      /**
+       * Primary CTA on the login form.
+       */
+      next?: string;
+      /**
+       * Loading-state label shown on the primary CTA while sign-in is in flight.
+       */
+      signing_in?: string;
+      /**
+       * Link opening the password recovery flow.
+       */
+      forgot_password?: string;
+      /**
+       * Tertiary link that routes the user to account creation instead of login.
+       */
+      continue_as_new_user?: string;
+      /**
+       * Title of the branch shown when the entered email has no matching account.
+       */
+      account_not_found_title?: string;
+      /**
+       * Subtitle of the same branch.
+       */
+      account_not_found_subtitle?: string;
+      /**
+       * Title of the branch shown when the entered email matches an account that uses a different sign-in method.
+       */
+      account_exists_title?: string;
+      /**
+       * Subtitle of the same branch. MUST preserve the {providers} placeholder — it is replaced at runtime with the localized provider list (e.g. 'Google or Apple').
+       */
+      account_exists_subtitle?: string;
+      /**
+       * CTA on the account-not-found branch routing the user to account creation.
+       */
+      create_new_account?: string;
+      /**
+       * CTA on the account-not-found branch letting the user re-enter a different email.
+       */
+      try_different_account?: string;
+      /**
+       * Fallback value injected into the {providers} placeholder when the existing provider list is empty or unresolved.
+       */
+      account_exists_existing_provider_fallback?: string;
+      /**
+       * CTA on the account-exists branch that reopens the login flow.
+       */
+      open_login?: string;
+      /**
+       * Error shown when the email-continuation branch cannot proceed.
+       */
+      error_cannot_continue_with_email?: string;
+      /**
+       * Error shown for invalid email/password combinations.
+       */
+      error_invalid_credentials?: string;
+      /**
+       * Error shown when sign-in is rate-limited.
+       */
+      error_too_many_requests?: string;
+      /**
+       * Error shown when sign-in succeeds at Firebase but the local session cannot be persisted.
+       */
+      error_session_persistence?: string;
+      /**
+       * Generic sign-in failure error.
+       */
+      error_generic?: string;
+    };
+    restore_password?: {
+      /**
+       * Password recovery screen title.
+       */
+      title?: string;
+      /**
+       * Body copy explaining the recovery-link flow.
+       */
+      description?: string;
+      /**
+       * Label for the email input on the recovery form.
+       */
+      email_label?: string;
+      /**
+       * Placeholder hint for the email input on the recovery form.
+       */
+      email_placeholder?: string;
+      /**
+       * Primary CTA submitting the recovery request.
+       */
+      submit?: string;
+      /**
+       * Validation error on the recovery form for an invalid email.
+       */
+      error_invalid_email?: string;
+    };
+    restore_password_email_sent?: {
+      /**
+       * Confirmation message. Preserve the embedded line break (\n).
+       */
+      message?: string;
+      /**
+       * Acknowledge CTA on the confirmation.
+       */
+      ok?: string;
+    };
+    create_account?: {
+      /**
+       * Sheet / modal title shown in the navigation chrome.
+       */
+      title?: string;
+      /**
+       * Hero title on the account creation screen.
+       */
+      screen_title?: string;
+      /**
+       * Hero subtitle on the account creation screen.
+       */
+      screen_subtitle?: string;
+      /**
+       * Tertiary action allowing a guest user to skip account creation.
+       */
+      skip_and_explore?: string;
+      /**
+       * Validation error shown when the user tries to submit without checking the consent box.
+       */
+      error_check_consent?: string;
+      /**
+       * Label for the email input.
+       */
+      email_label?: string;
+      /**
+       * Placeholder hint for the email input.
+       */
+      email_placeholder?: string;
+      /**
+       * Label for the password input.
+       */
+      password_label?: string;
+      /**
+       * Placeholder hint for the password input.
+       */
+      password_placeholder?: string;
+      /**
+       * Primary CTA submitting account creation.
+       */
+      submit?: string;
+      /**
+       * Loading-state label shown on the primary CTA while account creation is in flight.
+       */
+      creating?: string;
+      /**
+       * Error shown when the email is already associated with an account.
+       */
+      error_email_in_use?: string;
+      /**
+       * CTA on the email-in-use branch redirecting to login.
+       */
+      login_with_existing_account?: string;
+      /**
+       * Validation error for an invalid email.
+       */
+      error_invalid_email?: string;
+      /**
+       * Validation error for a password shorter than the minimum length.
+       */
+      error_weak_password?: string;
+      /**
+       * Error shown when account creation is rate-limited.
+       */
+      error_too_many_requests?: string;
+      /**
+       * Error shown when the account is created but the local session cannot be persisted.
+       */
+      error_session_persistence?: string;
+      /**
+       * Generic account-creation failure error.
+       */
+      error_generic?: string;
+      /**
+       * Error shown when Google sign-in fails during account creation.
+       */
+      error_google_failed?: string;
+      /**
+       * Error shown when Apple sign-in fails during account creation.
+       */
+      error_apple_failed?: string;
+      /**
+       * Error shown when Facebook sign-in fails during account creation.
+       */
+      error_facebook_failed?: string;
+      /**
+       * Message shown when the user cancels the social-auth flow.
+       */
+      error_provider_cancelled?: string;
+    };
     /**
      * Consent checkbox label on the account creation screen. Contains two inline links (Terms & Conditions, Privacy Policy) opening the corresponding in-app webviews (wemeditate://legal/terms, wemeditate://legal/privacy). Independent of the ad-measurement consent.
      */
@@ -5592,24 +7203,38 @@ export interface WmAppTranslation {
       [k: string]: unknown;
     } | null;
   };
-  navigation?:
-    | {
-        [k: string]: unknown;
-      }
-    | unknown[]
-    | string
-    | number
-    | boolean
-    | null;
-  general?:
-    | {
-        [k: string]: unknown;
-      }
-    | unknown[]
-    | string
-    | number
-    | boolean
-    | null;
+  navigation?: {
+    /**
+     * Bottom-nav label for the Daily tab (home / today’s meditations).
+     */
+    daily?: string;
+    /**
+     * Bottom-nav label for the Path tab (guided learning course).
+     */
+    path?: string;
+    /**
+     * Bottom-nav label for the Explore tab (library of meditations, talks, techniques).
+     */
+    explore?: string;
+    /**
+     * Bottom-nav label for the Profile tab (account, history, favourites, settings).
+     */
+    profile?: string;
+  };
+  general?: {
+    /**
+     * Generic back action label (used as accessibility text and as a back button label).
+     */
+    back?: string;
+    /**
+     * Generic retry action label used on error states across the app.
+     */
+    retry?: string;
+    /**
+     * Generic undo action label used on snackbars and other transient confirmations.
+     */
+    undo?: string;
+  };
   _status?: ('draft' | 'published') | null;
   updatedAt?: string | null;
   createdAt?: string | null;
@@ -5984,120 +7609,424 @@ export interface SyAtlasConfig {
  */
 export interface SyAtlasTranslation {
   id: number;
-  common?:
-    | {
-        [k: string]: unknown;
-      }
-    | unknown[]
-    | string
-    | number
-    | boolean
-    | null;
+  common?: {
+    /**
+     * Generic plural noun for meditation events, used in counts and labels (e.g. "3 events").
+     */
+    events?: string;
+    /**
+     * Singular label for a free meditation class; used in headings and map markers.
+     */
+    free_meditation_class?: string;
+    /**
+     * Plural label for free meditation classes; used in page headings and section titles.
+     */
+    free_meditation_classes?: string;
+    /**
+     * Accessible label (aria-label) for the language-picker dropdown in the navbar.
+     */
+    language_selector?: string;
+    /**
+     * Generic loading indicator shown while content is being fetched.
+     */
+    loading?: string;
+    /**
+     * Map filter toggle label (off state) — invites the user to include online-only classes.
+     */
+    show_online_classes?: string;
+    /**
+     * Map filter toggle label (on state) — indicates online classes are currently shown.
+     */
+    showing_online_classes?: string;
+  };
   region?: {
-    locations?:
-      | {
-          [k: string]: unknown;
-        }
-      | unknown[]
-      | string
-      | number
-      | boolean
-      | null;
-    venues?:
-      | {
-          [k: string]: unknown;
-        }
-      | unknown[]
-      | string
-      | number
-      | boolean
-      | null;
+    locations?: {
+      /**
+       * Heading on a location/region landing page. `%{location}` = region or place name.
+       */
+      title?: string;
+      /**
+       * Singular result-count line under a location heading. `%{count}` = 1, `%{location}` = region name.
+       */
+      description_one?: string;
+      /**
+       * Plural result-count line under a location heading. `%{count}` = number, `%{location}` = region name.
+       */
+      description_other?: string;
+    };
+    venues?: {
+      /**
+       * Heading on a venue landing page. `%{venue}` = venue name.
+       */
+      title?: string;
+      /**
+       * Singular result-count line under a venue heading. `%{count}` = 1, `%{venue}` = venue name.
+       */
+      description_one?: string;
+      /**
+       * Plural result-count line under a venue heading. `%{count}` = number, `%{venue}` = venue name.
+       */
+      description_other?: string;
+    };
   };
   event?: {
-    details?:
-      | {
-          [k: string]: unknown;
-        }
-      | unknown[]
-      | string
-      | number
-      | boolean
-      | null;
-    recurrence?:
-      | {
-          [k: string]: unknown;
-        }
-      | unknown[]
-      | string
-      | number
-      | boolean
-      | null;
-    timing?:
-      | {
-          [k: string]: unknown;
-        }
-      | unknown[]
-      | string
-      | number
-      | boolean
-      | null;
-    title?:
-      | {
-          [k: string]: unknown;
-        }
-      | unknown[]
-      | string
-      | number
-      | boolean
-      | null;
+    details?: {
+      /**
+       * Shown instead of a schedule when an event has no fixed time; prompts the user to contact the host.
+       */
+      contact_for_timing?: string;
+      /**
+       * Label/action to contact the event host.
+       */
+      contact_host?: string;
+      /**
+       * Button that opens map directions to the event venue.
+       */
+      get_directions?: string;
+      /**
+       * Host-location label for an online event. `%{city}` = host city.
+       */
+      hosted_from?: string;
+      /**
+       * Distance-unit suffix (kilometres) shown next to an event's distance from the user.
+       */
+      km?: string;
+      /**
+       * Link/button to expand or open fuller event details.
+       */
+      more_info?: string;
+      /**
+       * Short badge indicating an online event.
+       */
+      online?: string;
+      /**
+       * Fuller label for an online class.
+       */
+      online_class?: string;
+      /**
+       * Event start-date label. `%{date}` = formatted start date.
+       */
+      starting_on?: string;
+      /**
+       * Label for an event whose start is imminent.
+       */
+      starting_soon?: string;
+      /**
+       * Telephone-link label for the host's number. `%{phoneNumber}` = phone number.
+       */
+      tel?: string;
+      /**
+       * Button/link that opens the event's photo in the lightbox.
+       */
+      view_photo?: string;
+    };
+    recurrence?: {
+      /**
+       * Recurrence label for an event that repeats every day.
+       */
+      daily?: string;
+      /**
+       * Weekly recurrence, simple form (English). `%{weekday}` = day name.
+       */
+      weekly?: string;
+      /**
+       * Monthly recurrence, simple form (English).
+       */
+      monthly?: string;
+      /**
+       * Weekly recurrence, every week — detailed form used by non-English locales. `%{weekday}` = day name.
+       */
+      weekly_1?: string;
+      /**
+       * Weekly recurrence, every second week. `%{weekday}` = day name.
+       */
+      weekly_2?: string;
+      /**
+       * Monthly recurrence on the 1st given weekday of the month. `%{weekday}` = day name.
+       */
+      monthly_1st?: string;
+      /**
+       * Monthly recurrence on the 2nd given weekday of the month. `%{weekday}` = day name.
+       */
+      monthly_2nd?: string;
+      /**
+       * Monthly recurrence on the 3rd given weekday of the month. `%{weekday}` = day name.
+       */
+      monthly_3rd?: string;
+      /**
+       * Monthly recurrence on the 4th given weekday of the month. `%{weekday}` = day name.
+       */
+      monthly_4th?: string;
+      /**
+       * Monthly recurrence on the last given weekday of the month. `%{weekday}` = day name.
+       */
+      monthly_last?: string;
+      /**
+       * Fallback when an event has no fixed schedule (formerly the `null` key).
+       */
+      no_recurrence?: string;
+    };
+    timing?: {
+      /**
+       * Tooltip shown when an event time is converted to the viewer's timezone. `%{timezone}` = tz name, `%{offset}` = UTC offset.
+       */
+      converted_to?: string;
+    };
+    title?: {
+      /**
+       * Auto-title for an event starting between 05:00 and 11:59 local time. `%{place}` = venue or street.
+       */
+      morning?: string;
+      /**
+       * Auto-title for an event starting between 12:00 and 16:59 local time. `%{place}` = venue or street.
+       */
+      afternoon?: string;
+      /**
+       * Auto-title for an event starting between 17:00 and 21:59 local time. `%{place}` = venue or street.
+       */
+      evening?: string;
+      /**
+       * Auto-title used when the start time is late (22:00–04:59) or the event has no schedule at all. `%{place}` = venue or street.
+       */
+      default?: string;
+    };
   };
   registration?: {
-    form?:
-      | {
-          [k: string]: unknown;
-        }
-      | unknown[]
-      | string
-      | number
-      | boolean
-      | null;
-    errors?:
-      | {
-          [k: string]: unknown;
-        }
-      | unknown[]
-      | string
-      | number
-      | boolean
-      | null;
-    questions?:
-      | {
-          [k: string]: unknown;
-        }
-      | unknown[]
-      | string
-      | number
-      | boolean
-      | null;
+    form?: {
+      /**
+       * Cancel button in the registration form/modal.
+       */
+      cancel?: string;
+      /**
+       * Label/placeholder for the email input.
+       */
+      email?: string;
+      /**
+       * Confirmation note shown after registering.
+       */
+      followup?: string;
+      /**
+       * Option encouraging the user to bring a guest.
+       */
+      invite_friend?: string;
+      /**
+       * Consent checkbox label for the events mailing list.
+       */
+      mailing_list_consent?: string;
+      /**
+       * Label/placeholder for the name input.
+       */
+      name?: string;
+      /**
+       * Acknowledgement button (e.g. dismisses the thank-you state).
+       */
+      okay?: string;
+      /**
+       * Notice for online classes explaining the join link is emailed.
+       */
+      online_notice?: string;
+      /**
+       * Heading for the online-session notice.
+       */
+      online_notice_title?: string;
+      /**
+       * Consent/disclaimer text shown near the submit button.
+       */
+      privacy_policy?: string;
+      /**
+       * Primary CTA to open the registration form.
+       */
+      register_now?: string;
+      /**
+       * Label for the starting-date selector.
+       */
+      starting_date?: string;
+      /**
+       * Submit button for the registration form.
+       */
+      submit?: string;
+      /**
+       * Success message shown after a successful registration.
+       */
+      thank_you?: string;
+    };
+    errors?: {
+      /**
+       * Validation error for an invalid/empty email field.
+       */
+      email?: string;
+      /**
+       * Validation error for an empty/invalid name field.
+       */
+      name?: string;
+      /**
+       * Validation error when no starting date is chosen.
+       */
+      starting_at?: string;
+    };
+    questions?: {
+      /**
+       * Optional registration question about accessibility needs.
+       */
+      accessibility?: string;
+      /**
+       * Optional registration question about the attendee's goals.
+       */
+      aspirations?: string;
+      /**
+       * Optional registration question about prior experience with this meditation.
+       */
+      experience?: string;
+      /**
+       * Optional registration question about accompanying guests.
+       */
+      guests?: string;
+      /**
+       * Optional registration question about relevant health information (renamed from `healthInfo`).
+       */
+      health_info?: string;
+      /**
+       * Optional registration question about prior Sahaja Yoga practice (renamed from `priorExperience`).
+       */
+      prior_experience?: string;
+      /**
+       * Optional registration question inviting free-form questions.
+       */
+      questions?: string;
+      /**
+       * Optional registration question about how the attendee found the organisation.
+       */
+      referral?: string;
+      /**
+       * Optional registration question about how the attendee found this specific event (renamed from `referralSource`).
+       */
+      referral_source?: string;
+    };
   };
-  share?:
-    | {
-        [k: string]: unknown;
-      }
-    | unknown[]
-    | string
-    | number
-    | boolean
-    | null;
-  emails?:
-    | {
-        [k: string]: unknown;
-      }
-    | unknown[]
-    | string
-    | number
-    | boolean
-    | null;
+  share?: {
+    /**
+     * Label for the share action/button on an event; seeds the forthcoming Share view (renamed from `details.share`).
+     */
+    action?: string;
+  };
+  emails?: {
+    /**
+     * Subject line of the registration confirmation email. `%{event}` = event title.
+     */
+    confirmation_subject?: string;
+    /**
+     * Main heading inside the confirmation email, e.g. "You're registered".
+     */
+    confirmation_heading?: string;
+    /**
+     * Opening line addressing the registrant. `%{name}` = registrant's name.
+     */
+    confirmation_intro?: string;
+    /**
+     * Section label above the date/time of the class.
+     */
+    when_label?: string;
+    /**
+     * Section label above the address or joining link.
+     */
+    where_label?: string;
+    /**
+     * Call-to-action button label for joining an online class.
+     */
+    online_cta?: string;
+    /**
+     * Line introducing the plain-text join URL, shown for email clients that strip buttons.
+     */
+    online_link_hint?: string;
+    /**
+     * Call-to-action button label that opens the venue address in a maps app, for an in-person class.
+     */
+    directions_cta?: string;
+    /**
+     * Section label above the event description ("What to expect").
+     */
+    about_label?: string;
+    /**
+     * Section label above the host's name and phone number.
+     */
+    contact_label?: string;
+    /**
+     * Session count appended to a limited-run course's schedule, entered per plural form. `%{count}` = number of sessions.
+     */
+    sessions_count_one?: string;
+    /**
+     * Session count appended to a limited-run course's schedule, entered per plural form. `%{count}` = number of sessions.
+     */
+    sessions_count_few?: string;
+    /**
+     * Session count appended to a limited-run course's schedule, entered per plural form. `%{count}` = number of sessions.
+     */
+    sessions_count_many?: string;
+    /**
+     * Session count appended to a limited-run course's schedule, entered per plural form. `%{count}` = number of sessions.
+     */
+    sessions_count_other?: string;
+    /**
+     * Footer line explaining why the registrant received this email.
+     */
+    footer_reason?: string;
+    /**
+     * Footer link label pointing at the client service's website. `%{name}` = service name.
+     */
+    footer_website?: string;
+    /**
+     * Subject line of the session reminder email (sent 24h before a class). `%{event}` = event title.
+     */
+    reminder_subject?: string;
+    /**
+     * Main heading inside the reminder email, e.g. "Your class is tomorrow".
+     */
+    reminder_heading?: string;
+    /**
+     * Opening line of the reminder email. `%{name}` = registrant's name.
+     */
+    reminder_intro?: string;
+    /**
+     * Footer line explaining why the registrant received the reminder.
+     */
+    reminder_footer_reason?: string;
+    /**
+     * Footer link label in the reminder email that opens the unsubscribe page.
+     */
+    unsubscribe_cta?: string;
+    /**
+     * Heading on the unsubscribe landing page.
+     */
+    unsubscribe_heading?: string;
+    /**
+     * Prompt on the unsubscribe page confirming what stops. `%{event}` = event title.
+     */
+    unsubscribe_intro?: string;
+    /**
+     * Button label that confirms unsubscribing from reminders.
+     */
+    unsubscribe_confirm_cta?: string;
+    /**
+     * Button label shown while the unsubscribe request is in flight.
+     */
+    unsubscribe_working?: string;
+    /**
+     * Title of the success card after unsubscribing.
+     */
+    unsubscribe_done_title?: string;
+    /**
+     * Body of the success card after unsubscribing.
+     */
+    unsubscribe_done_message?: string;
+    /**
+     * Title of the error card when unsubscribing fails.
+     */
+    unsubscribe_error_title?: string;
+    /**
+     * Body of the error card when unsubscribing fails.
+     */
+    unsubscribe_error_message?: string;
+  };
   _status?: ('draft' | 'published') | null;
   updatedAt?: string | null;
   createdAt?: string | null;

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -2365,15 +2365,12 @@ export interface Meditation {
    */
   songTag?: (number | null) | SongTag;
   duration?: number | null;
-  subtleSystemNodeWeights?:
-    | {
-        [k: string]: unknown;
-      }
-    | unknown[]
-    | string
-    | number
-    | boolean
-    | null;
+  subtleSystemNodeWeights?: {
+    /**
+     * On-screen seconds for the node slug.
+     */
+    [k: string]: number;
+  } | null;
   durationMinutes?: number | null;
   /**
    * Optional auto-generated fallback title (e.g. Meditation for Anahat), derived from this meditation's dominant subtle-system node. Front-end clients use it only when they have no composed label of their own.

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -1042,6 +1042,7 @@ export interface Video {
     startTimeMs: number;
     endTimeMs: number;
     durationMs?: number;
+    [k: string]: unknown;
   }[];
   tags: 'testimonial' | 'workshop' | 'event' | 'technique';
   /**
@@ -2573,6 +2574,7 @@ export interface Lesson {
       startTimeMs: number;
       endTimeMs: number;
       durationMs?: number;
+      [k: string]: unknown;
     }[];
     id?: string | null;
   }[];
@@ -2605,6 +2607,7 @@ export interface Lesson {
     startTimeMs: number;
     endTimeMs: number;
     durationMs?: number;
+    [k: string]: unknown;
   }[];
   article?: {
     root: {

--- a/tests/COVERAGE.md
+++ b/tests/COVERAGE.md
@@ -19,7 +19,7 @@ Per `.claude/rules/tests.md`, only **custom logic** belongs in the integration l
 | `meditations`         | `filterMeditationsByLocale` beforeOperation, `extractAudioDuration` beforeChange, `durationMinutes` virtual, weight invalidation          | `meditations`, `meditation-duration`, `meditation-lectures`    |
 | `pages`               | `webUrl` virtual, Lexical block relationship depth, stale-content stripping                                                               | `pages`                                                        |
 | `songs`               | `autoSetIncludeForMeditationsOnCreate` beforeChange                                                                                       | `meditations` (via `includeForMeditations` behavior)           |
-| `videos`              | `previewUrl` virtual, `validateSubtitles` validator                                                                                       | `videos`                                                       |
+| `videos`              | `previewUrl` virtual, `subtitles` jsonSchema validation                                                                                   | `videos`                                                       |
 | `authors`             | Reachability only                                                                                                                         | `collections-smoke`                                            |
 | `images`              | `detectOrientationHook` beforeChange (auto-tags landscape/portrait/square)                                                                | `image-orientation`                                            |
 | `lectures`            | `populateFromNirmalaVidya` beforeChange, clip ↔ parent linking, subtitle language normalization, custom validators (stopTime > startTime) | `lectures`, `sync-lecture-metadata`, `meditation-lectures`     |
@@ -74,6 +74,7 @@ Per `.claude/rules/tests.md`, only **custom logic** belongs in the integration l
 | Content-Index block API endpoint generation (`computeApiEndpoint` virtual)                                     | `content-index-block`       |
 | Project-based admin visibility (`createHidden` from accessPlugin)                                              | `project-visibility`        |
 | RBAC (`hasPermission`, `hasAnyPermission`, document-level manager access, locale roles, translator scopes)     | `role-based-access`         |
+| `type: 'json'` fields reaching Ajv on write — malformed value is a 400 (`notificationPreferences`, both notification ledgers, Lessons subtitles) | `json-schema-fields`        |
 
 ## Gaps
 

--- a/tests/int/event-registration.int.spec.ts
+++ b/tests/int/event-registration.int.spec.ts
@@ -3,9 +3,15 @@ import type { Payload, PayloadRequest } from 'payload'
 import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest'
 
 import { registerForEvent } from '@/collections/Events/endpoints/registerForEvent'
+import type { Manager } from '@/payload-types'
 
 import { createData, testData } from '../utils/testData'
 import { createTestEnvironment } from '../utils/testHelpers'
+
+/** The cadences `event_registration` accepts, off the field's own jsonSchema. */
+type RegistrationFrequency = NonNullable<
+  NonNullable<Manager['notificationPreferences']>['event_registration']
+>['frequency']
 
 type TestUser = {
   id: number | string
@@ -556,7 +562,7 @@ describe('registerForEvent endpoint', () => {
         )
     }
 
-    async function createManagerWithFrequency(frequency: string, method = 'email') {
+    async function createManagerWithFrequency(frequency: RegistrationFrequency, method = 'email') {
       return testData.createManager(payload, {
         name: `Notify Mgr ${frequency}`,
         notificationPreferences: { event_registration: { frequency, method } },

--- a/tests/int/event-verification.int.spec.ts
+++ b/tests/int/event-verification.int.spec.ts
@@ -397,6 +397,8 @@ describe('Event verification lifecycle', () => {
           {
             kind: 'reminder',
             stage: 'escalated',
+            level: 'urgent',
+            role: 'manager',
             at: daysAgo(1),
             manager: { id: eventManager.id, name: 'Event Manager' },
             channel: 'email',

--- a/tests/int/json-schema-fields.int.spec.ts
+++ b/tests/int/json-schema-fields.int.spec.ts
@@ -1,0 +1,221 @@
+/**
+ * `jsonSchema` write enforcement (#597).
+ *
+ * Several `type: 'json'` fields carry a JSON Schema derived from their source of
+ * truth, which Payload feeds to Ajv on write and to the TypeScript generator.
+ * The generated types are checked by `pnpm typecheck` — what nothing else
+ * proves is that the schema actually *reaches* Ajv through Payload's config
+ * sanitization, so a malformed write is a 400 rather than a silently-stored blob.
+ *
+ * One case per newly-schema'd field. Fields covered elsewhere:
+ * `Videos.subtitles` (videos.int.spec.ts), the translations groups
+ * (translations-globals.int.spec.ts), `Registrations.questions`
+ * (event-registration.int.spec.ts, #595).
+ */
+import type { Payload, ValidationError } from 'payload'
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+
+import type { Event, Manager, Registration } from '@/payload-types'
+
+import { createData, testData } from '../utils/testData'
+import { createTestEnvironment } from '../utils/testHelpers'
+
+describe('jsonSchema write enforcement', () => {
+  let payload: Payload
+  let cleanup: () => Promise<void>
+
+  beforeAll(async () => {
+    const testEnv = await createTestEnvironment()
+    payload = testEnv.payload
+    cleanup = testEnv.cleanup
+  })
+
+  afterAll(async () => {
+    await cleanup()
+  })
+
+  /** Run a write expected to fail, and return its status + joined field messages. */
+  async function rejected(write: () => Promise<unknown>) {
+    try {
+      await write()
+    } catch (error) {
+      const { data, status } = error as ValidationError
+      return { messages: data.errors.map((e) => e.message).join(' '), status }
+    }
+    throw new Error('Expected the write to be rejected')
+  }
+
+  describe('Managers.notificationPreferences', () => {
+    // Every case here writes a value the generated type rightly rejects — that
+    // *is* the test — so each cast is deliberate, and narrow to the one field.
+    const createManager = (notificationPreferences: unknown) =>
+      testData.createManager(payload, {
+        notificationPreferences: notificationPreferences as Manager['notificationPreferences'],
+      })
+
+    it('rejects a frequency outside the type’s own options', async () => {
+      const { messages, status } = await rejected(() =>
+        // "Never" is not among event_verification's cadences.
+        createManager({ event_verification: { frequency: 'Never', method: 'email' } }),
+      )
+
+      expect(status).toBe(400)
+      expect(messages).toMatch(/frequency.*must be equal to one of the allowed values/)
+    })
+
+    it('rejects a notification type that isn’t configured', async () => {
+      const { status } = await rejected(() =>
+        createManager({ not_a_notification_type: { frequency: 'Immediate', method: 'email' } }),
+      )
+
+      expect(status).toBe(400)
+    })
+
+    it('still applies the cross-field rule the schema can’t express', async () => {
+      // Schema-valid (both keys present, frequency in range) but a non-Never
+      // cadence with no delivery method — only the pure-JS validate catches it,
+      // and only if it runs *after* delegating to the built-in json validation.
+      const { messages, status } = await rejected(() =>
+        createManager({ event_registration: { frequency: 'Immediate', method: '' } }),
+      )
+
+      expect(status).toBe(400)
+      expect(messages).toMatch(/Select a notification method for: Event Registration/)
+    })
+
+    it('accepts the shape the field’s own defaultValue produces', async () => {
+      const manager = await testData.createManager(payload)
+
+      expect(manager.notificationPreferences).toMatchObject({
+        event_verification: { frequency: 'Monthly', method: 'email' },
+      })
+    })
+  })
+
+  describe('Events.notificationLog', () => {
+    it('rejects a reminder entry missing its escalation level', async () => {
+      const event = await testData.createEvent(payload)
+      const { messages, status } = await rejected(() =>
+        payload.update({
+          collection: 'events',
+          id: event.id,
+          overrideAccess: true,
+          context: { skipVerifyHook: true },
+          data: {
+            // No `level` — the entry the builders always fill in.
+            notificationLog: [
+              {
+                kind: 'reminder',
+                stage: 'reminded',
+                role: 'manager',
+                at: new Date().toISOString(),
+                manager: { id: 1, name: 'Someone' },
+                channel: 'email',
+                destination: 'someone@example.com',
+              },
+            ] as unknown as Event['notificationLog'],
+          },
+        }),
+      )
+
+      expect(status).toBe(400)
+      expect(messages).toMatch(/level/)
+    })
+
+    it('accepts an entry in the shape the builders produce', async () => {
+      const event = await testData.createEvent(payload)
+      const at = new Date().toISOString()
+      const updated = await payload.update({
+        collection: 'events',
+        id: event.id,
+        overrideAccess: true,
+        context: { skipVerifyHook: true },
+        data: {
+          notificationLog: [{ kind: 'verification', at, by: null, method: 'import' }],
+        },
+      })
+
+      expect(updated.notificationLog).toEqual([
+        { kind: 'verification', at, by: null, method: 'import' },
+      ])
+    })
+  })
+
+  describe('Registrations.reminderLog', () => {
+    async function createRegistration(reminderLog: unknown) {
+      const event = await testData.createEvent(payload)
+      const user = await payload.create({
+        collection: 'users',
+        overrideAccess: true,
+        data: createData<'users'>({
+          email: `ledger-${Math.random().toString(36).slice(2)}@example.com`,
+          name: 'Ledger Tester',
+        }),
+      })
+      return payload.create({
+        collection: 'registrations',
+        overrideAccess: true,
+        data: createData<'registrations'>({
+          event: event.id,
+          user: user.id,
+          uuid: `uuid-${Math.random().toString(36).slice(2)}`,
+          reminderLog: reminderLog as Registration['reminderLog'],
+        }),
+      })
+    }
+
+    it('rejects a ledger entry missing its sentAt stamp', async () => {
+      const { messages, status } = await rejected(() =>
+        createRegistration([{ occurrence: '2026-09-01T09:00:00.000Z' }]),
+      )
+
+      expect(status).toBe(400)
+      expect(messages).toMatch(/sentAt/)
+    })
+
+    it('accepts an entry in the shape the reminder job appends', async () => {
+      const entry = { occurrence: '2026-09-01T09:00:00.000Z', sentAt: new Date().toISOString() }
+      const registration = await createRegistration([entry])
+
+      expect(registration.reminderLog).toEqual([entry])
+    })
+  })
+
+  describe('Lessons subtitles', () => {
+    it('rejects a malformed cue on introSubtitles', async () => {
+      const { messages, status } = await rejected(() =>
+        testData.createLesson(payload, {
+          introSubtitles: [{ content: 'Hi', startTimeMs: 0 }],
+        } as Parameters<typeof testData.createLesson>[1]),
+      )
+
+      expect(status).toBe(400)
+      expect(messages).toMatch(/endTimeMs/)
+    })
+
+    it('rejects a malformed cue on a panel’s subtitles', async () => {
+      // The panel field is `admin.condition`-gated on `media`, and Payload skips
+      // validation entirely for a field whose condition is false — so the panel
+      // needs its media for the schema to run at all.
+      const media = await testData.createFile(payload)
+      const { messages, status } = await rejected(() =>
+        testData.createLesson(payload, {
+          panels: [
+            { title: 'Panel', media: media.id, subtitles: [{ content: 'Hi', startTimeMs: 0 }] },
+          ],
+        } as Parameters<typeof testData.createLesson>[1]),
+      )
+
+      expect(status).toBe(400)
+      expect(messages).toMatch(/endTimeMs/)
+    })
+
+    it('accepts a well-formed cue', async () => {
+      const cues = [{ content: 'Welcome', startTimeMs: 0, endTimeMs: 1500, durationMs: 1500 }]
+      const lesson = await testData.createLesson(payload, { introSubtitles: cues })
+
+      expect(lesson.introSubtitles).toEqual(cues)
+    })
+  })
+})

--- a/tests/int/registration-digests.int.spec.ts
+++ b/tests/int/registration-digests.int.spec.ts
@@ -4,10 +4,16 @@ import type { Payload } from 'payload'
 import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest'
 
 import { SendRegistrationDigests } from '@/jobs/RegistrationNotifications/SendRegistrationDigests'
+import type { Manager } from '@/payload-types'
 
 import { runTaskHandler } from '../utils/taskRunner'
 import { createData, testData } from '../utils/testData'
 import { createTestEnvironmentWithEmail } from '../utils/testHelpers'
+
+/** The cadences `event_registration` accepts, off the field's own jsonSchema. */
+type RegistrationFrequency = NonNullable<
+  NonNullable<Manager['notificationPreferences']>['event_registration']
+>['frequency']
 
 const SCHEDULE = {
   firstDate: '2026-07-01T09:00:00.000Z',
@@ -52,7 +58,7 @@ describe('SendRegistrationDigests job', () => {
     emailAdapter.clearCapturedEmails()
   })
 
-  async function createManager(email: string, frequency: string): Promise<number> {
+  async function createManager(email: string, frequency: RegistrationFrequency): Promise<number> {
     const manager = await testData.createManager(payload, {
       name: `Dig ${email}`,
       email,

--- a/tests/int/translations-field.int.spec.ts
+++ b/tests/int/translations-field.int.spec.ts
@@ -10,6 +10,8 @@
  * many flat localized columns. wm-app-translations has ~478 leaf keys, which
  * a column-per-key design blows past.
  */
+import type { GroupField, JSONField, TabsField } from 'payload'
+
 import { describe, expect, it } from 'vitest'
 
 import { buildTranslationTabs, type SchemaEntry, type TranslationsSchema } from '@/fields'
@@ -159,7 +161,7 @@ describe('buildTranslationTabs', () => {
       expect(entries.find((e) => e.key === 'footer_reason')?.maxLength).toBeUndefined()
     })
 
-    it('expands a plural key into its CLDR family for storage + validation', () => {
+    it('passes a plural key to the admin as one grouped entry', () => {
       const schema: TranslationsSchema = {
         type: 'object',
         properties: {
@@ -180,20 +182,13 @@ describe('buildTranslationTabs', () => {
       const tabs = buildTranslationTabs(schema, 'sy-atlas-translations')
       const field = tabs[0].fields[0] as {
         admin?: { custom?: { schemaEntries?: SchemaEntry[] } }
-        validate?: (value: unknown) => true | string
       }
 
       // One grouped entry, flagged plural — the admin expands it per locale.
+      // (The *stored* keys are the expanded family; see the jsonSchema cases.)
       expect(field.admin?.custom?.schemaEntries).toEqual([
         { key: 'sessions_count', description: 'Session count', maxLength: 18, plural: true },
       ])
-
-      // Validation accepts the expanded category keys and rejects the bare base.
-      const validate = field.validate!
-      expect(validate({ sessions_count_one: '1 session', sessions_count_other: '%{count}' })).toBe(
-        true,
-      )
-      expect(validate({ sessions_count: 'nope' })).toContain('Unknown key')
     })
 
     it('EMAIL_STRING_DEFAULTS covers every plural form the field builder can store', () => {
@@ -209,7 +204,7 @@ describe('buildTranslationTabs', () => {
       }
     })
 
-    it('sets localized: true and no jsonSchema (Ajv breaks on Cloudflare Workers)', () => {
+    it('sets localized: true and leaves validation to the jsonSchema', () => {
       const schema: TranslationsSchema = {
         type: 'object',
         properties: {
@@ -221,14 +216,13 @@ describe('buildTranslationTabs', () => {
       }
 
       const tabs = buildTranslationTabs(schema, 'test')
-      const field = tabs[0].fields[0] as {
-        localized?: boolean
-        jsonSchema?: unknown
-        validate?: unknown
-      }
+      const field = tabs[0].fields[0] as JSONField
+
       expect(field.localized).toBe(true)
-      expect(field.jsonSchema).toBeUndefined()
-      expect(typeof field.validate).toBe('function')
+      expect(field.jsonSchema).toBeDefined()
+      // A custom `validate` would *replace* Payload's built-in json validation,
+      // silently disabling the schema — so the field must not declare one.
+      expect(field.validate).toBeUndefined()
     })
 
     it('omits the JSON field when a leaf contains only richText keys', () => {
@@ -327,14 +321,18 @@ describe('buildTranslationTabs', () => {
     })
   })
 
-  describe('validate function on the JSON field', () => {
-    function getValidate(schema: TranslationsSchema, fieldName: string) {
+  // The group schema is projected onto the field as a `jsonSchema` (#597), which
+  // Payload feeds to Ajv on write and to the TypeScript generator. These cases
+  // pin the projection; `translations-globals.int.spec.ts` proves the write
+  // rejection end-to-end against a real global.
+  describe('jsonSchema on the JSON field', () => {
+    function getJsonSchema(schema: TranslationsSchema, fieldName: string) {
       const tabs = buildTranslationTabs(schema, 'test')
       const field = tabs[0].fields.find(
         (f) => 'name' in f && (f as { name?: string }).name === fieldName,
-      ) as { validate?: (v: unknown) => true | string } | undefined
-      if (!field?.validate) throw new Error(`No validate function on field "${fieldName}"`)
-      return field.validate
+      ) as JSONField | undefined
+      if (!field?.jsonSchema) throw new Error(`No jsonSchema on field "${fieldName}"`)
+      return field.jsonSchema
     }
 
     const baseSchema: TranslationsSchema = {
@@ -351,24 +349,23 @@ describe('buildTranslationTabs', () => {
       },
     }
 
-    it('accepts undefined / null', () => {
-      const validate = getValidate(baseSchema, 'common')
-      expect(validate(undefined)).toBe(true)
-      expect(validate(null)).toBe(true)
+    it('declares each string key as an optional string, carrying its description', () => {
+      const { schema } = getJsonSchema(baseSchema, 'common')
+
+      expect(schema).toMatchObject({
+        type: 'object',
+        properties: {
+          loading: { type: 'string', description: 'L' },
+          error: { type: 'string', description: 'E' },
+        },
+      })
+      // No `required` — a locale may translate any subset of its group.
+      expect(schema.required).toBeUndefined()
     })
 
-    it('rejects non-object values', () => {
-      const validate = getValidate(baseSchema, 'common')
-      expect(validate('x')).toMatch(/must be a JSON object/)
-      expect(validate([])).toMatch(/must be a JSON object/)
-    })
+    it('forbids unknown keys unless the group opts into additionalProperties', () => {
+      expect(getJsonSchema(baseSchema, 'common').schema.additionalProperties).toBe(false)
 
-    it('rejects unknown keys when additionalProperties is false', () => {
-      const validate = getValidate(baseSchema, 'common')
-      expect(validate({ loading: 'a', mystery: 'b' })).toMatch(/Unknown key "mystery"/)
-    })
-
-    it('accepts unknown keys when additionalProperties is true', () => {
       const flexible: TranslationsSchema = {
         type: 'object',
         properties: {
@@ -379,23 +376,53 @@ describe('buildTranslationTabs', () => {
           },
         },
       }
-      const validate = getValidate(flexible, 'flexible')
-      expect(validate({ known: 'x', extra: 'y' })).toBe(true)
+      expect(getJsonSchema(flexible, 'flexible').schema.additionalProperties).toBe(true)
     })
 
-    it('rejects non-string values for declared keys', () => {
-      const validate = getValidate(baseSchema, 'common')
-      expect(validate({ loading: 42 })).toMatch(/must be a string/)
+    it('declares the expanded CLDR family for a plural key, not the bare key', () => {
+      const plural: TranslationsSchema = {
+        type: 'object',
+        properties: {
+          notices: {
+            type: 'object',
+            properties: { day_count: { type: 'string', description: 'D', plural: true } },
+          },
+        },
+      }
+      const { schema } = getJsonSchema(plural, 'notices')
+
+      expect(Object.keys(schema.properties ?? {})).toEqual(
+        PLURAL_CATEGORIES.map((cat) => `day_count_${cat}`),
+      )
+      expect(schema.properties?.day_count).toBeUndefined()
     })
 
-    it('accepts a well-formed object', () => {
-      const validate = getValidate(baseSchema, 'common')
-      expect(validate({ loading: 'Loading', error: 'Oops' })).toBe(true)
-    })
+    it('gives every field its own schema URI, namespaced by global and group', () => {
+      const nested: TranslationsSchema = {
+        type: 'object',
+        properties: {
+          onboarding: {
+            type: 'object',
+            properties: {
+              welcome: {
+                type: 'object',
+                properties: { title: { type: 'string', description: 'T' } },
+              },
+            },
+          },
+        },
+      }
+      const groupField = buildTranslationTabs(nested, 'wm-app-translations')[0]
+        .fields[0] as GroupField
+      const inner = (groupField.fields[0] as TabsField).tabs[0].fields[0] as JSONField
 
-    it('accepts an object that omits some optional keys', () => {
-      const validate = getValidate(baseSchema, 'common')
-      expect(validate({ loading: 'Loading' })).toBe(true)
+      expect(inner.jsonSchema?.uri).toBe(
+        'https://sahajcloud.dev/schemas/translations/wm-app-translations/onboarding/welcome.json',
+      )
+      expect(inner.jsonSchema?.fileMatch).toEqual([inner.jsonSchema?.uri])
+      expect(getJsonSchema(baseSchema, 'common').uri).toBe(
+        'https://sahajcloud.dev/schemas/translations/test/common.json',
+      )
     })
   })
 })

--- a/tests/int/translations-globals.int.spec.ts
+++ b/tests/int/translations-globals.int.spec.ts
@@ -15,7 +15,7 @@
  *   `welcome_legal_disclaimer` and the API path is
  *   `onboarding.welcome_legal_disclaimer`.
  */
-import type { Field, Payload, TabsField } from 'payload'
+import type { Field, Payload, TabsField, ValidationError } from 'payload'
 
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 
@@ -198,6 +198,54 @@ describe('Translations Globals Configuration', () => {
           expect(groups, label).toHaveLength(0)
         }
       }
+    })
+  })
+
+  // The per-group `jsonSchema` (#597) is what enforces the key/type contract now
+  // that the hand-rolled `validate` is gone. These cases prove the wiring
+  // survives Payload's config sanitization and reaches Ajv on a real write.
+  describe('jsonSchema enforcement on write', () => {
+    /** Write `common` and return the ValidationError's status + per-field messages. */
+    async function rejectedCommonWrite(common: unknown) {
+      try {
+        await payload.updateGlobal({
+          slug: 'wm-web-translations',
+          data: { common } as Parameters<typeof payload.updateGlobal>[0]['data'],
+        })
+      } catch (error) {
+        const { data, status } = error as ValidationError
+        return { messages: data.errors.map((e) => e.message).join(' '), status }
+      }
+      throw new Error('Expected the write to be rejected')
+    }
+
+    it('rejects a key the group schema does not declare', async () => {
+      const { messages, status } = await rejectedCommonWrite({
+        loading: 'Loading…',
+        not_a_declared_key: 'nope',
+      })
+
+      expect(status).toBe(400)
+      // Ajv's default `errorsText()` doesn't name the offending key here. That
+      // only reaches API clients — the admin edits these groups key-by-key
+      // through TranslationsRow, which can't produce an undeclared one.
+      expect(messages).toMatch(/must NOT have additional properties/)
+    })
+
+    it('rejects a non-string value for a declared key', async () => {
+      const { messages, status } = await rejectedCommonWrite({ loading: 42 })
+
+      expect(status).toBe(400)
+      expect(messages).toMatch(/loading.*must be string/)
+    })
+
+    it('accepts a partial, well-formed group', async () => {
+      const updated = await payload.updateGlobal({
+        slug: 'wm-web-translations',
+        data: { common: { loading: 'Loading…' } },
+      })
+
+      expect(updated.common).toMatchObject({ loading: 'Loading…' })
     })
   })
 })

--- a/tests/int/videos.int.spec.ts
+++ b/tests/int/videos.int.spec.ts
@@ -47,7 +47,7 @@ describe('Videos Collection — custom behavior', () => {
     expect(tagged.tags).toBe('workshop')
   })
 
-  describe('subtitles validator wiring (#317)', () => {
+  describe('subtitles jsonSchema wiring (#317, #597)', () => {
     it('accepts well-formed subtitles', async () => {
       const valid = [{ startTimeMs: 0, endTimeMs: 1000, durationMs: 1000, content: 'Hello' }]
       const video = await testData.createVideo(payload, {
@@ -60,14 +60,16 @@ describe('Videos Collection — custom behavior', () => {
 
     it('rejects malformed subtitles via the field validator', async () => {
       // Guards against a future regression where someone removes
-      // `validate: validateSubtitles` from the field config — the unit
+      // `jsonSchema: subtitlesJsonSchema` from the field config — the unit
       // suite would still pass, but the wiring would be silently broken.
       await expect(
         testData.createVideo(payload, {
           title: 'Invalid Subs Video',
           // Deliberately malformed — the case asserts the field validator
           // rejects it, so it can't be typed as a valid row.
-          subtitles: [{ startTimeMs: 'oops', endTimeMs: 1000, content: 'x' }] as unknown as Video['subtitles'],
+          subtitles: [
+            { startTimeMs: 'oops', endTimeMs: 1000, content: 'x' },
+          ] as unknown as Video['subtitles'],
         }),
       ).rejects.toThrow(/subtitles|startTimeMs/i)
     })

--- a/tests/unit/registration-recipient.spec.ts
+++ b/tests/unit/registration-recipient.spec.ts
@@ -16,8 +16,19 @@ function event(
   }
 }
 
-/** Minimal Manager with only the fields the resolver / pickChannel read. */
-function manager(overrides: Partial<Manager> = {}): Manager {
+/**
+ * Minimal Manager with only the fields the resolver / pickChannel read.
+ *
+ * `notificationPreferences` is widened with `| null`: the field's `jsonSchema`
+ * types it, and Payload's type-gen doesn't add `| null` to a jsonSchema-typed
+ * field — but a manager row that has never been given preferences really does
+ * read back null, which is exactly the fallback these cases exercise.
+ */
+function manager(
+  overrides: Partial<Omit<Manager, 'notificationPreferences'>> & {
+    notificationPreferences?: Manager['notificationPreferences'] | null
+  } = {},
+): Manager {
   return {
     id: 1,
     name: 'Anna Manager',
@@ -149,7 +160,7 @@ describe('resolveRegistrationRecipient', () => {
     it('defaults the frequency to Immediate when the manager has no preference', () => {
       const result = resolveRegistrationRecipient(
         event(),
-        manager({ notificationPreferences: null } as Partial<Manager>),
+        manager({ notificationPreferences: null }),
       )
       expect(result?.frequency).toBe('Immediate')
     })

--- a/tests/unit/reminder-ledger.spec.ts
+++ b/tests/unit/reminder-ledger.spec.ts
@@ -4,7 +4,7 @@
  */
 import { describe, expect, it } from 'vitest'
 
-import { asReminderLog, hasReminderFor } from '@/jobs/RegistrationNotifications/reminderLedger'
+import { asReminderLog, hasReminderFor } from '@/lib/registrations/reminderLog'
 
 describe('reminder ledger', () => {
   describe('asReminderLog', () => {

--- a/tests/unit/subtitles.spec.ts
+++ b/tests/unit/subtitles.spec.ts
@@ -1,50 +1,59 @@
 import { describe, expect, it } from 'vitest'
 
-import { parseSubtitles } from '@/lib/utilities/subtitles'
+import { subtitlesJsonSchema, subtitlesZodSchema } from '@/lib/utilities/subtitles'
 
-describe('parseSubtitles', () => {
-  const validSubtitles = [
-    { startTimeMs: 0, endTimeMs: 1500, durationMs: 1500, content: 'Hello' },
-    { startTimeMs: 1500, endTimeMs: 3500, content: 'World' },
-  ]
+/**
+ * The subtitles JSON Schema is *derived* from the Zod schema
+ * (`z.toJSONSchema`), and Payload feeds it to both Ajv (write validation) and
+ * the TypeScript generator. So the derivation itself is the contract: a Zod
+ * edit that silently changes it also changes the public API type and what a
+ * client is allowed to POST. These cases pin the parts that matter.
+ */
+describe('subtitlesJsonSchema', () => {
+  const items = subtitlesJsonSchema.schema.items as {
+    additionalProperties?: boolean
+    properties?: Record<string, { type?: string }>
+    required?: string[]
+    type?: string
+  }
 
-  it('accepts well-formed subtitles', () => {
-    expect(parseSubtitles(validSubtitles)).toBe(true)
+  it('targets draft-07 — the dialect Ajv’s default export understands', () => {
+    expect(subtitlesJsonSchema.schema.$schema).toBe('http://json-schema.org/draft-07/schema#')
   })
 
-  it('treats undefined / null / empty object / empty array as valid (field is optional)', () => {
-    expect(parseSubtitles(undefined)).toBe(true)
-    expect(parseSubtitles(null)).toBe(true)
-    expect(parseSubtitles({})).toBe(true)
-    expect(parseSubtitles([])).toBe(true)
+  it('describes an array of cue objects', () => {
+    expect(subtitlesJsonSchema.schema.type).toBe('array')
+    expect(items.type).toBe('object')
   })
 
-  it('rejects top-level objects', () => {
-    const result = parseSubtitles({ notSubtitles: [] })
-    expect(typeof result).toBe('string')
-    expect(result as string).toMatch(/array/i)
+  it('requires content + the time bounds, leaving durationMs optional', () => {
+    expect(items.required).toEqual(['content', 'startTimeMs', 'endTimeMs'])
+    expect(Object.keys(items.properties ?? {}).sort()).toEqual([
+      'content',
+      'durationMs',
+      'endTimeMs',
+      'startTimeMs',
+    ])
   })
 
-  it('rejects when a subtitle is missing a required field', () => {
-    const result = parseSubtitles([{ startTimeMs: 0, content: 'no endTimeMs' }])
-    expect(typeof result).toBe('string')
-    expect(result as string).toContain('endTimeMs')
+  it('pins each cue property to its scalar type', () => {
+    expect(items.properties?.content.type).toBe('string')
+    expect(items.properties?.startTimeMs.type).toBe('number')
+    expect(items.properties?.endTimeMs.type).toBe('number')
+    expect(items.properties?.durationMs.type).toBe('number')
   })
 
-  it('rejects when a subtitle field has the wrong type', () => {
-    const result = parseSubtitles([{ startTimeMs: '0', endTimeMs: 1000, content: 'oops' }])
-    expect(typeof result).toBe('string')
-    expect(result as string).toMatch(/0\.startTimeMs/)
+  it('forbids extra keys, so the generated type is exhaustive', () => {
+    expect(items.additionalProperties).toBe(false)
   })
 
-  it('rejects when the top-level value is not an array', () => {
-    const result = parseSubtitles({ subtitles: 'not-an-array' })
-    expect(typeof result).toBe('string')
-    expect(result as string).toMatch(/array/i)
-  })
-
-  it('rejects top-level non-array values', () => {
-    expect(typeof parseSubtitles('a string')).toBe('string')
-    expect(typeof parseSubtitles(42)).toBe('string')
+  it('still parses the same values as the Zod source of truth', () => {
+    expect(
+      subtitlesZodSchema.safeParse([{ content: 'Hello', startTimeMs: 0, endTimeMs: 1500 }]).success,
+    ).toBe(true)
+    expect(
+      subtitlesZodSchema.safeParse([{ content: 'Hello', startTimeMs: '0', endTimeMs: 1500 }])
+        .success,
+    ).toBe(false)
   })
 })

--- a/tests/unit/subtitles.spec.ts
+++ b/tests/unit/subtitles.spec.ts
@@ -43,8 +43,11 @@ describe('subtitlesJsonSchema', () => {
     expect(items.properties?.durationMs.type).toBe('number')
   })
 
-  it('forbids extra keys, so the generated type is exhaustive', () => {
-    expect(items.additionalProperties).toBe(false)
+  it('tolerates extra keys, so a legacy cue field still saves', () => {
+    // Stored rows carry legacy cue keys (`startOfParagraph`, …). The Zod-based
+    // field validator this schema replaces accepted them, and `false` here
+    // would 400 every later save of a lesson or video holding one.
+    expect(items.additionalProperties).not.toBe(false)
   })
 
   it('still parses the same values as the Zod source of truth', () => {


### PR DESCRIPTION
## Summary

- Every `type: 'json'` field with a known structure now carries a `jsonSchema` **derived from its source of truth**, so Payload validates it on write (400, not a silently-stored blob) and generates its TypeScript type instead of `unknown`.
- Retires the Cloudflare-Workers rationale that kept `jsonSchema` off these fields — `new Function()`/Ajv run fine on Railway/Node.
- **No new dependency**: Zod 4 ships `z.toJSONSchema()` natively, so `zod-to-json-schema` wasn't needed.

## Changes

| Field | Schema derived from |
|---|---|
| translations leaf groups (all 3 globals) | the group's own `properties` — plural keys expanded to their CLDR family |
| `Managers.notificationPreferences` | `NOTIFICATION_TYPES` (each frequency confined to its own options) |
| `Videos.subtitles`, `Lessons.introSubtitles`, `Lessons.panels.*.subtitles` | `subtitleCue` via `z.toJSONSchema(…, { target: 'draft-7' })` |
| `Events.notificationLog` | the entry builders + `VERIFICATION_STAGES` / `VERIFICATION_METHODS` |
| `Registrations.reminderLog` | `ReminderLogEntry` |
| `Meditations.subtleSystemNodeWeights` | `Record<slug, seconds> \| null` |

Also: `reminderLedger.ts` → `src/lib/registrations/reminderLog.ts` (the Registrations collection now shares it with the job, and a collection may not import a job folder's internals); `registrationQuestionsJsonSchema` reshaped so every field passes a complete `jsonSchema` object from its owning module.

The remaining json fields are recorded as deliberately unschema'd, with a one-line reason each, in `.claude/rules/collections.md`.

## Notes for reviewer

Three findings worth your attention, all resolved:

1. **A custom `validate` silently disables `jsonSchema`.** `sanitize.js` only installs Payload's built-in json validation when `validate` is `undefined`. So `translationsField`'s hand-rolled validator had to go, and `Managers.notificationPreferences` — which keeps a cross-field rule JSON Schema can't express with a readable message — delegates to `validations.json(value, options)` first. The int case *"rejects a frequency outside the type's own options"* is what proves that delegation runs.
2. **`additionalProperties: false` is a claim about rows already in the database.** Subtitles hit this: the Zod validator being replaced *stripped* unknown cue keys and passed, and `lessons.int.spec.ts` documents that tolerance as intentional. Rejecting them would have 400'd every later save of any lesson/video holding a legacy `startOfParagraph`. The cue schema is therefore derived from a **loose** variant of the same shared object — strict for the seed parser, tolerant for the field. Every other new `additionalProperties: false` / `required` was checked against each writer in `src/`, `seeds/`, `scripts/` and against git history (`NOTIFICATION_TYPES` options and the log-entry shapes are unchanged since introduction), so none can reject stored data.
3. **The stricter types caught a lying fixture** — an int fixture wrote a reminder entry with no `level`/`role`, hidden by an `as NotificationLogEntry[]` cast. Filled in to match what `buildReminderEntry` actually produces.

No migration: `jsonSchema` is config-only, the `jsonb` columns are unchanged (`db:migrations:create --skip-empty` generates nothing).

Pre-existing and left alone: `src/components/admin/NotificationPreferences/config.ts` is pure business logic imported by two collections, so by `project-structure.md` it belongs in `src/lib/`. Moving it is a separate refactor — happy to open a follow-up if you'd like.

## Test Results

- Lint: ✓ · Typecheck (src + tests): ✓ · Unit: 1023 passed
- New: `tests/int/json-schema-fields.int.spec.ts` — 11 cases, one per newly-schema'd field (malformed write → 400, well-formed → round-trips). The rejection cases can't pass vacuously: the helper throws when a write *succeeds*, which is how the conditional `Lessons.panels.*.subtitles` field was caught skipping validation until its panel has media.
- Targeted integration specs green: `translations-globals`, `translations-field`, `lessons`, `videos`, `meditations`, `collections-smoke`, `event-verification`, `event-registration`, `session-reminders`, `registration-digests`, `meditation-lectures`

## Manual verification

1. Admin → any translations global: edit a key, save. Rows still render and save normally (the fields keep their `TranslationsRow` component; only validation changed).
2. Admin → Managers → Notifications: set a non-Never frequency and clear the method — the error should still name the type ("Select a notification method for: Event Registration"), not an Ajv message.

Closes #597

🤖 Generated with [Claude Code](https://claude.com/claude-code)
