### PR TITLE
docs(claude): payload-cli skill + Drawer and hidden-collection contracts

### DIFF
--- a/.claude/rules/admin-ui.md
+++ b/.claude/rules/admin-ui.md
@@ -49,6 +49,41 @@ detail needs a delegated `closest('tr[data-id]')` listener on a wrapper
 (Payload writes the row's `id` there), and `cursor` has to be a stylesheet rule
 because it belongs on Payload's own `<tr>`.
 
+### `Drawer` must be mounted unconditionally, or it won't animate
+
+`Drawer` seeds its `animateIn` state from `modalState[slug].isOpen` with
+`useState` — read **once, at mount** — and only adds `drawer--is-open` in a
+layout effect. So a drawer rendered behind a condition that becomes true in the
+same tick as `openModal` mounts *already open*: the class is on its first paint
+and there is no transition left to play. It appears in place, which reads as a
+styling problem rather than a mounting one.
+
+```tsx
+// ❌ mounts already-open; no slide
+{selected !== null && <Drawer slug={slug}>{body}</Drawer>}
+
+// ✅ mounts closed, animates on open — and returns null while closed, so it costs nothing
+<Drawer slug={slug}>{selected === null ? null : body}</Drawer>
+```
+
+There is **no width prop**: `Drawer` sets `width: calc(100% - (drawerDepth *
+var(--gutter-h)))` in JS, narrowing one gutter per nesting level, and its SCSS
+says so explicitly. A narrower drawer means a `className` and a CSS rule.
+
+### A hidden collection is still reachable through a `join`
+
+`admin.hidden: true` removes a collection from the nav **and** unregisters its
+routes — `/admin/collections/<slug>/<id>` 404s. It does *not* make its
+documents unreachable: a `join` field on another collection still renders its
+rows and opens each one in a document drawer, which never touches the route.
+Nested drawers work from there too.
+
+That combination is often the arrangement you want — reachable in the context
+that explains it, absent from the sidebar. `Registrations` is hidden for
+exactly that reason and is opened from an Event's Registration tab. So a 404 on
+the route is not evidence that a field needs to be surfaced somewhere else; try
+the surfaces that already embed the document first.
+
 **Building a custom field component?** Compose Payload's field primitives instead
 of bespoke markup (see "Custom field components" below): `FieldLabel`,
 `FieldError`, `FieldDescription`, plus the input fields `TextField`,

--- a/.claude/skills/payload-cli/SKILL.md
+++ b/.claude/skills/payload-cli/SKILL.md
@@ -1,0 +1,97 @@
+---
+name: payload-cli
+description: Run Payload CLI work that dies silently or hangs on a prompt — generate:types, db:migrations:create, or any script that boots the config. Use when a Payload command exits 0 with no output and no files, or appears to hang.
+---
+
+# Payload CLI — when it dies silently or hangs
+
+Two failure modes account for nearly every "the Payload command did nothing"
+report in this repo. Both look like success from the shell.
+
+## 1. Exit 0, no output, no files
+
+`payload/bin.js` runs `void start()` with no `.catch()`, so any rejection while
+loading the config vanishes — most often the `serverEnv` validation throwing
+because `.env` wasn't in the process environment. The command prints its own
+`$ payload generate:types` echo and exits 0.
+
+**Escalation ladder.** Each rung is what to try when the one above still exits
+with nothing:
+
+1. **`dangerouslyDisableSandbox: true`** on the Bash call.
+2. **Preload the env and redirect to a file.** Piping to `tail`/`grep` also
+   loses the output — redirect, then `cat`:
+   ```bash
+   set -a; . ./.env; . ./.env.local; set +a
+   timeout 240 pnpm exec payload generate:types > /tmp/gt.log 2>&1; echo "exit=$?"; cat /tmp/gt.log
+   ```
+3. **Skip the CLI**, using `interactive.py` below. `migrate:create` in
+   particular stays silent even at rung 2, because it also hits the prompts.
+
+Diagnose the underlying throw with a bare boot, which has no `void start()` to
+swallow it:
+
+```bash
+set -a; . ./.env; . ./.env.local; set +a
+node --no-warnings --input-type=module --import tsx/esm -e "
+  process.on('unhandledRejection', e => { console.error('UNHANDLED:', e); process.exit(1) })
+  const config = (await import('./src/payload.config.ts')).default
+  console.log('loaded', (await config).collections.length)"
+```
+
+**Always verify generated output by content, not exit code** — `grep` the new
+field name in `src/payload-types.ts` after `generate:types`.
+
+## 2. It hangs on a drizzle prompt
+
+Dev `push: true` and `migrate:create` both ask interactive questions that no
+flag suppresses: a rename-vs-create select per column, and a data-loss `y/N`.
+Piped stdin doesn't reach them — they need a terminal.
+
+```bash
+set -a; . ./.env; . ./.env.local; set +a
+python3 .claude/skills/payload-cli/interactive.py "
+  const { getPayload } = await import('payload')
+  const config = (await import('./src/payload.config.ts')).default
+  const payload = await getPayload({ config })
+  await payload.db.createMigration({
+    payload, migrationName: 'my_change', forceAcceptWarning: true, skipEmpty: true,
+  })
+  process.exit(0)
+"
+```
+
+Use the same driver with a bare `getPayload({ config })` to clear the prompts
+once after a schema change, then run the normal CLI.
+
+**Output goes to `/tmp/payload-pty.log`**, not your terminal — a PTY has no
+separate stdout to inherit. `grep` that file for results and for the
+`[pty] answered …` lines confirming which prompts it handled.
+
+### What it answers, and when that's wrong
+
+| Prompt | Answer | Why |
+| --- | --- | --- |
+| `Is <col> column … created or renamed` | `\r` (the highlighted `+ create column`) | Right for a genuinely new column |
+| `Accept warnings and push schema…` | `y` | This drives a **local dev** database; production applies migrations and never sees it |
+
+**`+ create column` is a drop+add.** For a real column rename that destroys
+every value in it. Check whether the column holds rows before accepting, and
+hand-edit the generated migration to `ALTER TABLE … RENAME COLUMN` (both the
+table and its `_v` twin) when it does.
+
+### Three bugs this driver already has fixed
+
+Worth knowing if you modify it — each one presented as an unexplained hang:
+
+- **Dedup per column, not per prompt text.** The prompts arrive back to back;
+  a time-based debounce answered the first and swallowed the second.
+- **Reset that memo at `Starting migration`.** Push and migration-generation
+  ask the same questions, so text-keyed dedup answered only the first round.
+- **Answer with `\r`.** Raw mode ignores `\n`, and `yes ''` spins the CPU.
+
+## Related
+
+- `.claude/rules/migrations.md` — the outcome table, and what to do with a
+  generated migration once you have one.
+- `.claude/skills/migration-validator/` — run it on the result before committing.

--- a/.claude/skills/payload-cli/interactive.py
+++ b/.claude/skills/payload-cli/interactive.py
@@ -1,0 +1,105 @@
+"""Run a Payload script on a PTY, answering drizzle's interactive prompts.
+
+    python3 .claude/skills/payload-cli/interactive.py "<js module source>"
+
+The script is evaluated by `node --input-type=module --import tsx/esm -e`, from
+the repo root, so it can `await import('./src/payload.config.ts')`. Everything
+the child writes — including the output your script prints — goes to
+`/tmp/payload-pty.log`, because a PTY has no separate stdout to inherit.
+
+**Load `.env` and `.env.local` before calling this**, or the config's
+`serverEnv` validation throws and `payload/bin.js` swallows it (`void start()`,
+no `.catch()`):
+
+    set -a; . ./.env; . ./.env.local; set +a
+
+Three prompt-handling lessons are baked in, each learned from a hang:
+
+  * Answer once per distinct COLUMN, not per prompt text. The rename prompts
+    arrive back to back and a time-based debounce swallowed the second one.
+  * Clear that memo at the `Starting migration` phase boundary. Push and
+    migration-generation ask the same questions, so keying only on text
+    answered the first round and hung on the second.
+  * Accept the data-loss warning with `y`. Correct here because this drives a
+    LOCAL dev database catching up to a schema change; production applies
+    migrations instead and never sees this prompt.
+
+Raw mode needs `\\r`, not `\\n`.
+
+The rename prompt's highlighted default is `+ create column`, which is a
+**drop+add**. That is right for a genuinely new column and destroys data for a
+real rename — see `.claude/rules/migrations.md` before accepting one on a
+column that holds rows.
+"""
+
+import os
+import pty
+import re
+import select
+import subprocess
+import sys
+import time
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+LOG_PATH = '/tmp/payload-pty.log'
+
+script = sys.argv[1]
+log = open(LOG_PATH, 'wb', buffering=0)
+master, slave = pty.openpty()
+proc = subprocess.Popen(
+    ['node', '--no-warnings', '--input-type=module', '--import', 'tsx/esm', '-e', script],
+    stdin=slave,
+    stdout=slave,
+    stderr=slave,
+    cwd=REPO_ROOT,
+    close_fds=True,
+)
+os.close(slave)
+
+seen: set[str] = set()
+buf = b''
+while proc.poll() is None:
+    ready, _, _ = select.select([master], [], [], 1.0)
+    if not ready:
+        continue
+    try:
+        chunk = os.read(master, 65536)
+    except OSError:
+        break
+    if not chunk:
+        break
+    log.write(chunk)
+    buf = (buf + chunk)[-4000:]
+    text = buf.decode('utf-8', 'replace')
+
+    # Push and migration-generation ask the same questions; this boundary is
+    # what lets the second round be answered too.
+    if 'Starting migration' in text and 'phase2' not in seen:
+        seen.clear()
+        seen.add('phase2')
+        buf = b''
+        continue
+
+    match = re.search(r'Is (\w+) column in (\w+) table created or renamed', text)
+    if match and match.group(0) not in seen:
+        seen.add(match.group(0))
+        time.sleep(0.4)
+        os.write(master, b'\r')
+        log.write(f'\n[pty] answered `{match.group(1)}` on {match.group(2)}\n'.encode())
+        buf = b''
+        continue
+
+    if 'Accept warnings and push schema to database?' in text and 'dataloss' not in seen:
+        seen.add('dataloss')
+        time.sleep(0.4)
+        os.write(master, b'y\r')
+        log.write(b'\n[pty] accepted the data-loss warning (local dev DB)\n')
+        buf = b''
+
+# Reap before reading the code: the loop above usually exits on EOF from the
+# PTY, which happens *before* the child is reaped, so `returncode` would still
+# be None and every run would look inconclusive.
+rc = proc.wait()
+log.write(f'\n[pty] exited rc={rc}\n'.encode())
+print(f'[pty] done (rc={rc}) — full output in {LOG_PATH}')
+sys.exit(rc)


### PR DESCRIPTION
Session-reflection fixes from shipping #626. Docs-only (`.claude/**`).

## `.claude/skills/payload-cli/` — the silent-death ladder and a prompt driver

Two failure modes account for nearly every "the Payload command did nothing" report here, and both look like success from the shell:

- **exit 0, no output, no files** — `payload/bin.js` runs `void start()` with no `.catch()`, so a config-load rejection vanishes (usually `serverEnv` validation, because `.env` wasn't in the process env);
- **a hang on a drizzle prompt** — rename-vs-create and the data-loss `y/N`, neither of which piped stdin can reach.

`SKILL.md` carries the escalation ladder for the first (`dangerouslyDisableSandbox` → preload env and *redirect* rather than pipe → skip the CLI) and a bare-boot recipe that surfaces the throw `bin.js` swallows.

`interactive.py` handles the second. It had been written from scratch **three times** across sessions — twice in one session, after a scratchpad was cleared — and needed the same three bugs fixed each time:

- dedup per **column**, not per prompt text (they arrive back to back; a time debounce swallowed the second);
- reset that memo at the `Starting migration` phase boundary (push and generation ask the same questions, so text-keyed dedup answered only the first round);
- answer with `\r` — raw mode ignores `\n`, and `yes ''` spins the CPU.

Those are comments in the file now rather than lessons to relearn.

**Smoke-tested from its committed location**: runs the child from the repo root, writes to `/tmp/payload-pty.log`, and propagates the child's exit code — which needed a `proc.wait()`, since the loop exits on PTY EOF *before* the child is reaped and every run had been reporting `rc=None`. Verified both `exit 0` and `exit 3` propagate.

The skill is explicit that the rename prompt's highlighted default (`+ create column`) is a **drop+add**, and destroys every value in a column that's actually being renamed.

## `.claude/rules/admin-ui.md` — two Payload contracts

**`Drawer` won't animate if it's mounted already open.** It seeds `animateIn` from `modalState[slug].isOpen` with `useState` — once, at mount — and only adds `drawer--is-open` in a layout effect. Rendering it behind a condition that flips in the same tick as `openModal` puts the class on the first paint, so there's no transition left to play. The symptom is "it just appears", which reads as a CSS problem rather than a mounting one. Also records that there is **no width prop** — the width is JS-computed from nesting depth.

**`admin.hidden: true` unregisters the routes, not the document.** A 404 on `/admin/collections/registrations/:id` led me to report a field as unviewable and propose un-hiding the collection — a change that would have put registrant PII in the admin nav. A `join` field opens the same document in a drawer, bypassing routing entirely; the existing arrangement was already correct. The rule now says to try the surfaces that embed a document before concluding it's unreachable.

## Not included

The **column-rename data-loss trap** in `migrations.md` was proposed and not approved, so it isn't here. Two memory files were also written outside the repo (the 404 reasoning error, and a third way a mutation check can measure nothing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
