### PR TITLE
docs(claude): apply session-reflection fixes

### DIFF
--- a/.claude/rules/migrations.md
+++ b/.claude/rules/migrations.md
@@ -50,13 +50,38 @@ prompt still rendered.) Then classify the outcome:
 | Outcome | Signal | Action |
 | --- | --- | --- |
 | Migration created | exit 0, new `.ts` + `.json` pair in `src/migrations/` | Validate (migration-validator skill), review the `.ts` for duplicate DDL (snapshot trap below), commit both files |
-| No schema changes | exit 0, no new files | Report it — dev `push: true` may have already synced, or a pending migration already captures the schema. Not an error |
+| No schema changes | exit 0, no new files, **and** the newest `.json` snapshot already has the column | Report it — dev `push: true` may have already synced, or a pending migration already captures the schema. Not an error |
+| Silent CLI death | exit 0, no new files, no output, and the column is **absent** from the newest snapshot | The CLI died without saying so — see below. Do **not** conclude "no changes" |
 | Interactive hang | exit 124 (timeout), no new files | Drizzle hit the rename-vs-create prompt. Hand the user the plain `pnpm db:migrations:create <name>` to run interactively, then validate + commit their result |
 | Partial write | exit 124, lone `.json` (no `.ts`) | The `.json` snapshot is written before the `.ts`; delete the orphaned `.json`, then hand off to the user as above |
 | Other error | exit ≥ 1 with output | Surface the error; don't retry blindly |
 
 On success, augment the `.ts` only if needed (see "Augmenting" below) and
 commit both files.
+
+### "exit 0, no new files" is ambiguous — check the snapshot
+
+It means either *no schema changes* or *the CLI died silently* (exit 0, zero
+bytes on stdout **and** stderr — `payload/bin.js` runs `void start()` with no
+`.catch()`, so a config-load rejection vanishes). The two look identical from
+the shell, and reading the wrong one ships a schema change with no migration —
+which is a prod crash-loop on boot (`column ... does not exist`), not a silent
+no-op.
+
+Disambiguate against the newest snapshot, which is the schema the *next*
+migration will diff against. If the column you just added isn't there, no
+migration has captured it:
+
+```bash
+python3 -c "import json,pathlib,sys;print(sorted(json.loads(pathlib.Path(sys.argv[1]).read_text())['tables']['public.<table>']['columns']))"   "$(ls -t src/migrations/*.json | head -1)"
+```
+
+If it's absent, escalate: preload the env and redirect stdout to a file
+(`set -a; . ./.env; set +a` — piping to `tail`/`grep` also loses the output),
+and if that still says nothing, drive `payload.db.createMigration()` directly
+from `node --import tsx/esm` with an `unhandledRejection` handler. Both worked
+in PR #642 where `dangerouslyDisableSandbox` alone did not; the full ladder is
+in the `payload-cli-dies-silently-in-sandbox` memory.
 
 ## Running locally
 

--- a/.claude/rules/tests.md
+++ b/.claude/rules/tests.md
@@ -94,7 +94,14 @@ pnpm exec vitest run tests/int/albums.int.spec.ts -t "creates an album"         
 pnpm exec vitest run tests/unit/convert-vimeo.spec.ts --config ./vitest.config.mts  # one unit file
 ```
 
-The `--config ./vitest.config.mts` flag is required — the config defines the `unit`/`int` projects and injects test env vars. Reserve the full `pnpm test:int` / `pnpm build` for reproducing a red CI check. See `.claude/rules/testing-reqs.md` for the local-vs-CI split.
+The `--config ./vitest.config.mts` flag is required — the config defines the `unit`/`int` projects and injects test env vars.
+
+**`Tests  no tests` on a file you just edited means the spec doesn't parse** — not
+that no case matched. Vitest reports a syntax error in a spec as an empty file,
+so it looks like a config or lane problem. Re-run without piping through `grep`
+to see the real error, or `pnpm exec tsc --noEmit -p tsconfig.test.json`. (The
+one that caused this: an unescaped apostrophe inside a single-quoted test name —
+`it('renders keys in the collection's order', …)`.) Reserve the full `pnpm test:int` / `pnpm build` for reproducing a red CI check. See `.claude/rules/testing-reqs.md` for the local-vs-CI split.
 
 ## Verifying "coverage gap" claims
 


### PR DESCRIPTION
Two rules corrected after they misled a session (`/reflect-session` on PR #642). Docs-only.

## `.claude/rules/migrations.md` — "exit 0, no new files" was one row, and it's two

The outcome table read that signal as **no schema changes**, full stop. In #642 it meant the CLI had **died silently** instead — `payload/bin.js` runs `void start()` with no `.catch()`, so a config-load rejection exits 0 with zero bytes on stdout *and* stderr. A `manager_id` column genuinely needed a migration, and the table pointed straight at the wrong conclusion.

That matters more than most doc errors: shipping a schema change with no migration is a **prod crash-loop on boot** (`column ... does not exist`), not a silent no-op.

The two readings are indistinguishable from the shell, so the table now splits on the newest `.json` snapshot — it's the schema the next migration diffs against, so a column missing from it has been captured by nothing. A new subsection carries the check and the escalation ladder (preload `.env` and redirect stdout, since piping to `tail`/`grep` also loses the output; then drive `payload.db.createMigration()` from `node --import tsx/esm` with an `unhandledRejection` handler). Both rungs were needed in #642, where `dangerouslyDisableSandbox` alone was not — contrary to what the standing memory claimed, which has been corrected too.

## `.claude/rules/tests.md` — `Tests  no tests`

Vitest reports a syntax error in a spec as an *empty* file, so a broken test name reads as "no case matched" and sends you to the lane config instead of the file you just edited. One paragraph under "Running tests locally", with the two ways to see the real error.

## Not included

A third approved item — relationships aren't populated inside a field `afterRead`, so `data.<rel>` is a bare id at any depth — belongs in `collections.md` beside the sibling `afterRead` gotcha and next to the `resolveManager` code it cites. Both live on the unmerged #642 branch, so it ships there instead; putting it on `main` would cite a file that doesn't exist yet and would likely conflict.

Three memory files were also updated outside the repo (the CLI escalation ladder, the admin-copy audience, and two new ways a mutation check can lie).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
