### PR TITLE
chore(claude): apply session-reflection fixes

### DIFF
--- a/.claude/docs/environment.md
+++ b/.claude/docs/environment.md
@@ -65,6 +65,33 @@ Copy from `.env.example` and configure:
 1. Go to Cloudflare Dashboard → R2 → Buckets
 2. Note bucket name and create API token with R2 write scope
 
+### Claude-usable credentials (`.env.claude.local`)
+
+Separate from `.env`, gitignored via `.env*.local`, and **never committed**. It
+holds credentials provisioned so an agent can operate infrastructure directly
+rather than handing the steps back:
+
+| Key                     | What it opens                                                                          |
+| ----------------------- | -------------------------------------------------------------------------------------- |
+| `CLOUDFLARE_CLAUDE_KEY` | Cloudflare API token — Cache Rules / rulesets on the `sydevelopers.com` zone            |
+| `ADMIN_PASSWORD`        | `contact@sydevelopers.com` on **production** (`cloud.sydevelopers.com`), via `POST /api/managers/login` |
+
+```bash
+set -a; . ./.env.claude.local; set +a     # then use "$CLOUDFLARE_CLAUDE_KEY"
+```
+
+Never echo the values — redact when printing anything derived from this file,
+and delete any token/JWT written to a scratch file when you're done.
+
+> **Check here before reporting that a credential is unavailable.** The
+> `CLOUDFLARE_*` variables in `.env` are the app's runtime config (Images,
+> Stream, R2, and the purge token) — none of them can edit a Cache Rule, and
+> the Railway CLI is not authenticated on this machine. It's easy to conclude
+> from those three facts that no usable token exists, which is wrong.
+
+The credentials in `AGENTS.md` under "Admin Access" are the **local** dev admin
+(`localhost:{PORT}/admin`) and are unrelated to the production password above.
+
 ### Live Preview URLs
 
 - `WEMEDITATE_WEB_URL` - Preview URL for We Meditate Web frontend (required) — Pages/Meditations live preview + CSP `frame-src`

--- a/.claude/skills/finalize-pr/SKILL.md
+++ b/.claude/skills/finalize-pr/SKILL.md
@@ -53,6 +53,11 @@ pass for reuse / simplification / efficiency / altitude — it does **not** hunt
 - Let it apply fixes; review them and revert anything undesirable.
 - If it changed anything, re-run the lean gate (step 4) and commit
   (`refactor: simplify per /simplify pass`). If it made no changes, continue.
+- **`/simplify` edits the working tree, and it fans out** — fixes can land minutes after dispatch,
+  well after its first message. **Don't edit the same files while it runs.** Wait for its report,
+  then review `git diff` as one unit. Editing in parallel makes a patch fail an assertion or a file
+  read back unexpectedly, and the first suspicion is a corrupted edit rather than a second writer.
+  If you must work in parallel, pick disjoint files.
 
 ### 2. Code review (`/code-review`) — single pass
 
@@ -67,6 +72,14 @@ to keep working ("I'll wait for the finder agents…"), or a pointer to a file i
 sub-agents haven't finished, it reports what it has and names what's missing. Without this, a
 fan-out reviewer can return a progress note instead of findings, costing a `SendMessage` round trip
 to retrieve the actual review.
+
+**A "no findings" report must carry its evidence.** Require the reviewer to name the files and code
+paths it actually read to reach that conclusion, and treat a clean report that shows little or no
+reading as **not yet reviewed** — re-dispatch citing the gap, or read the highest-risk paths
+yourself. This has already cost a real bug: a reviewer returned "no correctness bugs… production
+ready" after a *single tool call* over a ~2,800-line diff, and a manual re-read then found that a
+relationship's stored order was being silently dropped, so `og:image` unfurled the wrong photo. An
+empty result is harder to notice than a wrong one — nothing about it looks like a failure.
 
 - **Blocking**: triage every finding. Fix the valid ones (each as its own commit), then re-run the
   lean gate. Note any finding you dismiss with a one-line reason for the report.


### PR DESCRIPTION
## Summary

Session-reflection fixes from the #645 / PR #646 run. Docs-only — no runtime code, so merged without waiting for CI per `AGENTS.md` → "Merging without CI".

## What landed

**`.claude/docs/environment.md` — document `.env.claude.local`.**
An agent reported that no Cloudflare API token existed and handed the work back. It had genuinely checked `.env`, the process environment, `wrangler` and the Railway CLI — all four are empty or unauthenticated here — but the token was in `.env.claude.local`, which nothing documented. The new section names the file, its two keys (`CLOUDFLARE_CLAUDE_KEY`, `ADMIN_PASSWORD`) and what each opens, spells out the redaction rule, and calls out why the wrong conclusion is easy to reach: the `CLOUDFLARE_*` variables that *are* in `.env` are runtime config for Images/Stream/R2 and a purge-scoped token, none of which can edit a Cache Rule. Values stay out of the repo; the file is gitignored via `.env*.local`.

**`.claude/skills/finalize-pr/SKILL.md` — distrust an unevidenced clean review.**
A code-review subagent returned "no correctness bugs… production ready" after a **single tool call** over a ~2,800-line diff. A manual re-read then found a real bug: a relationship's stored order was being silently dropped, so `og:image` unfurled the wrong photo. The skill already guarded against a reviewer returning a progress *note*; it said nothing about one returning a confident *empty result* — the harder of the two to catch, because nothing about it looks like a failure. Reviewers must now name the files and paths they read, and a clean report showing little reading counts as **not yet reviewed**.

**`.claude/skills/finalize-pr/SKILL.md` — warn that `/simplify` writes to the working tree.**
It fans out, so its fixes can land minutes after dispatch, well after its first message. In this run they arrived while the main thread was mid-edit on the same files; the first symptom was a patch failing an assertion, which reads as a corrupted edit rather than a second writer.

## Also applied, outside this PR

Two memory files (they live in `~/.claude/projects/…/memory/`, not the repo):

- **Corrected** `payload-cli-dies-silently-in-sandbox` — its escalation ladder started at `dangerouslyDisableSandbox`, which was *not* enough this time. Added the rung that actually worked: drop the `pnpm <script>` wrapper and call `pnpm exec payload …` directly. `pnpm generate:types` chains two commands and prints both banners while the first writes nothing, so the run looks clean.
- **New** `worktree-blocks-complex-bash` — in a worktree-isolated session the Bash guard refuses heredocs and chained commands; use Write/Edit and single plain commands.

## Considered and dropped

A memory recording that the local dev DB is an Atlas-only subset (no WeMeditateWeb client keys), which caused a wrong retraction mid-session. Deferred by the user.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
