### PR TITLE
fix(ci): make the nightly preview-asset cleanup actually run

### DIFF
--- a/.claude/rules/scripts.md
+++ b/.claude/rules/scripts.md
@@ -29,6 +29,7 @@ one-time backfills, deployment helpers, etc.
 | `preview-registration-emails.ts` | Send the registrant confirmation in each state (online/offline, locale, branded/fallback, one-off, minimal) to an Ethereal inbox, with the `.ics` attached |
 | `preview-registration-notification-emails.ts` | Send the manager registration notice (#588) in each state (named manager / override address / no session / long title) to an Ethereal inbox |
 | `preview-reminder-digest-emails.ts` | Send the registrant session reminder + manager registration digest (#589) in each state (online/offline, locale, branded/fallback, daily/weekly) to an Ethereal inbox |
+| `cleanup-preview-assets.ts` | Reap preview-namespaced Cloudflare Images / Stream / R2 assets older than `--days` (#432). Dry run by default, `--apply` to delete; run nightly by `.github/workflows/cleanup-preview-assets.yml`. Needs `CLOUDFLARE_ACCOUNT_ID`, `CLOUDFLARE_API_KEY`, `R2_BUCKET` — one token covers all three backends, see `.claude/rules/storage.md` |
 | `repair-r2-meditation-filenames.ts` | Backfill / fix R2 filenames on existing meditations |
 | `create-sample-page.ts` | Generate a sample Pages document |
 | `backfill-schedule-last-date.ts` | Recompute the derived `schedule.lastDate` column on existing `events` + `app-cards` rows (#603). Dry run by default, `--force` to write, re-runnable. Routine lives in `src/lib/schedule/backfillLastDate.ts` |

--- a/.claude/rules/storage.md
+++ b/.claude/rules/storage.md
@@ -65,18 +65,41 @@ GitHub Actions job (`.github/workflows/cleanup-preview-assets.yml` →
 `scripts/cleanup-preview-assets.ts`) reaps preview-marked assets older than 7
 days across all three backends. The reap predicate (`isReapablePreviewAsset`)
 only deletes assets that are **both** marked **and** past the cutoff; the script
-defaults to a dry run (`--apply` to delete). Required GitHub secrets — all three,
-the script exits 1 without any of them: `CLOUDFLARE_ACCOUNT_ID`,
-`CLOUDFLARE_API_KEY`, `R2_BUCKET`.
+defaults to a dry run (`--apply` to delete).
+
+**Config, split by whether it's actually sensitive.** Only the token is a GitHub
+*secret*; the rest are *variables*, so they stay unmasked in the run log — a
+masked `R2_BUCKET: ***` is exactly what makes an R2 403 hard to read.
+
+| Name | Kind | Required |
+| --- | --- | --- |
+| `CLOUDFLARE_ACCOUNT_ID` | secret | yes |
+| `CLOUDFLARE_API_KEY` | secret | yes |
+| `R2_BUCKET` | variable | yes |
+| `R2_JURISDICTION` | workflow env | only for a jurisdiction-bound bucket |
+
+The script exits 1 without any of the required three — deliberately: a cleanup
+that silently reaps nothing is worse than one that fails loudly.
 
 **One token, three backends.** The script takes no R2 access-key pair of its own.
 R2's `Object Read & Write` permission is honoured only by the S3-compatible API
 (SigV4) — the REST API rejects object-scoped tokens — so `r2Credentials.ts`
 derives the pair from `CLOUDFLARE_API_KEY` the way
 [Cloudflare documents](https://developers.cloudflare.com/r2/api/tokens/): access
-key = the token's id (`GET /user/tokens/verify`), secret = **hex** SHA-256 of the
-token value. Any other digest encoding fails as an opaque
-`SignatureDoesNotMatch`, which is what `tests/unit/r2-credentials.spec.ts` pins.
+key = the token's id, secret = **hex** SHA-256 of the token value. Any other
+digest encoding fails as an opaque `SignatureDoesNotMatch`.
+
+Two things here only fail against the live API, so both are pinned in
+`tests/unit/r2-credentials.spec.ts` rather than rediscovered:
+
+- **The id lives under one verify scope only.** Cloudflare issues account-owned
+  and user-owned tokens; asking the wrong scope answers `Invalid API Token` —
+  identical to the reply for a genuinely bad token. `r2AccessKeyId` tries
+  `/accounts/<id>/tokens/verify` then `/user/tokens/verify` before concluding.
+- **A jurisdiction-bound bucket lives on its own host**
+  (`<account>.<eu|fedramp>.r2.cloudflarestorage.com`). On the default host R2
+  answers `AccessDenied`, not a 404 — so it impersonates a permissions problem
+  and sends you auditing token scopes. Set `R2_JURISDICTION`.
 
 This is the **script's** contract only. The app's own R2 adapter still uses
 `serverEnv.R2_ACCESS_KEY_ID` / `R2_SECRET_ACCESS_KEY` / `R2_S3_ENDPOINT` as

--- a/.claude/rules/storage.md
+++ b/.claude/rules/storage.md
@@ -65,9 +65,22 @@ GitHub Actions job (`.github/workflows/cleanup-preview-assets.yml` →
 `scripts/cleanup-preview-assets.ts`) reaps preview-marked assets older than 7
 days across all three backends. The reap predicate (`isReapablePreviewAsset`)
 only deletes assets that are **both** marked **and** past the cutoff; the script
-defaults to a dry run (`--apply` to delete). Required GitHub secrets:
-`CLOUDFLARE_ACCOUNT_ID`, `CLOUDFLARE_API_KEY`, and (for R2) `R2_BUCKET`,
-`R2_ACCESS_KEY_ID`, `R2_SECRET_ACCESS_KEY` [, `R2_S3_ENDPOINT`].
+defaults to a dry run (`--apply` to delete). Required GitHub secrets — all three,
+the script exits 1 without any of them: `CLOUDFLARE_ACCOUNT_ID`,
+`CLOUDFLARE_API_KEY`, `R2_BUCKET`.
+
+**One token, three backends.** The script takes no R2 access-key pair of its own.
+R2's `Object Read & Write` permission is honoured only by the S3-compatible API
+(SigV4) — the REST API rejects object-scoped tokens — so `r2Credentials.ts`
+derives the pair from `CLOUDFLARE_API_KEY` the way
+[Cloudflare documents](https://developers.cloudflare.com/r2/api/tokens/): access
+key = the token's id (`GET /user/tokens/verify`), secret = **hex** SHA-256 of the
+token value. Any other digest encoding fails as an opaque
+`SignatureDoesNotMatch`, which is what `tests/unit/r2-credentials.spec.ts` pins.
+
+This is the **script's** contract only. The app's own R2 adapter still uses
+`serverEnv.R2_ACCESS_KEY_ID` / `R2_SECRET_ACCESS_KEY` / `R2_S3_ENDPOINT` as
+described below — those are unchanged.
 
 ### Manual safety verification (one-time, per #432 AC)
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,10 +47,11 @@ jobs:
       - run: pnpm test # test:unit + test:int (integration runs against Postgres)
 
       # ── Smoke specs against the Railway PR preview ──────────────────────────
-      # Discover the PR's Railway preview URL via the Railway API and wait until
+      # Discover the PR's Railway preview URL from Railway's commit status (via
+      # the built-in GITHUB_TOKEN — no Railway API token needed) and wait until
       # it's healthy, then run the smoke specs against it. Skips gracefully (empty
-      # preview_url) when there's no preview env or no RAILWAY_API_TOKEN secret —
-      # e.g. PRs whose branch is itself a deployed environment.
+      # preview_url) when there's no preview env — e.g. PRs whose branch is
+      # itself a deployed environment.
       - name: Discover Railway preview URL
         id: preview
         env:

--- a/.github/workflows/cleanup-preview-assets.yml
+++ b/.github/workflows/cleanup-preview-assets.yml
@@ -34,12 +34,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     env:
+      # One token covers all three backends: Images:Edit, Stream:Edit, and R2
+      # Object Read & Write (the script derives R2's S3 credentials from it).
       CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
       CLOUDFLARE_API_KEY: ${{ secrets.CLOUDFLARE_API_KEY }}
       R2_BUCKET: ${{ secrets.R2_BUCKET }}
-      R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
-      R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
-      R2_S3_ENDPOINT: ${{ secrets.R2_S3_ENDPOINT }}
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
@@ -51,10 +50,10 @@ jobs:
       # Scheduled runs always delete. Manual runs delete only when `apply` is
       # checked; otherwise they print a dry-run report.
       #
-      # This job is inert until the Cloudflare/R2 secrets are added (the script
-      # exits early without them). Before relying on the scheduled --apply, run
-      # this workflow once via "Run workflow" with `apply` UNCHECKED and review
-      # the dry-run output against real data.
+      # All three secrets above are REQUIRED — the script exits 1 without them,
+      # which is deliberate: a cleanup that silently reaps nothing is worse than
+      # a loud failure. (It previously read a secret name that didn't exist and
+      # failed nightly for six weeks unnoticed.)
       - name: Cleanup preview assets
         run: >-
           pnpm tsx scripts/cleanup-preview-assets.ts

--- a/.github/workflows/cleanup-preview-assets.yml
+++ b/.github/workflows/cleanup-preview-assets.yml
@@ -36,12 +36,15 @@ jobs:
     env:
       # One token covers all three backends: Images:Edit, Stream:Edit, and R2
       # Object Read & Write (the script derives R2's S3 credentials from it).
+      # One token covers all three backends; only it is a secret. The bucket
+      # name and jurisdiction are configuration, so they stay unmasked — a
+      # masked `R2_BUCKET: ***` is exactly what makes an R2 403 hard to read.
       CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
       CLOUDFLARE_API_KEY: ${{ secrets.CLOUDFLARE_API_KEY }}
-      R2_BUCKET: ${{ secrets.R2_BUCKET }}
-      # Not a secret, so it stays readable here: the bucket is jurisdiction-bound
-      # and is only reachable on the matching host. On the default host R2
-      # answers AccessDenied, which reads as a permissions problem.
+      R2_BUCKET: ${{ vars.R2_BUCKET }}
+      # The bucket is jurisdiction-bound and reachable only on the matching
+      # host; on the default host R2 answers AccessDenied, which impersonates a
+      # permissions problem.
       R2_JURISDICTION: eu
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/cleanup-preview-assets.yml
+++ b/.github/workflows/cleanup-preview-assets.yml
@@ -39,6 +39,10 @@ jobs:
       CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
       CLOUDFLARE_API_KEY: ${{ secrets.CLOUDFLARE_API_KEY }}
       R2_BUCKET: ${{ secrets.R2_BUCKET }}
+      # Not a secret, so it stays readable here: the bucket is jurisdiction-bound
+      # and is only reachable on the matching host. On the default host R2
+      # answers AccessDenied, which reads as a permissions problem.
+      R2_JURISDICTION: eu
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4

--- a/scripts/cleanup-preview-assets.ts
+++ b/scripts/cleanup-preview-assets.ts
@@ -128,7 +128,9 @@ const StreamListSchema = z.object({
 const TokenVerifySchema = z.object({
   success: z.boolean(),
   errors: z.array(z.object({ code: z.number().optional(), message: z.string() })).default([]),
-  result: z.object({ id: z.string() }).nullish(),
+  // `.min(1)`: an empty id would reach the S3 client as a blank access key and
+  // fail as SignatureDoesNotMatch, which names nothing useful.
+  result: z.object({ id: z.string().min(1) }).nullish(),
 })
 
 async function cfFetch(method: 'GET' | 'DELETE', path: string, apiKey: string): Promise<unknown> {

--- a/scripts/cleanup-preview-assets.ts
+++ b/scripts/cleanup-preview-assets.ts
@@ -18,11 +18,11 @@
  *   pnpm tsx scripts/cleanup-preview-assets.ts --apply          # actually delete
  *   pnpm tsx scripts/cleanup-preview-assets.ts --days 3 --apply
  *
- * Env required (Images + Stream):
+ * Env required (all three):
  *   CLOUDFLARE_ACCOUNT_ID
- *   CLOUDFLARE_API_KEY        (token with Images:Edit + Stream:Edit)
- * Env required for R2 cleanup (R2 step is skipped when any is unset):
- *   R2_BUCKET, R2_ACCESS_KEY_ID, R2_SECRET_ACCESS_KEY  [, R2_S3_ENDPOINT]
+ *   CLOUDFLARE_API_KEY   one token covering Images:Edit, Stream:Edit and
+ *                        R2 Object Read & Write — see `r2CredentialsFromToken`
+ *   R2_BUCKET
  */
 import { DeleteObjectCommand, ListObjectsV2Command, S3Client } from '@aws-sdk/client-s3'
 import { z } from 'zod'
@@ -32,6 +32,7 @@ import {
   isPreviewOwnedVideoMeta,
   isReapablePreviewAsset,
 } from '../src/plugins/storage/previewIsolation'
+import { r2S3Endpoint, r2SecretAccessKey } from '../src/plugins/storage/r2Credentials'
 
 const DEFAULT_MAX_AGE_DAYS = 7
 const CF_API_BASE = 'https://api.cloudflare.com/client/v4'
@@ -79,7 +80,7 @@ function printUsage(): void {
       '  pnpm tsx scripts/cleanup-preview-assets.ts [--days <n>] [--apply]',
       '',
       'Defaults to a dry run (no deletes). Pass --apply to delete.',
-      'Env: CLOUDFLARE_ACCOUNT_ID, CLOUDFLARE_API_KEY [, R2_BUCKET, R2_ACCESS_KEY_ID, R2_SECRET_ACCESS_KEY, R2_S3_ENDPOINT]',
+      'Env: CLOUDFLARE_ACCOUNT_ID, CLOUDFLARE_API_KEY, R2_BUCKET',
     ].join('\n'),
   )
 }
@@ -122,6 +123,12 @@ const StreamListSchema = z.object({
       }),
     )
     .default([]),
+})
+
+const TokenVerifySchema = z.object({
+  success: z.boolean(),
+  errors: z.array(z.object({ code: z.number().optional(), message: z.string() })).default([]),
+  result: z.object({ id: z.string() }).nullish(),
 })
 
 async function cfFetch(method: 'GET' | 'DELETE', path: string, apiKey: string): Promise<unknown> {
@@ -242,24 +249,42 @@ async function reapStream(
 }
 
 /**
+ * S3 credentials for R2, derived from the same Cloudflare API token used for
+ * Images and Stream — see `r2Credentials.ts` for why hashing a credential is
+ * the documented approach rather than a mistake.
+ *
+ * The access key is the token's **id**, which costs one extra call: only the
+ * token's value is in the environment.
+ */
+async function r2CredentialsFromToken(
+  apiKey: string,
+): Promise<{ accessKeyId: string; secretAccessKey: string }> {
+  const parsed = TokenVerifySchema.parse(await cfFetch('GET', '/user/tokens/verify', apiKey))
+  if (!parsed.success || !parsed.result) {
+    throw new Error(
+      `Cloudflare token verify failed: ${parsed.errors.map((e) => e.message).join(', ') || 'no token id returned'}`,
+    )
+  }
+  return { accessKeyId: parsed.result.id, secretAccessKey: r2SecretAccessKey(apiKey) }
+}
+
+/**
  * Reap preview-marked R2 objects older than the cutoff. R2 keys are
  * `<collection>/<filename>`; the marker is the `preview-` prefix on the
  * filename segment.
  */
-async function reapR2(now: Date, days: number, apply: boolean): Promise<ReapSummary | null> {
-  const bucket = process.env.R2_BUCKET
-  const accessKeyId = process.env.R2_ACCESS_KEY_ID
-  const secretAccessKey = process.env.R2_SECRET_ACCESS_KEY
-  if (!bucket || !accessKeyId || !secretAccessKey) {
-    console.log('  [r2] skipped (R2_BUCKET / R2_ACCESS_KEY_ID / R2_SECRET_ACCESS_KEY not set)')
-    return null
-  }
-
-  const accountId = process.env.CLOUDFLARE_ACCOUNT_ID
+async function reapR2(
+  accountId: string,
+  apiKey: string,
+  bucket: string,
+  now: Date,
+  days: number,
+  apply: boolean,
+): Promise<ReapSummary> {
   const client = new S3Client({
     region: 'auto',
-    endpoint: process.env.R2_S3_ENDPOINT || `https://${accountId}.r2.cloudflarestorage.com`,
-    credentials: { accessKeyId, secretAccessKey },
+    endpoint: r2S3Endpoint(accountId),
+    credentials: await r2CredentialsFromToken(apiKey),
   })
 
   let continuationToken: string | undefined
@@ -300,17 +325,18 @@ async function main(): Promise<void> {
   const args = parseArgs(process.argv)
   const accountId = requireEnv('CLOUDFLARE_ACCOUNT_ID')
   const apiKey = requireEnv('CLOUDFLARE_API_KEY')
+  const bucket = requireEnv('R2_BUCKET')
   const now = new Date()
 
   console.log(
     `Preview asset cleanup — cutoff ${args.days} day(s), ${args.apply ? 'APPLY (deleting)' : 'DRY RUN (no deletes)'}`,
   )
 
-  const summaries: ReapSummary[] = []
-  summaries.push(await reapImages(accountId, apiKey, now, args.days, args.apply))
-  summaries.push(await reapStream(accountId, apiKey, now, args.days, args.apply))
-  const r2Summary = await reapR2(now, args.days, args.apply)
-  if (r2Summary) summaries.push(r2Summary)
+  const summaries: ReapSummary[] = [
+    await reapImages(accountId, apiKey, now, args.days, args.apply),
+    await reapStream(accountId, apiKey, now, args.days, args.apply),
+    await reapR2(accountId, apiKey, bucket, now, args.days, args.apply),
+  ]
 
   console.log('\nSummary:')
   for (const summary of summaries) {

--- a/scripts/cleanup-preview-assets.ts
+++ b/scripts/cleanup-preview-assets.ts
@@ -32,7 +32,11 @@ import {
   isPreviewOwnedVideoMeta,
   isReapablePreviewAsset,
 } from '../src/plugins/storage/previewIsolation'
-import { r2S3Endpoint, r2SecretAccessKey } from '../src/plugins/storage/r2Credentials'
+import {
+  r2AccessKeyId,
+  r2S3Endpoint,
+  r2SecretAccessKey,
+} from '../src/plugins/storage/r2Credentials'
 
 const DEFAULT_MAX_AGE_DAYS = 7
 const CF_API_BASE = 'https://api.cloudflare.com/client/v4'
@@ -123,14 +127,6 @@ const StreamListSchema = z.object({
       }),
     )
     .default([]),
-})
-
-const TokenVerifySchema = z.object({
-  success: z.boolean(),
-  errors: z.array(z.object({ code: z.number().optional(), message: z.string() })).default([]),
-  // `.min(1)`: an empty id would reach the S3 client as a blank access key and
-  // fail as SignatureDoesNotMatch, which names nothing useful.
-  result: z.object({ id: z.string().min(1) }).nullish(),
 })
 
 async function cfFetch(method: 'GET' | 'DELETE', path: string, apiKey: string): Promise<unknown> {
@@ -254,20 +250,15 @@ async function reapStream(
  * S3 credentials for R2, derived from the same Cloudflare API token used for
  * Images and Stream — see `r2Credentials.ts` for why hashing a credential is
  * the documented approach rather than a mistake.
- *
- * The access key is the token's **id**, which costs one extra call: only the
- * token's value is in the environment.
  */
 async function r2CredentialsFromToken(
+  accountId: string,
   apiKey: string,
 ): Promise<{ accessKeyId: string; secretAccessKey: string }> {
-  const parsed = TokenVerifySchema.parse(await cfFetch('GET', '/user/tokens/verify', apiKey))
-  if (!parsed.success || !parsed.result) {
-    throw new Error(
-      `Cloudflare token verify failed: ${parsed.errors.map((e) => e.message).join(', ') || 'no token id returned'}`,
-    )
+  return {
+    accessKeyId: await r2AccessKeyId(accountId, (path) => cfFetch('GET', path, apiKey)),
+    secretAccessKey: r2SecretAccessKey(apiKey),
   }
-  return { accessKeyId: parsed.result.id, secretAccessKey: r2SecretAccessKey(apiKey) }
 }
 
 /**
@@ -286,7 +277,7 @@ async function reapR2(
   const client = new S3Client({
     region: 'auto',
     endpoint: r2S3Endpoint(accountId),
-    credentials: await r2CredentialsFromToken(apiKey),
+    credentials: await r2CredentialsFromToken(accountId, apiKey),
   })
 
   let continuationToken: string | undefined

--- a/scripts/cleanup-preview-assets.ts
+++ b/scripts/cleanup-preview-assets.ts
@@ -23,6 +23,10 @@
  *   CLOUDFLARE_API_KEY   one token covering Images:Edit, Stream:Edit and
  *                        R2 Object Read & Write — see `r2CredentialsFromToken`
  *   R2_BUCKET
+ * Optional:
+ *   R2_JURISDICTION      `eu` / `fedramp` when the bucket was created with one.
+ *                        Not a secret; set it in the workflow. A jurisdictional
+ *                        bucket is unreachable on the default host.
  */
 import { DeleteObjectCommand, ListObjectsV2Command, S3Client } from '@aws-sdk/client-s3'
 import { z } from 'zod'
@@ -33,6 +37,7 @@ import {
   isReapablePreviewAsset,
 } from '../src/plugins/storage/previewIsolation'
 import {
+  R2_JURISDICTIONS,
   r2AccessKeyId,
   r2S3Endpoint,
   r2SecretAccessKey,
@@ -84,7 +89,7 @@ function printUsage(): void {
       '  pnpm tsx scripts/cleanup-preview-assets.ts [--days <n>] [--apply]',
       '',
       'Defaults to a dry run (no deletes). Pass --apply to delete.',
-      'Env: CLOUDFLARE_ACCOUNT_ID, CLOUDFLARE_API_KEY, R2_BUCKET',
+      'Env: CLOUDFLARE_ACCOUNT_ID, CLOUDFLARE_API_KEY, R2_BUCKET [, R2_JURISDICTION]',
     ].join('\n'),
   )
 }
@@ -274,9 +279,10 @@ async function reapR2(
   days: number,
   apply: boolean,
 ): Promise<ReapSummary> {
+  const endpoint = r2S3Endpoint(accountId, process.env.R2_JURISDICTION)
   const client = new S3Client({
     region: 'auto',
-    endpoint: r2S3Endpoint(accountId),
+    endpoint,
     credentials: await r2CredentialsFromToken(accountId, apiKey),
   })
 
@@ -285,9 +291,19 @@ async function reapR2(
   let reaped = 0
 
   do {
-    const list = await client.send(
-      new ListObjectsV2Command({ Bucket: bucket, ContinuationToken: continuationToken }),
-    )
+    // R2 answers a jurisdictional bucket addressed on the default host with
+    // AccessDenied, not a 404 — so the raw SDK error sends you auditing token
+    // permissions when the endpoint is what's wrong. Name both.
+    const list = await client
+      .send(new ListObjectsV2Command({ Bucket: bucket, ContinuationToken: continuationToken }))
+      .catch((error: unknown) => {
+        const reason = error instanceof Error ? error.message : String(error)
+        throw new Error(
+          `R2 list failed for bucket "${bucket}" at ${endpoint}: ${reason}. ` +
+            'If the bucket was created with a jurisdiction, set R2_JURISDICTION ' +
+            `(${R2_JURISDICTIONS.join(' / ')}); otherwise check the token covers this bucket.`,
+        )
+      })
     const objects = list.Contents ?? []
     scanned += objects.length
 

--- a/src/plugins/storage/r2Credentials.ts
+++ b/src/plugins/storage/r2Credentials.ts
@@ -1,5 +1,7 @@
 import { createHash } from 'node:crypto'
 
+import { z } from 'zod'
+
 /**
  * R2's S3-compatible API, addressed from a Cloudflare API token.
  *
@@ -26,3 +28,44 @@ export const r2S3Endpoint = (accountId: string): string =>
  */
 export const r2SecretAccessKey = (apiToken: string): string =>
   createHash('sha256').update(apiToken).digest('hex')
+
+const TokenVerifySchema = z.object({
+  success: z.boolean(),
+  // `.min(1)`: an empty id would reach the S3 client as a blank access key and
+  // fail as SignatureDoesNotMatch, which names neither the token nor the cause.
+  result: z.object({ id: z.string().min(1) }).nullish(),
+})
+
+/** Issues an authenticated `GET` against the Cloudflare API and returns the parsed body. */
+export type CloudflareGet = (path: string) => Promise<unknown>
+
+/**
+ * The **Access Key ID** for an API token: the token's own id.
+ *
+ * Only the token's value is in the environment, so the id has to be looked up —
+ * and *which* endpoint answers depends on how the token was created. Cloudflare
+ * issues two kinds, and each is verifiable under one scope only:
+ *
+ * - **account-owned** (what it recommends for services, since they outlive any
+ *   one person) → `/accounts/<id>/tokens/verify`
+ * - **user-owned** → `/user/tokens/verify`
+ *
+ * The value alone doesn't say which it is, and asking the wrong one answers
+ * `Invalid API Token` — indistinguishable from a genuinely bad token. So try
+ * both before concluding anything.
+ */
+export async function r2AccessKeyId(accountId: string, cfGet: CloudflareGet): Promise<string> {
+  const scopes = [`/accounts/${accountId}/tokens/verify`, '/user/tokens/verify']
+
+  for (const path of scopes) {
+    const parsed = TokenVerifySchema.safeParse(await cfGet(path))
+    if (parsed.success && parsed.data.success && parsed.data.result) {
+      return parsed.data.result.id
+    }
+  }
+
+  throw new Error(
+    `Could not resolve the API token's id — neither ${scopes.join(' nor ')} accepted it. ` +
+      'Check CLOUDFLARE_API_KEY is valid and carries R2 Object Read & Write.',
+  )
+}

--- a/src/plugins/storage/r2Credentials.ts
+++ b/src/plugins/storage/r2Credentials.ts
@@ -15,9 +15,29 @@ import { z } from 'zod'
  * https://developers.cloudflare.com/r2/api/tokens/
  */
 
-/** Default S3 endpoint for an account's buckets (no jurisdiction). */
-export const r2S3Endpoint = (accountId: string): string =>
-  `https://${accountId}.r2.cloudflarestorage.com`
+/** Jurisdictions a bucket can be bound to, each reachable at its own host. */
+export const R2_JURISDICTIONS = ['eu', 'fedramp'] as const
+export type R2Jurisdiction = (typeof R2_JURISDICTIONS)[number]
+
+/**
+ * S3 endpoint for an account's buckets.
+ *
+ * A bucket created with a jurisdiction is reachable **only** through that
+ * jurisdiction's host. Addressing it on the default host doesn't 404 — it
+ * answers `AccessDenied`, which reads as a permissions problem and sends you
+ * off auditing token scopes instead of the URL.
+ * https://developers.cloudflare.com/r2/reference/data-location/
+ */
+export function r2S3Endpoint(accountId: string, jurisdiction?: string | null): string {
+  if (!jurisdiction) return `https://${accountId}.r2.cloudflarestorage.com`
+  if (!R2_JURISDICTIONS.includes(jurisdiction as R2Jurisdiction)) {
+    // Otherwise this builds a plausible-looking host that fails at DNS.
+    throw new Error(
+      `Unknown R2 jurisdiction "${jurisdiction}" — expected one of: ${R2_JURISDICTIONS.join(', ')}`,
+    )
+  }
+  return `https://${accountId}.${jurisdiction}.r2.cloudflarestorage.com`
+}
 
 /**
  * The Secret Access Key for an API token: the SHA-256 of its **value**.

--- a/src/plugins/storage/r2Credentials.ts
+++ b/src/plugins/storage/r2Credentials.ts
@@ -1,0 +1,28 @@
+import { createHash } from 'node:crypto'
+
+/**
+ * R2's S3-compatible API, addressed from a Cloudflare API token.
+ *
+ * R2's `Object Read & Write` permission is honoured **only** by the
+ * S3-compatible API, which signs with AWS SigV4 — the Cloudflare REST API
+ * rejects object-scoped tokens outright (`10002 Unauthorized`, or `10000
+ * Authentication error` when the token is bucket-scoped). So an S3 client is
+ * the only way in, and it needs an access-key pair rather than a bearer token.
+ *
+ * Cloudflare's documented bridge is to derive that pair from the token itself:
+ * https://developers.cloudflare.com/r2/api/tokens/
+ */
+
+/** Default S3 endpoint for an account's buckets (no jurisdiction). */
+export const r2S3Endpoint = (accountId: string): string =>
+  `https://${accountId}.r2.cloudflarestorage.com`
+
+/**
+ * The Secret Access Key for an API token: the SHA-256 of its **value**.
+ *
+ * Hex, not base64 — R2 rejects any other encoding of the same digest, and the
+ * failure surfaces as an opaque SignatureDoesNotMatch rather than anything
+ * naming the encoding.
+ */
+export const r2SecretAccessKey = (apiToken: string): string =>
+  createHash('sha256').update(apiToken).digest('hex')

--- a/tests/unit/r2-credentials.spec.ts
+++ b/tests/unit/r2-credentials.spec.ts
@@ -1,0 +1,41 @@
+import { createHash } from 'node:crypto'
+
+import { describe, expect, it } from 'vitest'
+
+import { r2S3Endpoint, r2SecretAccessKey } from '@/plugins/storage/r2Credentials'
+
+/**
+ * R2's S3 API is the only way to reach objects held by an `Object Read & Write`
+ * token, and it wants an access-key pair rather than the bearer token. These
+ * pin Cloudflare's documented derivation, whose failure mode is an opaque
+ * `SignatureDoesNotMatch` rather than anything naming the real cause.
+ */
+describe('r2SecretAccessKey', () => {
+  it('is the hex SHA-256 of the token value', () => {
+    // Fixed vector rather than a re-implementation, so a "tidy-up" that swaps
+    // the digest encoding has something concrete to fail against.
+    expect(r2SecretAccessKey('hello')).toBe(
+      '2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824',
+    )
+  })
+
+  it('emits hex, never base64', () => {
+    const token = 'v1.0-abcdef0123456789'
+    const digest = r2SecretAccessKey(token)
+
+    expect(digest).toMatch(/^[0-9a-f]{64}$/)
+    expect(digest).not.toBe(createHash('sha256').update(token).digest('base64'))
+  })
+
+  it('hashes the token value, never passes it through', () => {
+    // Sending the raw token as the secret is the obvious wrong implementation.
+    const token = 'v1.0-should-never-appear'
+    expect(r2SecretAccessKey(token)).not.toContain(token)
+  })
+})
+
+describe('r2S3Endpoint', () => {
+  it('addresses the account bucket host', () => {
+    expect(r2S3Endpoint('abc123')).toBe('https://abc123.r2.cloudflarestorage.com')
+  })
+})

--- a/tests/unit/r2-credentials.spec.ts
+++ b/tests/unit/r2-credentials.spec.ts
@@ -2,7 +2,7 @@ import { createHash } from 'node:crypto'
 
 import { describe, expect, it } from 'vitest'
 
-import { r2S3Endpoint, r2SecretAccessKey } from '@/plugins/storage/r2Credentials'
+import { r2AccessKeyId, r2S3Endpoint, r2SecretAccessKey } from '@/plugins/storage/r2Credentials'
 
 /**
  * R2's S3 API is the only way to reach objects held by an `Object Read & Write`
@@ -37,5 +37,62 @@ describe('r2SecretAccessKey', () => {
 describe('r2S3Endpoint', () => {
   it('addresses the account bucket host', () => {
     expect(r2S3Endpoint('abc123')).toBe('https://abc123.r2.cloudflarestorage.com')
+  })
+})
+
+/**
+ * Cloudflare issues account-owned and user-owned tokens, each verifiable under
+ * one scope only, and asking the wrong one answers `Invalid API Token` — which
+ * is indistinguishable from a genuinely bad token. A live dry run caught this:
+ * the token worked for Images and Stream but the id lookup rejected it.
+ *
+ * `cfGet` is injected rather than stubbing global fetch, per `.claude/rules/tests.md`.
+ */
+describe('r2AccessKeyId', () => {
+  const ACCOUNT = 'acct-1'
+  const ACCOUNT_SCOPE = `/accounts/${ACCOUNT}/tokens/verify`
+  const USER_SCOPE = '/user/tokens/verify'
+  const invalid = { success: false, errors: [{ code: 1000, message: 'Invalid API Token' }] }
+  const valid = (id: string) => ({ success: true, result: { id, status: 'active' } })
+
+  /** Records the paths tried, answering `valid` only for `respondsAt`. */
+  const cfGet = (respondsAt: string | null, id = 'tok-id') => {
+    const tried: string[] = []
+    const get = async (path: string) => {
+      tried.push(path)
+      return path === respondsAt ? valid(id) : invalid
+    }
+    return { get, tried }
+  }
+
+  it('resolves an account-owned token', async () => {
+    const { get, tried } = cfGet(ACCOUNT_SCOPE, 'acct-token-id')
+    await expect(r2AccessKeyId(ACCOUNT, get)).resolves.toBe('acct-token-id')
+    // Account scope is tried first — it's the kind Cloudflare recommends for
+    // services, so the common case shouldn't pay for a wasted round trip.
+    expect(tried).toEqual([ACCOUNT_SCOPE])
+  })
+
+  it('falls back to the user scope when the account scope rejects it', async () => {
+    const { get, tried } = cfGet(USER_SCOPE, 'user-token-id')
+    await expect(r2AccessKeyId(ACCOUNT, get)).resolves.toBe('user-token-id')
+    expect(tried).toEqual([ACCOUNT_SCOPE, USER_SCOPE])
+  })
+
+  it('throws only after both scopes reject it, naming both', async () => {
+    const { get, tried } = cfGet(null)
+    await expect(r2AccessKeyId(ACCOUNT, get)).rejects.toThrow(/tokens\/verify/)
+    expect(tried).toEqual([ACCOUNT_SCOPE, USER_SCOPE])
+  })
+
+  it('treats a success with no result as a rejection, not an empty key', async () => {
+    // Would otherwise hand the S3 client `undefined` as its access key.
+    const get = async () => ({ success: true, result: null })
+    await expect(r2AccessKeyId(ACCOUNT, get)).rejects.toThrow()
+  })
+
+  it('treats an empty id as a rejection', async () => {
+    const get = async () => ({ success: true, result: { id: '' } })
+    await expect(r2AccessKeyId(ACCOUNT, get)).rejects.toThrow()
   })
 })

--- a/tests/unit/r2-credentials.spec.ts
+++ b/tests/unit/r2-credentials.spec.ts
@@ -34,9 +34,29 @@ describe('r2SecretAccessKey', () => {
   })
 })
 
+/**
+ * A jurisdictional bucket addressed on the default host answers `AccessDenied`,
+ * not a 404 — so getting this wrong looks like a token-permissions problem and
+ * sends you auditing scopes. A live dry run cost exactly that detour.
+ */
 describe('r2S3Endpoint', () => {
-  it('addresses the account bucket host', () => {
+  it('addresses the default host when there is no jurisdiction', () => {
     expect(r2S3Endpoint('abc123')).toBe('https://abc123.r2.cloudflarestorage.com')
+    expect(r2S3Endpoint('abc123', undefined)).toBe('https://abc123.r2.cloudflarestorage.com')
+    // Unset env arrives as '' rather than undefined.
+    expect(r2S3Endpoint('abc123', '')).toBe('https://abc123.r2.cloudflarestorage.com')
+  })
+
+  it('infixes the jurisdiction when there is one', () => {
+    expect(r2S3Endpoint('abc123', 'eu')).toBe('https://abc123.eu.r2.cloudflarestorage.com')
+    expect(r2S3Endpoint('abc123', 'fedramp')).toBe(
+      'https://abc123.fedramp.r2.cloudflarestorage.com',
+    )
+  })
+
+  it('rejects an unknown jurisdiction rather than building a dead host', () => {
+    // `europe` would otherwise yield a plausible URL that fails at DNS.
+    expect(() => r2S3Endpoint('abc123', 'europe')).toThrow(/Unknown R2 jurisdiction/)
   })
 })
 


### PR DESCRIPTION
## Summary

- The nightly preview-asset reaper has **never succeeded** — 40+ runs, 0 successes, back to 2026-06-28 — so it has never reaped anything, which is what #432 built it to do.
- It now runs end to end against all three backends. **Verified live**, not just tested: see the dry-run results below.
- Config surface: one secret (the token), one variable (the bucket), one workflow env (the jurisdiction).

## What was broken — four distinct faults

1. **Wrong secret name.** The workflow read `secrets.CLOUDFLARE_API_KEY`; the repo had `CLOUDFLARE_API_TOKEN`. An undefined secret interpolates to empty, so `requireEnv` exited 1 every night. (Fixed out-of-band by setting the secret.)
2. **R2 needed credentials that were never configured** — it wanted an access-key pair, so the R2 step had never run even in principle.
3. **The token id lookup used the wrong verify scope.**
4. **The bucket is jurisdiction-bound**, so it isn't reachable on the default S3 host.

Faults 3 and 4 were only reachable against the live API — see below.

## One token, three backends

R2's `Object Read & Write` is honoured **only** by the S3-compatible API (SigV4); the REST API rejects object-scoped tokens outright. So a bearer token can't be handed to an S3 client. [Cloudflare documents the bridge](https://developers.cloudflare.com/r2/api/tokens/): access key = the token's id, secret = **hex** SHA-256 of the token value.

`src/plugins/storage/r2Credentials.ts` does the derivation. It sits outside the script for a concrete reason: importing the script *executes* it (`main()` runs at module load), so an inline export couldn't be unit-tested at all.

## Two failures that impersonate other problems

Both cost a dry-run cycle to find, and neither was reachable by any test written first — so both are now pinned in `tests/unit/r2-credentials.spec.ts`.

**The verify scope.** Cloudflare issues account-owned and user-owned tokens, each verifiable under one scope only. Asking the wrong one answers `Invalid API Token` — byte-identical to the reply for a genuinely bad token. The obvious next move is to go re-issue a perfectly good token. `r2AccessKeyId` now tries `/accounts/<id>/tokens/verify`, then `/user/tokens/verify`, before concluding anything.

**The jurisdiction host.** A jurisdiction-bound bucket is reachable only at `<account>.<eu|fedramp>.r2.cloudflarestorage.com`. On the default host R2 answers `AccessDenied` — not a 404 — so it reads as a permissions problem and sends you auditing token scopes. The endpoint is now derived from `CLOUDFLARE_ACCOUNT_ID` + `R2_JURISDICTION`, and an unrecognised jurisdiction throws rather than building a host that dies at DNS.

## Dry-run results (live, `--apply` never passed)

| Backend | Scanned | Reapable |
| --- | --- | --- |
| Cloudflare Images | 804 | 0 |
| Cloudflare Stream | 143 | 0 |
| R2 | 284 | 0 |

R2 listing 284 objects is the first time that path has ever worked.

**`reapable 0` is not a no-op result** — a second dry run at `--days 0` (which makes age irrelevant) also returned 0 across all three. So **no asset in the account carries a preview marker at all.** The reaper is correct; there is nothing marked to reap. That's a finding about the *marking* side of #432, not this change — see below.

A useful consequence: the first `--apply` run has nothing to delete, so merging carries no deletion risk today.

## Config split by whether it's actually sensitive

| Name | Kind | Required |
| --- | --- | --- |
| `CLOUDFLARE_ACCOUNT_ID` | secret | yes |
| `CLOUDFLARE_API_KEY` | secret | yes |
| `R2_BUCKET` | **variable** | yes |
| `R2_JURISDICTION` | workflow env | only when the bucket is jurisdiction-bound |

The bucket name isn't a credential, and masking it cost real time: the run that took the R2 403 showed `R2_BUCKET: ***`, so the log couldn't rule out a name mismatch and the endpoint had to be suspected by elimination. As a variable it prints.

## Test Results

- Unit: **1124 passed** (95 files), including `tests/unit/r2-credentials.spec.ts` — both verify scopes, the jurisdiction hosts, the hex-vs-base64 digest, and empty/absent token ids
- Lint / typecheck / typecheck:tests: ✓ clean
- Live: 4 dry runs, ending in two clean successes
- No integration spec applies — operator script, not Payload code

## Follow-up (not this PR)

**Nothing is being preview-marked.** The smoke specs do upload (`images`, `songs`, `meditations` e2e specs), and preview isolation should prefix those, yet `--days 0` finds zero marked assets across all three backends. Either previews aren't uploading in practice or `isStorageIsolationActive()` isn't engaging on Railway previews. Worth its own issue against #432 — this PR only makes the reaper work; it can't make it useful on its own.

## Notes for reviewer

- Review flagged `cfFetch` not checking `response.ok`. **Deliberately not fixed:** it also serves `DELETE`, whose response is ignored, so throwing on non-2xx would let one already-deleted asset (404) abort the sweep partway through.
- **App runtime is untouched.** `r2NativeAdapter` still uses `serverEnv.R2_ACCESS_KEY_ID` / `R2_SECRET_ACCESS_KEY` / `R2_S3_ENDPOINT`; only the script's contract changed, and `storage.md` says so explicitly.
- Drive-by: `ci.yml` claimed preview discovery needs `RAILWAY_API_TOKEN`; `get-railway-preview-url.ts` reads Railway's commit status via the built-in `GITHUB_TOKEN`.
- One empty commit (`chore(ci): retrigger…`)-equivalent noise isn't present here, but note commit `1033b914` reworks the secret→variable split after the fact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
