### PR TITLE
fix(atlas): re-adopt email-matched managers when rebuilding paginated id maps

### DIFF
--- a/seeds/atlas/import.ts
+++ b/seeds/atlas/import.ts
@@ -365,7 +365,38 @@ export class AtlasImporter extends BaseImporter<BaseImportOptions> {
       }
     }
 
-    if (need('regions') || need('events') || need('clients')) await rebuildLegacyIdMap('managers')
+    if (need('regions') || need('events') || need('clients')) {
+      await rebuildLegacyIdMap('managers')
+      // Re-adopt managers whose Atlas email belongs to a pre-existing non-Atlas
+      // account. importManagers deliberately never stamps `legacyId` on such an
+      // account (a later --update would then overwrite its password and type),
+      // so the adoption exists only in that request's memory — and each
+      // paginated batch is a fresh importer. Without re-adopting here, an
+      // adopted manager's events resolve to nothing and silently skip.
+      const { managers } = await this.getData()
+      const unmapped = managers.filter((m) => !this.idMaps.managers.has(m.legacyId))
+      if (unmapped.length > 0) {
+        const nonAtlas = await this.payload.find({
+          collection: 'managers',
+          where: { legacyId: { exists: false } },
+          limit: 0,
+          pagination: false,
+          depth: 0,
+          overrideAccess: true,
+          select: { email: true },
+        })
+        const byEmail = new Map<string, number | string>(
+          nonAtlas.docs.map((doc) => [
+            String((doc as { email?: string }).email ?? '').toLowerCase(),
+            doc.id,
+          ]),
+        )
+        for (const manager of unmapped) {
+          const adoptedId = byEmail.get(manager.email.toLowerCase())
+          if (adoptedId != null) this.idMaps.managers.set(manager.legacyId, adoptedId)
+        }
+      }
+    }
     if (need('registrations') || need('pictures')) await rebuildLegacyIdMap('events')
 
     if (need('events') || need('clients')) {


### PR DESCRIPTION
## Summary

An Atlas manager whose email already belongs to a pre-existing non-Atlas account is "adopted, not overwritten" by `importManagers` — mapped to the existing doc in memory, with `legacyId` deliberately left unstamped so a later `--update` can't reset the real account's password or type. But each paginated seed request is a fresh importer whose manager map is rebuilt from `legacyId` columns alone, so the adoption evaporated between requests and the adopted manager's events silently skipped.

Surfaced on the production first seed: events #311/#319/#335 (owned by a manager with a real SahajCloud account) never imported, leaving prod 3 events and 5 registrations short of the verification floors. Local seeding never hit it because no Atlas email collides with a local account.

`reconstructIdMaps` now repeats the adoption: any data manager still unmapped after the `legacyId` pass is matched by lowercased email against `legacyId`-less accounts — the same rule `importManagers` applies.

## Testing

- `pnpm lint`, `pnpm typecheck`, 1127 unit tests — green.
- Will be verified directly against production after deploy: the targeted events + registrations reseed should create the 3 missing events and their 5 registrations, closing the floors (events 649, registrations 2004).

🤖 Generated with [Claude Code](https://claude.com/claude-code)